### PR TITLE
Add a warning when installing Bref

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,7 +46,7 @@ Install Bref in your project using [Composer](https://getcomposer.org/):
 composer require bref/bref
 ```
 
-> Make sure that you have installed a version greater than or equal to 0.5.* of Bref, to make use of the serverless plugin. Older version of Bref won't work with the serverless plugin.
+> Make sure that you have installed a version greater than or equal to 0.5.* of Bref.
 
 > To run the latest version of Bref you must have PHP 7.2 or greater! If you are using PHP 7.1 or less an older (outdated) version of Bref will be installed instead.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,8 @@ Install Bref in your project using [Composer](https://getcomposer.org/):
 composer require bref/bref
 ```
 
+> Make sure that you have installed a version greater than or equal to 0.5.* of Bref, to make use of the serverless plugin. Older version of Bref won't work with the serverless plugin.
+
 > To run the latest version of Bref you must have PHP 7.2 or greater! If you are using PHP 7.1 or less an older (outdated) version of Bref will be installed instead.
 
 The `bref` command line tool can now be used by running `vendor/bin/bref` in your project.


### PR DESCRIPTION
Add a note to encourage using Bref greater than or equal to 0.5.* and close https://github.com/brefphp/bref/issues/425

> More and more people are installing Bref either via old blog posts or using an old version of PHP.
>
> They end up with an old version of Bref and the serverless plugin doesn't work.
>
> We should add a warning here: https://bref.sh/docs/installation.html#bref to encourage users to check that they have installed Bref 0.5.*.