### PR TITLE
Make console layer self contained

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -10,7 +10,7 @@ export/php-%.zip:
 	cd php && make distribution
 
 # The console runtime
-export/console.zip: console/bootstrap
+export/console.zip: console/bootstrap ../src/Runtime/LambdaRuntime.php
 	rm -f export/console.zip
 	cp ../src/Runtime/LambdaRuntime.php console/LambdaRuntime.php
 	cd console && zip ../export/console.zip bootstrap LambdaRuntime.php

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -12,4 +12,6 @@ export/php-%.zip:
 # The console runtime
 export/console.zip: console/bootstrap
 	rm -f export/console.zip
-	cd console && zip ../export/console.zip bootstrap
+	cp ../src/Runtime/LambdaRuntime.php console/LambdaRuntime.php
+	cd console && zip ../export/console.zip bootstrap LambdaRuntime.php
+	rm console/LambdaRuntime.php

--- a/runtime/console/bootstrap
+++ b/runtime/console/bootstrap
@@ -1,14 +1,14 @@
 #!/opt/bin/php
 <?php declare(strict_types=1);
 
+require 'LambdaRuntime.php';
+
 use Bref\Runtime\LambdaRuntime;
 
 ini_set('display_errors', '1');
 error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
-
-require $appRoot . '/vendor/autoload.php';
 
 $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 


### PR DESCRIPTION
As like as the FPM layer, the console layer needs a autoloader in order to be able to instantiate the LambdaRuntime. In order to remove this need this PR copies over the LambdaRuntime inside the Layer and directly requires it. As the LambdaRuntime has no other dependencies we can completely get rid of the autoloader here which opens a lot of possibilties for console applications without actually requiring bref itself.