### PR TITLE
Enable GD extension

### DIFF
--- a/runtime/php-intermediary.Dockerfile
+++ b/runtime/php-intermediary.Dockerfile
@@ -365,7 +365,9 @@ WORKDIR  ${PHP_BUILD_DIR}/
 # readline-devel : needed for the --with-libedit flag
 # gettext-devel : needed for the --with-gettext flag
 # libicu-devel : needed for
-RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel
+# libpng-devel : needed for gd
+# libjpeg-devel : needed for gd
+RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libpng-devel libjpeg-devel
 
 # Configure the build
 # -fstack-protector-strong : Be paranoid about stack overflows
@@ -416,7 +418,10 @@ RUN set -xe \
         --with-pdo-pgsql=shared,${INSTALL_DIR} \
         --enable-intl=shared \
         --enable-opcache-file \
-        --enable-soap
+        --enable-soap \
+        --with-gd \
+        --with-png-dir=${INSTALL_DIR} \
+        --with-jpeg-dir=${INSTALL_DIR}
 RUN make -j $(nproc)
 # Run `make install` and override PEAR's PHAR URL because pear.php.net is down
 RUN set -xe; \


### PR DESCRIPTION
I was trying to manipulate some images using bref, and I just saw that gd is not available.

I tried to run it locally, but doing a simple docker-composer (like explained in the documentation)

```
console:
    image: bref/php-73:local
    volumes:
        - .:/var/task:ro # Read only, like a lambda function
        # Some directories can be made writable for the development environment:
        # - ./cache:/var/task/cache
    command: php -i
```

But I always have:

```
> % docker-compose run console                                                                    
Could not open input file: /var/task/php
START RequestId: 52fdfc07-2182-154f-163f-5f0f9a621d72 Version: $LATEST
END RequestId: 52fdfc07-2182-154f-163f-5f0f9a621d72
REPORT RequestId: 52fdfc07-2182-154f-163f-5f0f9a621d72  Init Duration: 43.91 ms Duration: 0.00 ms       Billed Duration: 100 ms     Memory Size: 1536 MB    Max Memory Used: 7 MB
{
  "errorType": "Runtime.ExitError",
  "errorMessage": "RequestId: 52fdfc07-2182-154f-163f-5f0f9a621d72 Error: Runtime exited without providing a reason"
}
```
