### PR TITLE
Doc: improve iamRoleStatements

### DIFF
--- a/docs/environment/serverless-yml.md
+++ b/docs/environment/serverless-yml.md
@@ -144,6 +144,30 @@ Note that it is possible to mix PHP functions with functions written in other la
 If your lambda needs to access other AWS services (S3, SQS, SNS…), you will need to add the proper permissions via the [`iamRoleStatements` section](https://serverless.com/framework/docs/providers/aws/guide/functions#permissions):
 
 ```yaml
+provider:
+    name: aws
+    timeout: 10
+    runtime: provided
+    iamRoleStatements:
+        # Allow to put a file in the `my-bucket` S3 bucket
+        -   Effect: Allow
+            Action: s3:PutObject
+            Resource: 'arn:aws:s3:::my-bucket/*'
+        # Allow to query and update the `example` DynamoDB table
+        -   Effect: Allow
+            Action:
+                - dynamodb:Query
+                - dynamodb:Scan
+                - dynamodb:GetItem
+                - dynamodb:PutItem
+                - dynamodb:UpdateItem
+                - dynamodb:DeleteItem
+            Resource: 'arn:aws:dynamodb:us-east-1:111110002222:table/example'
+```
+
+If you only want to define some permissions **per function**, instead of globally (ie: in the provider), you should install and enable the Serverless plugin [`serverless-iam-roles-per-function`](https://github.com/functionalone/serverless-iam-roles-per-function) and then use the `iamRoleStatements` at the function definition block:
+
+```yaml
 functions:
     foo:
         handler: foo.php

--- a/docs/environment/serverless-yml.md
+++ b/docs/environment/serverless-yml.md
@@ -165,30 +165,7 @@ provider:
             Resource: 'arn:aws:dynamodb:us-east-1:111110002222:table/example'
 ```
 
-If you only want to define some permissions **per function**, instead of globally (ie: in the provider), you should install and enable the Serverless plugin [`serverless-iam-roles-per-function`](https://github.com/functionalone/serverless-iam-roles-per-function) and then use the `iamRoleStatements` at the function definition block:
-
-```yaml
-functions:
-    foo:
-        handler: foo.php
-        layers:
-            - ${bref:layer.php-73}
-        iamRoleStatements:
-            # Allow to put a file in the `my-bucket` S3 bucket
-            -   Effect: Allow
-                Action: s3:PutObject
-                Resource: 'arn:aws:s3:::my-bucket/*'
-            # Allow to query and update the `example` DynamoDB table
-            -   Effect: Allow
-                Action:
-                    - dynamodb:Query
-                    - dynamodb:Scan
-                    - dynamodb:GetItem
-                    - dynamodb:PutItem
-                    - dynamodb:UpdateItem
-                    - dynamodb:DeleteItem
-                Resource: 'arn:aws:dynamodb:us-east-1:111110002222:table/example'
-```
+If you only want to define some permissions **per function**, instead of globally (ie: in the provider), you should install and enable the Serverless plugin [`serverless-iam-roles-per-function`](https://github.com/functionalone/serverless-iam-roles-per-function) and then use the `iamRoleStatements` at the function definition block.
 
 ## Resources
 


### PR DESCRIPTION
The documentation were wrong about how to define custom permissions.

It defines them at the `function` block which isn't possible in
Serverless.
It should be defined at the `provider` block.

I've also added a section to explain how to define them at the `function`
block (using a Serverless plugin).
