### PR TITLE
Add stage command option

### DIFF
--- a/bref
+++ b/bref
@@ -250,7 +250,7 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
     return 0;
 })->descriptions('Displays the latest deployment logs from CloudFormation. Only the logs from the last 24 hours are displayed. Use these logs to debug why a deployment failed.');
 
-$app->command('dashboard [--host=] [--port=] [--profile=] [--stage=]', function (string $host = 'localhost', int $port = 8000, string $profile = 'default', string $stage = 'prod', SymfonyStyle $io) {
+$app->command('dashboard [--host=] [--port=] [--profile=] [--stage=]', function (string $host = 'localhost', int $port = 8000, string $profile = 'default', string $stage = null, SymfonyStyle $io) {
     if ($host === 'localhost') {
         $host = '127.0.0.1';
     }

--- a/bref
+++ b/bref
@@ -280,7 +280,7 @@ $app->command('dashboard [--host=] [--port=] [--profile=] [--stage=]', function 
         return 1;
     }
 
-    $servelessInfo = new Process(['serverless', 'info', '--stage', $stage], '--aws-profile', $profile);
+    $servelessInfo = new Process(['serverless', 'info', '--stage', $stage, '--aws-profile', $profile]);
     $servelessInfo->start();
     $animation = new LoadingAnimation($io);
     do {

--- a/bref
+++ b/bref
@@ -250,7 +250,7 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
     return 0;
 })->descriptions('Displays the latest deployment logs from CloudFormation. Only the logs from the last 24 hours are displayed. Use these logs to debug why a deployment failed.');
 
-$app->command('dashboard [--host=] [--port=] [--profile=]', function (string $host = 'localhost', int $port = 8000, string $profile = 'default', SymfonyStyle $io) {
+$app->command('dashboard [--host=] [--port=] [--profile=] [--stage=]', function (string $host = 'localhost', int $port = 8000, string $profile = 'default', string $stage = 'prod', SymfonyStyle $io) {
     if ($host === 'localhost') {
         $host = '127.0.0.1';
     }
@@ -280,7 +280,7 @@ $app->command('dashboard [--host=] [--port=] [--profile=]', function (string $ho
         return 1;
     }
 
-    $servelessInfo = new Process(['serverless', 'info', '--aws-profile', $profile]);
+    $servelessInfo = new Process(['serverless', 'info', '--stage', $stage], '--aws-profile', $profile);
     $servelessInfo->start();
     $animation = new LoadingAnimation($io);
     do {


### PR DESCRIPTION
Serverless application might have different stages, and it can be different from aws-profile name (eg: `stage=prod` and `aws-profile=production`).
When this happens, serverless info is throwing an error:
`[ERROR] The command serverless info failed`

<img width="975" alt="Screenshot 2019-08-24 at 13 39 43" src="https://user-images.githubusercontent.com/1071148/63637512-b368b300-c674-11e9-8596-652475a8a720.png">
