### PR TITLE
Allow reading AWS credentials from environment

### DIFF
--- a/src/Lambda/SimpleLambdaClient.php
+++ b/src/Lambda/SimpleLambdaClient.php
@@ -21,8 +21,8 @@ final class SimpleLambdaClient
             'region' => $region,
         ];
 
-        $awsKey = getenv('AWS_KEY');
-        $awsSecret = getenv('AWS_SECRET');
+        $awsKey = getenv('AWS_ACCESS_KEY_ID');
+        $awsSecret = getenv('AWS_SECRET_ACCESS_KEY');
         if ($awsKey && $awsSecret) {
             $args['credentials'] = new Credentials($awsKey, $awsSecret);
         }

--- a/src/Lambda/SimpleLambdaClient.php
+++ b/src/Lambda/SimpleLambdaClient.php
@@ -15,10 +15,16 @@ final class SimpleLambdaClient
 
     public function __construct(string $region)
     {
-        $this->lambda = new LambdaClient([
+        $args = [
             'version' => 'latest',
             'region' => $region,
-        ]);
+        ];
+
+        if ($awsKey = getenv('AWS_KEY') && $awsSecret =getenv('AWS_SECRET')) {
+            $args['credentials'] = new Credentials($awsKey, $awsSecret);
+        }
+
+        $this->lambda = new LambdaClient($args);
     }
 
     /**

--- a/src/Lambda/SimpleLambdaClient.php
+++ b/src/Lambda/SimpleLambdaClient.php
@@ -20,7 +20,9 @@ final class SimpleLambdaClient
             'region' => $region,
         ];
 
-        if ($awsKey = getenv('AWS_KEY') && $awsSecret =getenv('AWS_SECRET')) {
+        $awsKey = getenv('AWS_KEY');
+        $awsSecret = getenv('AWS_SECRET');
+        if ($awsKey && $awsSecret) {
             $args['credentials'] = new Credentials($awsKey, $awsSecret);
         }
 

--- a/src/Lambda/SimpleLambdaClient.php
+++ b/src/Lambda/SimpleLambdaClient.php
@@ -2,6 +2,7 @@
 
 namespace Bref\Lambda;
 
+use Aws\Credentials\Credentials;
 use Aws\Lambda\LambdaClient;
 use Psr\Http\Message\StreamInterface;
 


### PR DESCRIPTION
When I run `vendor/bin/bref cli <function-name>` I get an error saying: 

```
In InstanceProfileProvider.php line 95:
                                                                                                                                               
  Error retrieving credentials from the instance profile metadata server. (cURL error 28: Connection timed out after 1004 milliseconds (see h  
  ttp://curl.haxx.se/libcurl/c/libcurl-errors.html))  
```

That is because we are trying to connect to http://169.254.169.254/latest/meta-data/iam/security-credentials/

(On my CI server I get 404)

I guess the AWS client is checking my default profile in ´~./aws/credentiials` and verify those. 

---------------

This PR allows you to specify environment variables so we never have to go to the IAM service. 

```
AWS_KEY=foo AWS_SECRET=bar vendor/bin/bref cli <function-name>
```