### PR TITLE
Fix issue #394

### DIFF
--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -17,7 +17,7 @@ The simplest way to write a lambda is to write one in the form of a PHP function
 
 require __DIR__.'/vendor/autoload.php';
 
-lambda(function (array $event) {
+lambda(function ($event) {
     return 'Hello ' . ($event['name'] ?? 'world');
 });
 ```
@@ -39,7 +39,7 @@ A function can be defined by calling Bref's `lambda()` function and passing it a
 
 require __DIR__.'/vendor/autoload.php';
 
-lambda(function (array $event) {
+lambda(function ($event) {
     return /* response */;
 });
 ```
@@ -62,7 +62,7 @@ use Bref\Context\Context;
 
 require __DIR__.'/vendor/autoload.php';
 
-lambda(function (array $event, Context $context) {
+lambda(function ($event, Context $context) {
     return /* response */;
 });
 ```

--- a/template/default/index.php
+++ b/template/default/index.php
@@ -2,6 +2,6 @@
 
 require __DIR__.'/vendor/autoload.php';
 
-lambda(function (array $event) {
+lambda(function ($event) {
     return 'Hello ' . ($event['name'] ?? 'world');
 });


### PR DESCRIPTION
As mentioned in https://github.com/brefphp/bref/issues/394, using the array type hint will throw an exception if the user didn't provide any data to the request.

This removes the type hint from the default generated code