### PR TITLE
Log output to Cloudwatch for console layer

### DIFF
--- a/runtime/console/bootstrap
+++ b/runtime/console/bootstrap
@@ -30,6 +30,9 @@ while (true) {
 
         $output = implode("\n", $output);
 
+        // Echo $output so it is written to CLoudwatch logs as well as terminal connections.
+        echo $output;
+
         return [
             'exitCode' => $exitCode,
             'output' => $output,


### PR DESCRIPTION
Related to issue #347 

This PR allows logging and other output from the console layer to be captured by CloudWatch. I have tested that it works, but don't know if there is any other considerations or tests that should be done.

You can test this by using 
`arn:aws:lambda:eu-west-2:928780349604:layer:consolebref:1`
(I can replicate this layer in another region if requested)

The layer can be download to check its contents by using the below command via the AWS CLI
`aws lambda get-layer-version-by-arn --arn arn:aws:lambda:eu-west-2:928780349604:layer:consolebref:1`