### PR TITLE
Updating link to use correct href

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,4 +55,4 @@ The `bref` command line tool can now be used by running `vendor/bin/bref` in you
 
 ## What's next?
 
-Read the [first steps](/docs/runtimes/function.md) guide to create and deploy your first serverless application using Bref.
+Read the [first steps](/docs/first-steps.md) guide to create and deploy your first serverless application using Bref.


### PR DESCRIPTION
WHY
Current link skips a page in the "Getting Started" section and takes the user to the runtime functions page.

WHAT
Change link to expected one
