### PR TITLE
Increase function timeout for console applications

### DIFF
--- a/template/console/serverless.yml
+++ b/template/console/serverless.yml
@@ -12,7 +12,7 @@ functions:
     console:
         handler: bin/console # Replace by `artisan` if you are using Laravel
         description: ''
-        timeout: 30 # in seconds (API Gateway has a timeout of 30 seconds)
+        timeout: 30 # in seconds
         layers:
             - ${bref:layer.php-73} # PHP
             - ${bref:layer.console} # The "console" layer

--- a/template/console/serverless.yml
+++ b/template/console/serverless.yml
@@ -12,6 +12,7 @@ functions:
     console:
         handler: bin/console # Replace by `artisan` if you are using Laravel
         description: ''
+        timeout: 30 # in seconds (API Gateway has a timeout of 30 seconds)
         layers:
             - ${bref:layer.php-73} # PHP
             - ${bref:layer.console} # The "console" layer


### PR DESCRIPTION
The default timeout it's no much for console applications. It was increased until the current [API Gateway max timeout (30s)](https://serverless.com/framework/docs/providers/aws/guide/serverless.yml/). 

This PR will fix #261 