### PR TITLE
add MyBuilder workers to case studies page

### DIFF
--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -23,3 +23,7 @@ Enoptea is a french startup that migrated their infrastructure of PHP workers fr
 - [PrettyCI.com](https://mnapoli.fr/serverless-case-study-prettyci/)
 
 [PrettyCI](https://prettyci.com/) is a SaaS providing continuous integration for PHP coding standards. Internally, it runs PHP-CS-Fixer or CodeSniffer on AWS Lambda using Bref. This article is a good introduction on how AWS Lambda can be a good solution to run workers and background jobs.
+
+- [MyBuilder](https://mybuilder.com)
+
+MyBuilder is an online marketplace matching tradespeople with home owners. They used Lambda with Bref to create a highly scalable on-demand microservice to generate PDF reports. The solution involved [creating their own layer](https://tech.mybuilder.com/compiling-wkhtmltopdf-aws-lambda-with-bref-easier-than-you-think/) to include a self-compiled binary file to use alongside Bref's base PHP layer.


### PR DESCRIPTION
Added MyBuilder's case study, with a brief description of our use-case and a link to our tech article on creating our own layer to use alongside Bref's own layers