### PR TITLE
Fall back to parent functions for Symfony Kernel

### DIFF
--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -61,7 +61,7 @@ Since [the filesystem is readonly](/docs/environment/storage.md) except for `/tm
             return '/tmp/log/';
         }
 
-        return $this->getProjectDir().'/var/log';
+        return parent::getLogDir();;
     }
 
     public function getCacheDir()
@@ -71,7 +71,7 @@ Since [the filesystem is readonly](/docs/environment/storage.md) except for `/tm
             return '/tmp/cache/'.$this->environment;
         }
 
-        return $this->getProjectDir().'/var/cache/'.$this->environment;
+        return parent::getCacheDir();
     }
 ```
 


### PR DESCRIPTION
Thanks for sharing Bref!

I just ran through the initial setup of a Symfony app and noticed  that Lambda needs a customized Symfony Kernel to be able to specify were to write logs and cache.

However when the application is not executed through Lambda we can fall back to the parent definitions instead of replicating the code. There is no need to replicate the code in these functions. I suggest that we update the documentation.