### PR TITLE
Remove cluster client

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -106,7 +106,6 @@ Bref strives to include the most common PHP extensions. If a major PHP extension
 
 - **[intl](http://php.net/manual/en/intro.intl.php)** - Internationalization extension (referred as Intl) is a wrapper for ICU library, enabling PHP programmers to perform various locale-aware operations.
 - **[APCu](http://php.net/manual/en/intro.apcu.php)** - APCu is APC stripped of opcode caching.
-- **[ElastiCache php-memcached extension](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/Appendix.PHPAutoDiscoverySetup.html)** - 
 - **[phpredis](https://github.com/phpredis/phpredis)** -  The phpredis extension provides an API for communicating with the Redis key-value store. 
 - **[PostgreSQL PDO Driver](http://php.net/manual/en/ref.pdo-pgsql.php)** -  PDO_PGSQL is a driver that implements the PHP Data Objects (PDO) interface to enable access from PHP to PostgreSQL databases.
 - **[MySQL PDO Driver](http://php.net/manual/en/ref.pdo-mysql.php)** -  PDO_MYSQL is a driver that implements the PHP Data Objects (PDO) interface to enable access from PHP to MySQL databases.
@@ -118,7 +117,6 @@ You can enable these extensions by loading them in `php/conf.d/php.ini` (as ment
 ```ini
 extension=intl
 extension=apcu
-extension=amazon-elasticache-cluster-client.so
 extension=redis
 extension=pdo_pgsql
 extension=pdo_mysql

--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -429,18 +429,6 @@ RUN pecl install mongodb
 RUN pecl install redis
 RUN pecl install APCu
 
-RUN set -xe; \
-    curl -Ls https://elasticache-downloads.s3.amazonaws.com/ClusterClient/PHP-7.0/latest-64bit \
-  | tar xzC $(php-config --extension-dir) --strip-components=1
-
-ENV PTHREADS_BUILD_DIR=${BUILD_DIR}/pthreads
-
-# Build from master because there are no pthreads release compatible with PHP 7.3
-RUN set -xe; \
-    mkdir -p ${PTHREADS_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/krakjoe/pthreads/archive/master.tar.gz \
-    | tar xzC ${PTHREADS_BUILD_DIR} --strip-components=1
-
 WORKDIR  ${PTHREADS_BUILD_DIR}/
 
 RUN set -xe; \


### PR DESCRIPTION
I want to remove this for the following reasons: 

- It does not work when adding `extension=amazon-elasticache-cluster-client.so`
- It does not support PHP 7.2 or 7.3
- It is only required with Memcached but we dont provide the Memcached extensions. 

Users should consider using Redis. 