### PR TITLE
Document the bref/logger package

### DIFF
--- a/docs/environment/logs.md
+++ b/docs/environment/logs.md
@@ -10,18 +10,24 @@ As explained in the [storage documentation](storage.md), the filesystem on AWS L
 - not shared between lambda instances
 - not persistent
 
-Because of that application logs should not be stored on disk.
+Because of that, logs should not be stored on disk.
 
 ## CloudWatch
 
 The simplest solution is to push logs to AWS CloudWatch, AWS' service for logs.
 
+### PHP errors and warnings
+
+By default, all PHP errors, warnings and notices emitted by PHP will be forwarded into CloudWatch.
+
+That means that you don't have to configure anything to log errors, warnings or uncaught exceptions.
+
 ### Writing logs
 
-To send logs to CloudWatch:
+Your application can write logs to CloudWatch:
 
 - in a [PHP function](/docs/runtimes/function.md): write logs to `stdout` (using `echo` for example) or `stderr`
-- in a [HTTP](/docs/runtimes/http.md): write logs to `stderr`
+- in a [HTTP application](/docs/runtimes/http.md): write logs to `stderr`
 
 For example with [Monolog](https://github.com/Seldaek/monolog):
 
@@ -42,7 +48,7 @@ $log->warning('This is a warning!');
 
 ### Reading logs
 
-To read logs, either open the [CloudWatch console](https://us-east-1.console.aws.amazon.com/cloudwatch/home) or use SAM in the CLI:
+To read logs, either open the [CloudWatch console](https://console.aws.amazon.com/cloudwatch/home#logs:) or use SAM in the CLI:
 
 ```bash
 sam logs --name <function-name>

--- a/docs/environment/logs.md
+++ b/docs/environment/logs.md
@@ -32,6 +32,14 @@ $log->pushHandler(new StreamHandler('php://stderr', Logger::WARNING));
 $log->warning('This is a warning!');
 ```
 
+For simple needs, you can replace Monolog with [Bref's logger](https://github.com/brefphp/logger), a PSR-3 logger designed for AWS Lambda:
+
+```php
+$logger = new \Bref\Logger\StderrLogger();
+
+$log->warning('This is a warning!');
+```
+
 ### Reading logs
 
 To read logs, either open the [CloudWatch console](https://us-east-1.console.aws.amazon.com/cloudwatch/home) or use SAM in the CLI:
@@ -46,4 +54,3 @@ sam logs --name <function-name> --tail
 ## Advanced use cases
 
 If you have more specific needs you can send logs to other services, for example Logstash, Papertrail, or Loggly.
-

--- a/docs/environment/logs.md
+++ b/docs/environment/logs.md
@@ -32,7 +32,7 @@ Your application can write logs to CloudWatch:
 For example with [Monolog](https://github.com/Seldaek/monolog):
 
 ```php
-$log = new Logger('name');
+$log = new Monolog\Logger('name');
 $log->pushHandler(new StreamHandler('php://stderr', Logger::WARNING));
 
 $log->warning('This is a warning!');


### PR DESCRIPTION
This PR documents and makes official the [`bref/logger`](https://github.com/brefphp/logger) package.

This package is a PSR-3 logger designed for AWS Lambda. In other words, it logs everything into `stderr` so that logs end up in CloudWatch.

This is a lightweight alternative to Monolog, and it is ready to use without having to configure Monolog handlers. It is also a bit more limited as it has no extension points.