### PR TITLE
Remove PHP-FPM from "function" layers

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 TAG = latest
 .PHONY: layers
+
 # Publish the layers on AWS Lambda
 publish: layers
 	php publish.php
@@ -10,7 +11,7 @@ layers: export/console.zip export/php-72.zip export/php-73.zip export/php-72-fpm
 
 # The PHP runtimes
 export/php%.zip: build
-	PHP_VERSION=$$(echo $@| tail -c +8|head -c -5);\
+	PHP_VERSION=$$(echo $@ | cut -d'/' -f 2 | cut -d'.' -f 1);\
 	rm -f $@;\
 	mkdir export/tmp ; cd export/tmp ;\
 	docker run --entrypoint "tar" bref/$$PHP_VERSION:latest -ch -C /opt .  |tar -x;zip --quiet --recurse-paths ../$$PHP_VERSION.zip . ;
@@ -36,7 +37,3 @@ build: compiler
 	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
 	cd layers/function ; docker build -t bref/php-73:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
 	cd layers/web; docker build -t bref/fpm-dev-gateway:$(TAG) . ; cd ../..
-
-publish: build
-	docker push bref/php-72:latest
-	docker push bref/php-73:latest

--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -7,7 +7,8 @@ COPY bootstrap bootstrap
 COPY php.ini bref/etc/php/conf.d/bref.ini
 COPY php-fpm.conf bref/etc/php-fpm.conf
 
+# Build the final image from the lambci image that is close to the production environment
 FROM lambci/lambda:provided
 
-WORKDIR /
 COPY --from=0  /opt /opt
+WORKDIR /var/task

--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -11,4 +11,3 @@ COPY php-fpm.conf bref/etc/php-fpm.conf
 FROM lambci/lambda:provided
 
 COPY --from=0  /opt /opt
-WORKDIR /var/task

--- a/runtime/layers/function/Dockerfile
+++ b/runtime/layers/function/Dockerfile
@@ -13,4 +13,3 @@ RUN rm bref/sbin/php-fpm bin/php-fpm
 FROM lambci/lambda:provided
 
 COPY --from=0  /opt /opt
-WORKDIR /var/task

--- a/runtime/layers/function/Dockerfile
+++ b/runtime/layers/function/Dockerfile
@@ -6,9 +6,11 @@ WORKDIR /opt
 COPY bootstrap bootstrap
 COPY php.ini bref/etc/php/conf.d/bref.ini
 
+# Remove PHP-FPM
+RUN rm bref/sbin/php-fpm bin/php-fpm
+
+# Build the final image from the lambci image that is close to the production environment
 FROM lambci/lambda:provided
 
-WORKDIR /
 COPY --from=0  /opt /opt
-RUN pwd
 WORKDIR /var/task


### PR DESCRIPTION
FPM was no longer removed from the runtimes.

This is not affecting production images. This is a bug we detected on master. Nobody should be impacted by this.

Before:

```
❯ ll export
total 275720
-rw-r--r--  1 matthieu  staff   746B  8 aoû 13:59 console.zip
-rw-r--r--  1 matthieu  staff    33M  9 aoû 09:05 php-72-fpm.zip
-rw-r--r--  1 matthieu  staff    33M  9 aoû 09:04 php-72.zip
-rw-r--r--  1 matthieu  staff    33M  9 aoû 09:05 php-73-fpm.zip
-rw-r--r--  1 matthieu  staff    33M  9 aoû 09:04 php-73.zip
```

After:

```
❯ ll export
total 240704
-rw-r--r--  1 matthieu  staff   746B  8 aoû 13:59 console.zip
-rw-r--r--  1 matthieu  staff    33M  9 aoû 09:21 php-72-fpm.zip
-rw-r--r--  1 matthieu  staff    24M  9 aoû 09:20 php-72.zip
-rw-r--r--  1 matthieu  staff    33M  9 aoû 09:21 php-73-fpm.zip
-rw-r--r--  1 matthieu  staff    25M  9 aoû 09:21 php-73.zip
```