### PR TITLE
Add Tag parameter in makefile

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-
+TAG = latest
 .PHONY: layers
 # Publish the layers on AWS Lambda
 publish: layers
@@ -28,14 +28,14 @@ compiler: compiler.Dockerfile
 # Compile PHP and its extensions
 build: compiler
 	docker build -f ${PWD}/php-intermediary.Dockerfile -t bref/php-72-intermediary:latest $(shell helpers/docker_args.sh versions.ini php72) .
-	cd layers/fpm ; docker build -t bref/php-72-fpm:latest --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
-	cd layers/fpm-dev ; docker build -t bref/php-72-fpm-dev:latest --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
-	cd layers/function ; docker build -t bref/php-72:latest --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
+	cd layers/fpm ; docker build -t bref/php-72-fpm:$(TAG) --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
+	cd layers/fpm-dev ; docker build -t bref/php-72-fpm-dev:$(TAG) --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
+	cd layers/function ; docker build -t bref/php-72:$(TAG) --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
 	docker build -f ${PWD}/php-intermediary.Dockerfile -t bref/php-73-intermediary:latest $(shell helpers/docker_args.sh versions.ini php73) .
-	cd layers/fpm ; docker build -t bref/php-73-fpm:latest --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
-	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev:latest --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
-	cd layers/function ; docker build -t bref/php-73:latest --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
-	cd layers/web; docker build -t bref/fpm-dev-gateway:latest . ; cd ../..
+	cd layers/fpm ; docker build -t bref/php-73-fpm:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
+	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
+	cd layers/function ; docker build -t bref/php-73:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
+	cd layers/web; docker build -t bref/fpm-dev-gateway:$(TAG) . ; cd ../..
 
 publish: build
 	docker push bref/php-72:latest


### PR DESCRIPTION
Simplify tag creation with docker images. 

I've added this function in my zsh : 
```
push_bref () {
    : ${1=latest}
    images=('fpm-dev-gateway' 'php-72' 'php-73' 'php-72-fpm' 'php-73-fpm' 'php-72-fpm-dev' 'php-73-fpm-dev')
    cd bref_directory/runtime
    make build TAG=$1
    for i ($images) docker push bref/$i
}
```
and then `push_bref; push_bref 0.5.1; etc...`