### PR TITLE
Add AWS profile option when using the dashboard

### DIFF
--- a/bref
+++ b/bref
@@ -250,10 +250,11 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
     return 0;
 })->descriptions('Displays the latest deployment logs from CloudFormation. Only the logs from the last 24 hours are displayed. Use these logs to debug why a deployment failed.');
 
-$app->command('dashboard [--host=] [--port=]', function (string $host = 'localhost', int $port = 8000, SymfonyStyle $io) {
+$app->command('dashboard [--host=] [--port=] [--profile=]', function (string $host = 'localhost', int $port = 8000, string $profile = 'default', SymfonyStyle $io) {
     if ($host === 'localhost') {
         $host = '127.0.0.1';
     }
+
     if (! file_exists('serverless.yml')) {
         $io->error('No `serverless.yml` file found.');
 
@@ -279,7 +280,7 @@ $app->command('dashboard [--host=] [--port=]', function (string $host = 'localho
         return 1;
     }
 
-    $servelessInfo = new Process(['serverless', 'info']);
+    $servelessInfo = new Process(['serverless', 'info', '--aws-profile', $profile]);
     $servelessInfo->start();
     $animation = new LoadingAnimation($io);
     do {

--- a/bref
+++ b/bref
@@ -324,7 +324,7 @@ $app->command('dashboard [--host=] [--port=] [--profile=]', function (string $ho
         return 1;
     }
 
-    $process = new Process(['docker', 'run', '--rm', '-p', $host . ':' . $port.':8000', '-v', getenv('HOME').'/.aws:/root/.aws:ro', '--env', 'STACKNAME='.$stack, '--env', 'REGION='.$region, 'bref/dashboard']);
+    $process = new Process(['docker', 'run', '--rm', '-p', $host . ':' . $port.':8000', '-v', getenv('HOME').'/.aws:/root/.aws:ro', '--env', 'STACKNAME='.$stack, '--env', 'REGION='.$region, '--env', 'AWS_PROFILE='.$profile, 'bref/dashboard']);
     $process->setTimeout(null);
     $process->start();
     do {


### PR DESCRIPTION
~~This is kind of work in progress, because the `bref/dashboard` docker image will also need to be updated to use the profile parameter.~~

Some people use a lot of differents AWS credentials and the Serverless CLI allow to specify which profile to use: https://serverless.com/framework/docs/providers/aws/guide/credentials#using-the-aws-profile-option

In my case, I didn't have a `default` profile but a lot of different one. That's why I needed to be able to define the profile the dashboard command has to use to retrieve the stack.

Without the parameter I got:
> [ERROR] The command `serverless info` failed

~~But now, the dashboard fails to render because the command needs to send him the profile too~~

![image](https://user-images.githubusercontent.com/62333/63523189-f3575b00-c4f9-11e9-93a2-9d19d08e3f56.png)

~~And it looks like the repo of the image isn't public (I got a 404) so I can't update it 🤷‍♂  https://github.com/mnapoli/bref-dashboard~~