### PR TITLE
Compile php using GCC -O3

### DIFF
--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -371,7 +371,7 @@ RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel
 # -fstack-protector-strong : Be paranoid about stack overflows
 # -fpic : Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)
 # -fpie : Support Address Space Layout Randomization (see -fpic)
-# -0s : Optimize for smallest binaries possible.
+# -O3 : Optimize for fastest binaries possible.
 # -I : Add the path to the list of directories to be searched for header files during preprocessing.
 # --enable-option-checking=fatal: make sure invalid --configure-flags are fatal errors instead of just warnings
 # --enable-ftp: because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
@@ -382,8 +382,8 @@ RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel
 #
 RUN set -xe \
  && ./buildconf --force \
- && CFLAGS="-fstack-protector-strong -fpic -fpie -Os -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
-    CPPFLAGS="-fstack-protector-strong -fpic -fpie -Os -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+ && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+    CPPFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-O1 -Wl,--strip-all -Wl,--hash-style=both -pie" \
     ./configure \
         --build=x86_64-pc-linux-gnu \


### PR DESCRIPTION
I've looked around too see if there's a reason why we are compiling PHP for size instead of speed, but I haven't found any motivation in the commits/issues so I tested out the options. Especially because compiler optimization can be quite good in an interpreter.

Size-optimized compilation outputs two binaries (`php` and `php-fpm`) of around 13M each. The output directory weights 67M, which compresses down 35M in the layer zip file.
Tier 3 optimization produces 15M binaries, 71M directory which compresses down to 36M.

I tested out the "language" performance using [Zend/bench.php](https://github.com/php/php-src/blob/master/Zend/bench.php) on 10 runs (AMD FX-8350).
Size-optimized compilation executes the benchmark in 0.96, while Tier 3 optimization executes it in 0.86. 

It is a ~10% improvement in interpreter performance, against a ~6% total layer increase.

I know this is quite borderline, and it applies especially to CPU-bound programs, but in a lambda environment where we can run with a fraction of 1 vCPU it might lead to a significant improvement (and cost saving). 
The main example that comes into my mind is hydration of database models (e.g. Laravel Eloquent, Symfony Doctrine), which is basically CPU bound.

Similar consideration can be done for other libraries (we're not setting optimization level for most of them, so they either have a default one in the config or we might be using `-O0`), but I left them out of here for now.