### PR TITLE
Adds optional base64 encoding status via response headers

### DIFF
--- a/src/Http/LambdaResponse.php
+++ b/src/Http/LambdaResponse.php
@@ -70,10 +70,23 @@ final class LambdaResponse
         // This is the format required by the AWS_PROXY lambda integration
         // See https://stackoverflow.com/questions/43708017/aws-lambda-api-gateway-error-malformed-lambda-proxy-response
         return [
-            'isBase64Encoded' => false,
+            'isBase64Encoded' => $this->isBase64Encoded((array) $headers),
             'statusCode' => $this->statusCode,
             $headersKey => $headers,
             'body' => $this->body,
         ];
+    }
+
+    /**
+     * Determine if the response body is base64 encoded based on the value
+     * provided in the optional `isbase64encoded` header.
+     *
+     * @param array $headers
+     *
+     * @return bool
+     */
+    protected function isBase64Encoded(array $headers): bool
+    {
+        return (bool) ($headers['isbase64encoded'] ?? false);
     }
 }

--- a/src/Http/LambdaResponse.php
+++ b/src/Http/LambdaResponse.php
@@ -77,14 +77,6 @@ final class LambdaResponse
         ];
     }
 
-    /**
-     * Determine if the response body is base64 encoded based on the value
-     * provided in the optional `isbase64encoded` header.
-     *
-     * @param array $headers
-     *
-     * @return bool
-     */
     protected function isBase64Encoded(array $headers): bool
     {
         return (bool) ($headers['isbase64encoded'] ?? false);

--- a/tests/Http/LambdaResponseTest.php
+++ b/tests/Http/LambdaResponseTest.php
@@ -61,8 +61,8 @@ class LambdaResponseTest extends TestCase
 
     public function test base64 encoding status is taken from headers()
     {
-        $encodedResponse = new LambdaResponse(200, ['isbase64encoded' => '1'], "");
-        $unencodedResponse = new LambdaResponse(200, ['isbase64encoded' => '0'], "");
+        $encodedResponse = new LambdaResponse(200, ['isbase64encoded' => '1'], '');
+        $unencodedResponse = new LambdaResponse(200, ['isbase64encoded' => '0'], '');
 
         self::assertSame([
             'isBase64Encoded' => true,

--- a/tests/Http/LambdaResponseTest.php
+++ b/tests/Http/LambdaResponseTest.php
@@ -58,4 +58,24 @@ class LambdaResponseTest extends TestCase
         // Make sure that the headers are `"headers":{}` (object) and not `"headers":[]` (array)
         self::assertEquals('{"isBase64Encoded":false,"statusCode":204,"headers":{},"body":""}', json_encode($response->toApiGatewayFormat()));
     }
+
+    public function test base64 encoding status is taken from headers()
+    {
+        $encodedResponse = new LambdaResponse(200, ['isbase64encoded' => '1'], "");
+        $unencodedResponse = new LambdaResponse(200, ['isbase64encoded' => '0'], "");
+
+        self::assertSame([
+            'isBase64Encoded' => true,
+            'statusCode' => 200,
+            'headers' => ['isbase64encoded' => '1'],
+            'body' => '',
+        ], $encodedResponse->toApiGatewayFormat());
+
+        self::assertSame([
+            'isBase64Encoded' => false,
+            'statusCode' => 200,
+            'headers' => ['isbase64encoded' => '0'],
+            'body' => '',
+        ], $unencodedResponse->toApiGatewayFormat());
+    }
 }


### PR DESCRIPTION
we have a Laravel application served through lambda that I've been able to greatly simplify by switching away from my home-grown solution to bref, which has been a great help towards maintainability, thank you very much! our application serves images and html so we rely on the `isBase64Encoded` value -- which we explicitly provide through the response headers, as that was the ideal approach with the lambda->laravel implementation.

This pull request allows an application to return a value for `isBase64Encoded` through the response header: there's no magic required of bref, it defers responsibility to the application. #288 discusses the magic approach, I'm not sure if there's any intention to implement that in future but for now this seems like a good first step.

The test doesn't use `fromPsr7Response` because (as far as I've been able to tell) in the real world (that is, outside of the tests) header names are all lowercase whereas `fromPsr7Response` uses `ucwords` which means the header names do not match what I'm seeing in production. I'm not sure if that's a quirk of API Gateway or my environment but for now I've used the lowercase version in the tests.

I've used a helper method (`isBase64Encoded`) even though the check is short because the logic is a little confusing if it's all on one line, and potentially if in future a magic method is implemented, the logic for `isBase64Encoded` can be swapped out.

```php
(bool) ((array) $headers['isbase64encoded'] ?? false) // huh
```

thanks!