### PR TITLE
Remove tests and docs from php library directory

### DIFF
--- a/runtime/php/php.Dockerfile
+++ b/runtime/php/php.Dockerfile
@@ -460,6 +460,9 @@ RUN rm -rf /opt/bref/lib/php/PEAR \
   rm -rf /opt/bref/share/man \
   rm -rf /opt/bref/share/gtk-doc \
   rm -rf /opt/bref/include \
+  rm -rf /opt/bref/lib/php/test \
+  rm -rf /opt/bref/lib/php/doc \
+  rm -rf /opt/bref/lib/php/docs \
   rm -rf /opt/bref/tests \
   rm -rf /opt/bref/doc \
   rm -rf /opt/bref/docs \


### PR DESCRIPTION
While testing #378 I found out the cleanup script is leaving out extension's tests and docs files because they are stored in `bref/lib/php`.

Resulting layer dropped from 67M to 58M, compressed version dropped from 33M to 31M.
I tested the redis extension and it worked correctly.