### PR TITLE
[WIP] Documentation for PHPUnit

### DIFF
--- a/docs/frameworks/phpunit.md
+++ b/docs/frameworks/phpunit.md
@@ -12,14 +12,15 @@ For this reason, bref provides a Docker image containing the same php binary as 
 
 ## Usage
 
-```
-docker run -v /path/to/my/project:/var/task -t bref/php-73 ./vendor/bin/phpunit
-```
+The following command assumes that you're executing it from the root folder of your project:
 
-TODO: Should we tag the Docker image with the PHP version or with the Layer tag?  
+```
+docker run -v $(pwd):/var/task -w /var/task -t bref/php-73 sh -c "php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php && php composer.phar install && ./vendor/bin/phpunit"
+```
 
 ## How it works?
 
 When building the Lambda Layer, Bref uses a base image provided by Amazon containing the Amazon Linux. This is the same operating system that Lambda is using under the hood.
 The PHP binary is then compiled from source code and packaged into a Lambda layer. 
 Bref pushes the same Docker image used to make up the layer to Docker Hub, which means the exact same binary is being used.
+After starting the container, the command will download and run Composer on the project in order to install all the dependencies, including the development dependencies to bring in the testing framework (e.g. PHPUnit).

--- a/docs/frameworks/phpunit.md
+++ b/docs/frameworks/phpunit.md
@@ -1,0 +1,25 @@
+---
+title: Serverless Testing with PHPUnit
+currentMenu: frameworks
+introduction: Run your unit tests as close to production environment
+---
+
+Running unit tests in an environment that is not close to the production environment might not bring as much confidence as expected from a test suite.
+One way of visualizing this fact is to try and run a test suite using PHP 7.0 against a codebase that makes use of nullable type-hit. 
+Of course, this example is extreme, but the sentiment remains: it is somewhat relevant to execute a test suite using the same php binary that will be running on production to cater for php version as well as required extesions.
+
+For this reason, bref provides a Docker image containing the same php binary as the one inside the Lambda Layer.
+
+## Usage
+
+```
+docker run -v /path/to/my/project:/var/task -t bref/php:7.3.2 ./vendor/bin/phpunit
+```
+
+TODO: Should we tag the Docker image with the PHP version or with the Layer tag?  
+
+## How it works?
+
+When building the Lambda Layer, Bref uses a base image provided by Amazon containing the Amazon Linux. This is the same operating system that Lambda is using under the hood.
+The PHP binary is then compiled from source code and packaged into a Lambda layer. 
+Bref pushes the same Docker image used to make up the layer to Docker Hub, which means the exact same binary is being used.

--- a/docs/frameworks/phpunit.md
+++ b/docs/frameworks/phpunit.md
@@ -13,7 +13,7 @@ For this reason, bref provides a Docker image containing the same php binary as 
 ## Usage
 
 ```
-docker run -v /path/to/my/project:/var/task -t bref/php:7.3.2 ./vendor/bin/phpunit
+docker run -v /path/to/my/project:/var/task -t bref/php-73 ./vendor/bin/phpunit
 ```
 
 TODO: Should we tag the Docker image with the PHP version or with the Layer tag?  


### PR DESCRIPTION
This Pull Request is an attempt to start the work for #237. I successfully accomplished the desire to run PHPUnit using the php binary provided by the layer using my personal Docker Hub (https://hub.docker.com/r/deleugpn/bref/tags) and I would like to provide as much help as I can to bring this to Bref.

At first, I thought about documenting the entire AWS Code Pipeline process, but maybe that's too much at once and not everyone is using CI/CD. I tried to reduce the scope as much as I could, leading to just documenting how to run phpunit using the same binary. I would be happy to provide a documentation section dedicated for CodePipeline if there is any interest from the community to have this documented (and if Bref wants to provide the documentation).

The reason I mention CI/CD is because for me they're quite intertwined. AWS CodePipeline downloads my source code from GitHub every time I commit and there's no vendor folder, so I had to use 2 Docker images: 1 with PHP Binary + Composer + building instructions and 1 with just PHP Binary. Running composer with a different version of PHP as production might also cause issues.
However, for the sake of brevity, at the moment I'm going to assume this is a deeper problem for another pull request and focus solely on having a Docker image with the binary only that can be used for executing the tests once the source code is ready for it.

Things to consider:

- How to tag the Docker Image? With the same tag as the Layers or with the PHP version?
- Should we focus the documentation on phpunit terms or be more generic about testing frameworks?
- Are there any other considerations I'm missing for this documentation?

I'd love to get feedback on this process as a whole and help bref provide this Docker image officially.