### PR TITLE
Fix active page on the sidebar menu

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 title: What is Bref and serverless?
-currentMenu: what-is-bref
+current_menu: what-is-bref
 introduction: An introduction to what serverless and Bref can offer for PHP applications.
 next:
     link: /docs/installation.html

--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -1,6 +1,6 @@
 ---
 title: Case studies
-currentMenu: case-studies
+current_menu: case-studies
 introduction: A collection of case studies of serverless PHP applications built using Bref. Learn about performances, costs and migrations from existing projects.
 ---
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,6 +1,6 @@
 ---
 title: Community
-currentMenu: community
+current_menu: community
 introduction: A collection of links to places where to discuss and learn about Bref.
 ---
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,6 +1,6 @@
 ---
 title: Deployment
-currentMenu: deploy
+current_menu: deploy
 ---
 
 Bref recommends to use [the Serverless framework](https://serverless.com/) to deploy your serverless application.

--- a/docs/environment/custom-domains.md
+++ b/docs/environment/custom-domains.md
@@ -1,6 +1,6 @@
 ---
 title: Custom domain names
-currentMenu: php
+current_menu: custom-domains
 introduction: Configure custom domain names for your web applications.
 ---
 

--- a/docs/environment/database.md
+++ b/docs/environment/database.md
@@ -1,6 +1,6 @@
 ---
 title: Using a database
-currentMenu: php
+current_menu: database
 introduction: Configure Bref to use a database in your PHP application on AWS Lambda.
 ---
 

--- a/docs/environment/logs.md
+++ b/docs/environment/logs.md
@@ -1,6 +1,6 @@
 ---
 title: Logs
-currentMenu: logs
+current_menu: logs
 introduction: Learn how to write and read PHP logs on AWS Lambda using Bref.
 ---
 

--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring PHP
-currentMenu: php
+current_menu: php
 introduction: Configure PHP versions, extensions and options for your serverless application using Bref.
 ---
 

--- a/docs/environment/serverless-yml.md
+++ b/docs/environment/serverless-yml.md
@@ -1,6 +1,6 @@
 ---
 title: serverless.yml
-currentMenu: serverless-yml
+current_menu: serverless-yml
 introduction: Configure your application with the serverless.yml file.
 ---
 

--- a/docs/environment/storage.md
+++ b/docs/environment/storage.md
@@ -1,6 +1,6 @@
 ---
 title: Storage
-currentMenu: storage
+current_menu: storage
 introduction: Learn how to store data and files in serverless PHP applications running on AWS Lambda.
 ---
 

--- a/docs/environment/variables.md
+++ b/docs/environment/variables.md
@@ -1,6 +1,6 @@
 ---
 title: Environment variables
-currentMenu: php
+current_menu: variables
 introduction: Define environment variables for your Bref application.
 ---
 

--- a/docs/first-steps.md
+++ b/docs/first-steps.md
@@ -1,6 +1,6 @@
 ---
 title: First steps
-currentMenu: first-steps
+current_menu: first-steps
 introduction: First steps to discover Bref and deploy your first PHP function on AWS Lambda.
 previous:
     link: /docs/installation.html

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -1,6 +1,6 @@
 ---
 title: Serverless Laravel applications
-currentMenu: laravel
+current_menu: laravel
 introduction: Learn how to deploy serverless Laravel applications on AWS Lambda using Bref.
 ---
 

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -1,6 +1,6 @@
 ---
 title: Serverless Symfony applications
-currentMenu: symfony
+current_menu: symfony
 introduction: Learn how to deploy serverless Symfony applications on AWS Lambda using Bref.
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 ---
 title: Installation
-currentMenu: installation
+current_menu: installation
 introduction: How to install Bref and the required tools.
 previous:
     link: /docs/

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,6 +1,6 @@
 ---
 title: Local development
-currentMenu: local-development
+current_menu: local-development
 ---
 
 To run your applications locally with an architecture close to production you can use the `sam` command line tool from AWS.

--- a/docs/newsletters.md
+++ b/docs/newsletters.md
@@ -1,6 +1,6 @@
 ---
 title: Newsletters
-currentMenu: newsletters
+current_menu: newsletters
 introduction: A collection of newsletters related to serverless and PHP.
 ---
 

--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -1,6 +1,6 @@
 ---
 title: Runtimes
-currentMenu: runtimes-introduction
+current_menu: runtimes-introduction
 introduction: Bref provides runtimes to bring support for PHP on AWS Lambda.
 previous:
     link: /docs/first-steps.html

--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -1,6 +1,6 @@
 ---
 title: Console applications
-currentMenu: console-applications
+current_menu: console-applications
 introduction: Learn how to run serverless console commands on AWS Lambda with Symfony Console or Laravel Artisan.
 previous:
     link: /docs/runtimes/http.html

--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -1,6 +1,6 @@
 ---
 title: PHP functions
-currentMenu: php-functions
+current_menu: php-functions
 introduction: Learn how to run serverless PHP functions on AWS Lambda using Bref.
 previous:
     link: /docs/runtimes/

--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -1,6 +1,6 @@
 ---
 title: HTTP applications
-currentMenu: http-applications
+current_menu: http-applications
 introduction: Learn how to run serverless HTTP applications with PHP on AWS Lambda using Bref.
 previous:
     link: /docs/runtimes/function.html

--- a/docs/websites.md
+++ b/docs/websites.md
@@ -1,6 +1,6 @@
 ---
 title: Creating serverless PHP websites
-currentMenu: php
+current_menu: websites
 introduction: Learn how to deal with assets and static files to deploy serverless PHP websites.
 ---
 


### PR DESCRIPTION
[Couscous](http://couscous.io/) uses a variable called `current_menu` [(see here)](https://github.com/CouscousPHP/Couscous/blob/master/docs/templates.md) to build the menu sidebar and that variable was mistyped as `currentMenu` in most of the `.md` files and also some page names were wrong. That was why the active page links weren't working properly. This PR will fix #315.