### PR TITLE
Add layer to "Keep Alive"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
-        "zendframework/zend-diactoros": "^1.6|^2.0",
+        "riverline/multipart-parser": "^1.2",
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.11.5",
         "guzzlehttp/guzzle": "^6.3",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
-        "riverline/multipart-parser": "^1.2",
+        "riverline/multipart-parser": "^2.0",
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.11.5",
         "guzzlehttp/guzzle": "^6.3",

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "zendframework/zend-diactoros": "^1.6|^2.0",
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.11.5",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3",
+        "symfony/http-foundation": "^4.3"
     }
 }

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -7,7 +7,7 @@ publish: layers
 	php publish.php
 
 # Build the layers
-layers: export/console.zip export/php-72.zip export/php-73.zip export/php-72-fpm.zip export/php-73-fpm.zip
+layers: export/console.zip export/keep-alive.zip export/php-72.zip export/php-73.zip export/php-72-fpm.zip export/php-73-fpm.zip
 
 # The PHP runtimes
 export/php%.zip: build
@@ -21,6 +21,11 @@ export/php%.zip: build
 export/console.zip: layers/console/bootstrap
 	rm -f export/console.zip
 	cd layers/console && zip ../../export/console.zip bootstrap
+
+# The keep-alive runtime
+export/keep-alive.zip: layers/keep-alive/bootstrap
+	rm -f export/keep-alive.zip
+	cd layers/keep-alive && zip ../../export/keep-alive.zip bootstrap
 
 # Build the docker container that will be used to compile PHP and its extensions
 compiler: compiler.Dockerfile

--- a/runtime/layer-list.php
+++ b/runtime/layer-list.php
@@ -17,6 +17,7 @@ const LAYER_NAMES = [
     'php-72',
     'php-72-fpm',
     'console',
+    'keep-alive',
 ];
 
 $regions = json_decode(file_get_contents(__DIR__ . '/regions.json'), true);

--- a/runtime/layers/keep-alive/README.md
+++ b/runtime/layers/keep-alive/README.md
@@ -1,0 +1,5 @@
+The "keep-alive" layer is a layer that comes on top of the PHP runtime.
+
+This layer overrides the `bootstrap` to make sure your application is never unloaded.
+
+Read more at [bref.sh/docs/runtimes/keep-alive.html](https://bref.sh/docs/runtimes/keep-alive.html).

--- a/runtime/layers/keep-alive/bootstrap
+++ b/runtime/layers/keep-alive/bootstrap
@@ -1,0 +1,43 @@
+#!/opt/bin/php
+<?php declare(strict_types=1);
+
+use Bref\Http\LambdaRequest;
+use Bref\Http\LambdaResponse;
+use Bref\Runtime\LambdaRuntime;
+
+$appRoot = getenv('LAMBDA_TASK_ROOT');
+$callableFile = $appRoot . '/' . getenv('_HANDLER');
+if (! is_file($callableFile)) {
+    $lambdaRuntime->failInitialization("Handler `$handler` doesn't exist");
+}
+
+$callable = include $callableFile;
+if (!is_callable($callable)) {
+    throw new LogicException('The handler must return a callable when using keep-alive.');
+}
+
+if (!class_exists(LambdaRuntime::class)) {
+    throw new LogicException('You must load composer\'s autoloader.');
+}
+
+$lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
+$memoryMax = getenv('BREF_MEMORY_MAX') ?: 1000000000;
+$loopMax = getenv('BREF_LOOP_MAX') ?: 50;
+$loops = 0;
+while (true) {
+    if (++$loops > $loopMax || memory_get_usage() > $memoryMax) {
+        // Quit.
+        return;
+    }
+
+    $lambdaRuntime->processNextEvent(function ($event) use ($callable): array {
+        $response = $callable(LambdaRequest::create($event));
+
+        if (!$response instanceof LambdaResponse) {
+            throw new LogicException('Wrong response type');
+        }
+
+        $multiHeader = array_key_exists('multiValueHeaders', $event);
+        return $response->toApiGatewayFormat($multiHeader);
+    });
+}

--- a/runtime/layers/keep-alive/bootstrap
+++ b/runtime/layers/keep-alive/bootstrap
@@ -30,8 +30,8 @@ while (true) {
         return;
     }
 
-    $lambdaRuntime->processNextEvent(function ($event) use ($callable): array {
-        $response = $callable(LambdaRequest::create($event));
+    $lambdaRuntime->processNextEvent(function ($event, $context) use ($callable): array {
+        $response = $callable(LambdaRequest::create($event), $context);
 
         if (!$response instanceof LambdaResponse) {
             throw new LogicException('Wrong response type');

--- a/runtime/layers/keep-alive/bootstrap
+++ b/runtime/layers/keep-alive/bootstrap
@@ -13,11 +13,11 @@ if (! is_file($callableFile)) {
 
 $callable = include $callableFile;
 if (!is_callable($callable)) {
-    throw new LogicException('The handler must return a callable when using keep-alive.');
+    $lambdaRuntime->failInitialization("The handler must return a callable when using keep-alive");
 }
 
 if (!class_exists(LambdaRuntime::class)) {
-    throw new LogicException('You must load composer\'s autoloader.');
+    $lambdaRuntime->failInitialization("You must load composer's autoloader");
 }
 
 $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();

--- a/runtime/publish.php
+++ b/runtime/publish.php
@@ -14,6 +14,7 @@ $layers = [
     'php-72' => 'PHP 7.2 for PHP functions',
     'php-72-fpm' => 'PHP-FPM 7.2 for HTTP applications',
     'console' => 'Console runtime for PHP applications',
+    'keep-alive' => 'Keep your application alive',
 ];
 foreach ($layers as $layer => $layerDescription) {
     $file = __DIR__ . "/export/$layer.zip";

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 class LambdaRequest
 {
+    /** @var array */
     private $event;
 
     private function __construct()
@@ -32,8 +33,9 @@ class LambdaRequest
     }
 
     /**
-     * @experimental
      * There is currently no support for uploading files
+     *
+     * @experimental
      */
     public function getSymfonyRequest(): Request
     {
@@ -73,6 +75,8 @@ class LambdaRequest
     }
 
     /**
+     * There are no test coverage that prove that this is 100% correct.
+     *
      * @experimental
      */
     public function getPsr7Request(): RequestInterface

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -114,7 +114,7 @@ class LambdaRequest
                 if ($document->isMultiPart()) {
                     $parsedBody = [];
                     foreach ($document->getParts() as $part) {
-                        if (!$part->isFile()) {
+                        if (! $part->isFile()) {
                             $this->parseKeyAndInsertValueInArray($parsedBody, $part->getName(), $part->getBody());
                             continue;
                         }

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class LambdaRequest
+{
+    private $event;
+
+    public static function create(array $event)
+    {
+        $model = new self();
+        $model->event = $event;
+
+        return $model;
+    }
+
+    public function getRawEvent()
+    {
+        return $this->event;
+    }
+
+    public function getSymfonyRequest()
+    {
+        $event = $this->event;
+        $requestBody = $event['body'] ?? '';
+        if ($event['isBase64Encoded'] ?? false) {
+            $requestBody = base64_decode($requestBody);
+        }
+
+        $queryString = $this->getQueryString($event);
+        $uri = $event['path'] ?? '/';
+        if (! empty($queryString)) {
+            $uri .= '?' . $queryString;
+        }
+
+        $method = strtoupper($event['httpMethod']);
+        $request = Request::create($uri, $method, [], [], [], [], $requestBody);
+
+        // Normalize headers
+        if (isset($event['multiValueHeaders'])) {
+            $headers = $event['multiValueHeaders'];
+        } else {
+            $headers = $event['headers'] ?? [];
+            // Turn the headers array into a multi-value array to simplify the code below
+            $headers = array_map(function ($value): array {
+                return [$value];
+            }, $headers);
+        }
+        $headers = array_change_key_case($headers, CASE_LOWER);
+
+        $request->headers->add($headers);
+
+        return $request;
+    }
+
+    public function getPsr7Request()
+    {
+        // TODO write me
+    }
+
+    private function getQueryString(array $event): string
+    {
+        if (isset($event['multiValueQueryStringParameters']) && $event['multiValueQueryStringParameters']) {
+            $queryParameters = [];
+            /*
+             * Watch out: to support multiple query string parameters with the same name like:
+             *     ?array[]=val1&array[]=val2
+             * we need to support "multi-value query string", else only the 'val2' value will survive.
+             * At the moment we only take the first value (which means we DON'T support multiple values),
+             * this needs to be implemented below in the future.
+             */
+            foreach ($event['multiValueQueryStringParameters'] as $key => $value) {
+                $queryParameters[$key] = $value[0];
+            }
+            return http_build_query($queryParameters);
+        }
+
+        if (empty($event['queryStringParameters'])) {
+            return '';
+        }
+
+        /*
+         * Watch out in the future if using $event['queryStringParameters'] directly!
+         *
+         * (that is no longer the case here but it was in the past with the PSR-7 bridge, and it might be
+         * reintroduced in the future)
+         *
+         * queryStringParameters does not handle correctly arrays in parameters
+         * ?array[key]=value gives ['array[key]' => 'value'] while we want ['array' => ['key' = > 'value']]
+         * In that case we should recreate the original query string and use parse_str which handles correctly arrays
+         */
+        return http_build_query($event['queryStringParameters']);
+    }
+}

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Bref\Http;
 
+use GuzzleHttp\Psr7\ServerRequest;
+use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\UploadedFile;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Riverline\MultiPartParser\Part;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -13,7 +19,12 @@ class LambdaRequest
 {
     private $event;
 
-    public static function create(array $event)
+    private function __construct()
+    {
+    }
+
+
+    public static function create(array $event): self
     {
         $model = new self();
         $model->event = $event;
@@ -21,13 +32,17 @@ class LambdaRequest
         return $model;
     }
 
-    public function getRawEvent()
+    public function getRawEvent(): array
     {
         return $this->event;
     }
 
-    public function getSymfonyRequest()
+    public function getSymfonyRequest(): Request
     {
+        if (!class_exists(Request::class)) {
+            throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require symfony/http-foundation".');
+        }
+
         $event = $this->event;
         $requestBody = $event['body'] ?? '';
         if ($event['isBase64Encoded'] ?? false) {
@@ -60,9 +75,130 @@ class LambdaRequest
         return $request;
     }
 
-    public function getPsr7Request()
+    public function getPsr7Request(): RequestInterface
     {
-        // TODO write me
+        if (!class_exists(Request::class)) {
+            throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require guzzle/psr7".');
+        }
+
+        $method = $event['httpMethod'] ?? 'GET';
+        $query = [];
+        $bodyString = $event['body'] ?? '';
+        $parsedBody = null;
+        $files = [];
+        $uri = $event['requestContext']['path'] ?? '/';
+        $headers = $event['headers'] ?? [];
+        $protocolVersion = $event['requestContext']['protocol'] ?? '1.1';
+        if ($event['isBase64Encoded'] ?? false) {
+            $bodyString = base64_decode($bodyString);
+        }
+        $body = self::createBodyStream($bodyString);
+        /*
+         * queryStringParameters does not handle correctly arrays in parameters
+         * ?array[key]=value gives ['array[key]' => 'value'] while we want ['array' => ['key' => 'value']]
+         * We recreate the original query string and we use parse_str which handles correctly arrays
+         *
+         * There's still an issue: AWS API Gateway does not support multiple query string parameters with the same name
+         * So you can't use something like ?array[]=val1&array[]=val2 because only the 'val2' value will survive
+         */
+        $queryString = http_build_query($event['queryStringParameters'] ?? []);
+        parse_str($queryString, $query);
+        $cookies = [];
+        if (isset($headers['Cookie'])) {
+            $cookieParts = explode('; ', $headers['Cookie']);
+            foreach ($cookieParts as $cookiePart) {
+                [$cookieName, $cookieValue] = explode('=', $cookiePart, 2);
+                $cookies[$cookieName] = urldecode($cookieValue);
+            }
+        }
+        $contentType = $headers['content-type'] ?? $headers['Content-Type'] ?? null;
+        if ($method === 'POST' && $contentType !== null) {
+            /** @var string $contentType */
+            if ($contentType === 'application/x-www-form-urlencoded') {
+                parse_str($bodyString, $parsedBody);
+            } else {
+                $document = new Part("Content-type: $contentType\r\n\r\n" . $bodyString);
+                if ($document->isMultiPart()) {
+                    $parsedBody = [];
+                    foreach ($document->getParts() as $part) {
+                        if ($part->isFile()) {
+                            $tmpPath = tempnam(sys_get_temp_dir(), 'bref_upload_');
+                            if ($tmpPath === false) {
+                                throw new \RuntimeException('Unable to create a temporary directory');
+                            }
+                            file_put_contents($tmpPath, $part->getBody());
+                            $file = new UploadedFile($tmpPath, filesize($tmpPath), UPLOAD_ERR_OK, $part->getFileName(), $part->getMimeType());
+                            self::parseKeyAndInsertValueInArray($files, $part->getName(), $file);
+                        } else {
+                            self::parseKeyAndInsertValueInArray($parsedBody, $part->getName(), $part->getBody());
+                        }
+                    }
+                }
+            }
+        }
+        $server = [
+            'SERVER_PROTOCOL' => $protocolVersion,
+            'REQUEST_METHOD' => $method,
+            'REQUEST_TIME' => $event['requestContext']['requestTimeEpoch'] ?? time(),
+            'REQUEST_TIME_FLOAT' => microtime(true),
+            'QUERY_STRING' => $queryString,
+            'DOCUMENT_ROOT' => getcwd(),
+            'REQUEST_URI' => $uri,
+        ];
+        if (isset($headers['Host'])) {
+            $server['HTTP_HOST'] = $headers['Host'];
+        }
+
+        return (new ServerRequest($method, $uri, $headers, $body, $protocolVersion, $server))
+            ->withUploadedFiles($files)
+            ->withCookieParams($cookies)
+            ->withQueryParams($query)
+            ->withParsedBody($parsedBody)
+        ;
+    }
+
+    private static function createBodyStream(string $body): StreamInterface
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $body);
+        rewind($stream);
+
+        return new Stream($stream);
+    }
+    /**
+     * Parse a string key like "files[id_cards][jpg][]" and do $array['files']['id_cards']['jpg'][] = $value
+     *
+     * @param mixed $value
+     */
+    private static function parseKeyAndInsertValueInArray(array &$array, string $key, $value): void
+    {
+        if (strpos($key, '[') === false) {
+            $array[$key] = $value;
+            return;
+        }
+        $parts = explode('[', $key); // files[id_cards][jpg][] => [ 'files',  'id_cards]', 'jpg]', ']' ]
+        $pointer = &$array;
+        foreach ($parts as $k => $part) {
+            if ($k === 0) {
+                $pointer = &$pointer[$part];
+                continue;
+            }
+            // Skip two special cases:
+            // [[ in the key produces empty string
+            // [test : starts with [ but does not end with ]
+            if ($part === '' || substr($part, -1) !== ']') {
+                // Malformed key, we use it "as is"
+                $array[$key] = $value;
+                return;
+            }
+            $part = substr($part, 0, -1); // The last char is a ] => remove it to have the real key
+            if ($part === '') { // [] case
+                $pointer = &$pointer[];
+            } else {
+                $pointer = &$pointer[$part];
+            }
+        }
+        $pointer = $value;
     }
 
     private function getQueryString(array $event): string

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Bref\Http;
 
@@ -12,9 +10,6 @@ use Psr\Http\Message\StreamInterface;
 use Riverline\MultiPartParser\StreamedPart;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * @author Tobias Nyholm <tobias.nyholm@gmail.com>
- */
 class LambdaRequest
 {
     private $event;
@@ -23,10 +18,9 @@ class LambdaRequest
     {
     }
 
-
     public static function create(array $event): self
     {
-        $model = new self();
+        $model = new self;
         $model->event = $event;
 
         return $model;
@@ -45,7 +39,7 @@ class LambdaRequest
      */
     public function getSymfonyRequest(): Request
     {
-        if (!class_exists(Request::class)) {
+        if (! class_exists(Request::class)) {
             throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require symfony/http-foundation".');
         }
 
@@ -83,10 +77,10 @@ class LambdaRequest
 
     public function getPsr7Request(): RequestInterface
     {
-        if (!class_exists(Request::class)) {
+        if (! class_exists(Request::class)) {
             throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require guzzlehttp/psr7".');
         }
-        if (!class_exists(StreamedPart::class)) {
+        if (! class_exists(StreamedPart::class)) {
             throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require riverline/multipart-parser".');
         }
 
@@ -162,8 +156,7 @@ class LambdaRequest
             ->withUploadedFiles($files)
             ->withCookieParams($cookies)
             ->withQueryParams($query)
-            ->withParsedBody($parsedBody)
-        ;
+            ->withParsedBody($parsedBody);
     }
 
     private static function createBodyStream(string $body): StreamInterface
@@ -174,6 +167,7 @@ class LambdaRequest
 
         return new Stream($stream);
     }
+
     /**
      * Parse a string key like "files[id_cards][jpg][]" and do $array['files']['id_cards']['jpg'][] = $value
      *
@@ -183,6 +177,7 @@ class LambdaRequest
     {
         if (strpos($key, '[') === false) {
             $array[$key] = $value;
+
             return;
         }
         $parts = explode('[', $key); // files[id_cards][jpg][] => [ 'files',  'id_cards]', 'jpg]', ']' ]
@@ -198,6 +193,7 @@ class LambdaRequest
             if ($part === '' || substr($part, -1) !== ']') {
                 // Malformed key, we use it "as is"
                 $array[$key] = $value;
+
                 return;
             }
             $part = substr($part, 0, -1); // The last char is a ] => remove it to have the real key
@@ -224,6 +220,7 @@ class LambdaRequest
             foreach ($event['multiValueQueryStringParameters'] as $key => $value) {
                 $queryParameters[$key] = $value[0];
             }
+
             return http_build_query($queryParameters);
         }
 

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -9,7 +9,7 @@ use GuzzleHttp\Psr7\Stream;
 use GuzzleHttp\Psr7\UploadedFile;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
-use Riverline\MultiPartParser\Part;
+use Riverline\MultiPartParser\StreamedPart;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -86,6 +86,9 @@ class LambdaRequest
         if (!class_exists(Request::class)) {
             throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require guzzlehttp/psr7".');
         }
+        if (!class_exists(StreamedPart::class)) {
+            throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require riverline/multipart-parser".');
+        }
 
         $method = $event['httpMethod'] ?? 'GET';
         $query = [];
@@ -123,7 +126,7 @@ class LambdaRequest
             if ($contentType === 'application/x-www-form-urlencoded') {
                 parse_str($bodyString, $parsedBody);
             } else {
-                $document = new Part("Content-type: $contentType\r\n\r\n" . $bodyString);
+                $document = new StreamedPart("Content-type: $contentType\r\n\r\n" . $bodyString);
                 if ($document->isMultiPart()) {
                     $parsedBody = [];
                     foreach ($document->getParts() as $part) {

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -84,7 +84,7 @@ class LambdaRequest
     public function getPsr7Request(): RequestInterface
     {
         if (!class_exists(Request::class)) {
-            throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require guzzle/psr7".');
+            throw new \RuntimeException('You need to Symfony HTTP foundation to use this function. Please run "composer require guzzlehttp/psr7".');
         }
 
         $method = $event['httpMethod'] ?? 'GET';

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -37,6 +37,12 @@ class LambdaRequest
         return $this->event;
     }
 
+    /**
+     * TODO this class needs some more work
+     * Currently we only support GET request
+     *
+     * @experimental
+     */
     public function getSymfonyRequest(): Request
     {
         if (!class_exists(Request::class)) {

--- a/src/Http/LambdaRequest.php
+++ b/src/Http/LambdaRequest.php
@@ -32,10 +32,8 @@ class LambdaRequest
     }
 
     /**
-     * TODO this class needs some more work
-     * Currently we only support GET request
-     *
      * @experimental
+     * There is currently no support for uploading files
      */
     public function getSymfonyRequest(): Request
     {
@@ -74,6 +72,9 @@ class LambdaRequest
         return $request;
     }
 
+    /**
+     * @experimental
+     */
     public function getPsr7Request(): RequestInterface
     {
         if (! class_exists(Request::class)) {

--- a/src/Http/LambdaResponse.php
+++ b/src/Http/LambdaResponse.php
@@ -15,7 +15,7 @@ final class LambdaResponse
     /** @var int */
     private $statusCode = 200;
 
-    /** @var array */
+    /** @var array<string, string> */
     private $headers;
 
     /** @var string */
@@ -33,7 +33,7 @@ final class LambdaResponse
         // The lambda proxy integration does not support arrays in headers
         $headers = [];
         foreach ($response->getHeaders() as $name => $values) {
-            $headers[strtolower($name)] = [implode($values, '; ')];
+            $headers[strtolower($name)] = implode($values, '; ');
         }
 
         $response->getBody()->rewind();
@@ -46,7 +46,7 @@ final class LambdaResponse
     {
         $headers = [];
         foreach ($response->headers->all() as $name => $values) {
-            $headers[strtolower($name)] = [implode($values, '; ')];
+            $headers[strtolower($name)] = implode($values, '; ');
         }
 
         $body = $response->getContent();

--- a/src/Http/LambdaResponse.php
+++ b/src/Http/LambdaResponse.php
@@ -28,22 +28,12 @@ final class LambdaResponse
         $this->body = $body;
     }
 
-    /**
-     * TODO make sure to test this. I think it is broken // Tobias
-     */
     public static function fromPsr7Response(ResponseInterface $response): self
     {
         // The lambda proxy integration does not support arrays in headers
         $headers = [];
         foreach ($response->getHeaders() as $name => $values) {
-            // See https://github.com/zendframework/zend-diactoros/blob/754a2ceb7ab753aafe6e3a70a1fb0370bde8995c/src/Response/SapiEmitterTrait.php#L96
-            $name = str_replace('-', ' ', $name);
-            $name = ucwords($name);
-            $name = str_replace(' ', '-', $name);
-            foreach ($values as $value) {
-                // TODO this will overwrite all but last header
-                $headers[$name] = $value;
-            }
+            $headers[strtolower($name)] = [implode($values, '; ')];
         }
 
         $response->getBody()->rewind();
@@ -56,7 +46,7 @@ final class LambdaResponse
     {
         $headers = [];
         foreach ($response->headers->all() as $name => $values) {
-            $headers[$name] = [implode($values, '; ')];
+            $headers[strtolower($name)] = [implode($values, '; ')];
         }
 
         $body = $response->getContent();

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -63,6 +63,7 @@ final class LambdaRuntime
             $this->handler = null;
         }
     }
+
     private function closeReturnHandler(): void
     {
         if ($this->returnHandler !== null) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -240,6 +240,7 @@ final class PhpFpm
         // Never seen this happen but just in case
         if (! file_exists(self::PID_FILE)) {
             unlink(self::SOCKET);
+
             return;
         }
 
@@ -250,6 +251,7 @@ final class PhpFpm
             echo "PHP-FPM's PID file contained an invalid PID, assuming PHP-FPM isn't running.\n";
             unlink(self::SOCKET);
             unlink(self::PID_FILE);
+
             return;
         }
 
@@ -258,6 +260,7 @@ final class PhpFpm
             // PHP-FPM is not running anymore, we can cleanup
             unlink(self::SOCKET);
             unlink(self::PID_FILE);
+
             return;
         }
 
@@ -269,6 +272,7 @@ final class PhpFpm
             echo "PHP-FPM's PID file contained a PID that doesn't exist, assuming PHP-FPM isn't running.\n";
             unlink(self::SOCKET);
             unlink(self::PID_FILE);
+
             return;
         }
 
@@ -308,6 +312,7 @@ final class PhpFpm
             foreach ($event['multiValueQueryStringParameters'] as $key => $value) {
                 $queryParameters[$key] = $value[0];
             }
+
             return http_build_query($queryParameters);
         }
 

--- a/tests/Fixture/Http/lambdaRequest0.json
+++ b/tests/Fixture/Http/lambdaRequest0.json
@@ -1,0 +1,133 @@
+{
+  "resource": "/hello-world",
+  "path": "/hello-world",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.9,sv;q=0.8,la;q=0.7",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "SE",
+    "Cookie": "PHPSESSID=7tk4oc6dsa6e4chai4sljcffha",
+    "Host": "abc123.execute-api.eu-west-1.amazonaws.com",
+    "sec-fetch-mode": "navigate",
+    "sec-fetch-site": "none",
+    "sec-fetch-user": "?1",
+    "upgrade-insecure-requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36",
+    "Via": "2.0 0123456789.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "uT34zMm8aYW-q3RC_Z6_NMYu5kQxoxpMJOPfJy-Vd1hqjp9ak5VxLg==",
+    "X-Amzn-Trace-Id": "Root=1-5d7e228c-2e1603a0d1c5aec07d8e1eb0",
+    "X-Forwarded-For": "22.22.22.22, 11.11.11.11",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3"
+    ],
+    "Accept-Encoding": [
+      "gzip, deflate, br"
+    ],
+    "Accept-Language": [
+      "en-US,en;q=0.9,sv;q=0.8,la;q=0.7"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-Country": [
+      "SE"
+    ],
+    "Cookie": [
+      "PHPSESSID=7tk4oc6dsa6e4chai4sljcffha"
+    ],
+    "Host": [
+      "abc123.execute-api.eu-west-1.amazonaws.com"
+    ],
+    "sec-fetch-mode": [
+      "navigate"
+    ],
+    "sec-fetch-site": [
+      "none"
+    ],
+    "sec-fetch-user": [
+      "?1"
+    ],
+    "upgrade-insecure-requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36"
+    ],
+    "Via": [
+      "2.0 0123456789.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "uT34zMm8aYW-q3RC_Z6_NMYu5kQxoxpMJOPfJy-Vd1hqjp9ak5VxLg=="
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-5d7e228c-2e1603a0d1c5aec07d8e1eb0"
+    ],
+    "X-Forwarded-For": [
+      "22.22.22.22, 11.11.11.11"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "queryStringParameters": null,
+  "multiValueQueryStringParameters": null,
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "4obcbv",
+    "resourcePath": "/hello-world",
+    "httpMethod": "GET",
+    "extendedRequestId": "ADpV7F21DoEFcug=",
+    "requestTime": "15/Sep/2019:11:37:48 +0000",
+    "path": "/dev/hello-world",
+    "accountId": "863577320427",
+    "protocol": "HTTP/1.1",
+    "stage": "dev",
+    "domainPrefix": "abc123",
+    "requestTimeEpoch": 1568547468262,
+    "requestId": "be0d2f51-722d-4ee2-8258-3fcaa6907815",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "22.22.22.22",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36",
+      "user": null
+    },
+    "domainName": "abc123.execute-api.eu-west-1.amazonaws.com",
+    "apiId": "abc123"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/tests/Fixture/Http/lambdaRequest1.json
+++ b/tests/Fixture/Http/lambdaRequest1.json
@@ -1,0 +1,68 @@
+{
+  "resource": "/multipart-post",
+  "path": "/multipart-post",
+  "httpMethod": "POST",
+  "headers": {
+    "Content-Type": "multipart/form-data; boundary=\"578de3b0e3c46.2334ba3\"",
+    "Host": "example.com"
+  },
+  "multiValueHeaders": {
+    "Content-Type": [
+      "multipart/form-data; boundary=\"578de3b0e3c46.2334ba3\""
+    ],
+    "Host": [
+      "example.com"
+    ]
+  },
+  "queryStringParameters": {
+    "foo[]": "baz",
+    "foobar": "baz",
+    "test": ""
+  },
+  "multiValueQueryStringParameters": {
+    "foo[]": [
+      "bar",
+      "baz"
+    ],
+    "foobar": [
+      "baz"
+    ],
+    "test": [
+      ""
+    ]
+  },
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "4obcbv",
+    "resourcePath": "/multipart-post",
+    "httpMethod": "POST",
+    "extendedRequestId": "AEPPLH2RjoEF-zg=",
+    "requestTime": "15/Sep/2019:15:56:29 +0000",
+    "path": "/dev/multipart-post",
+    "accountId": "863577320427",
+    "protocol": "HTTP/1.1",
+    "stage": "dev",
+    "domainPrefix": "mwmkks635j",
+    "requestTimeEpoch": 1568562989871,
+    "requestId": "ae163dd5-3df3-43c8-9120-d83b1f1dfca5",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "22.22.22.22",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "PostmanRuntime/7.15.2",
+      "user": null
+    },
+    "domainName": "abc123.execute-api.eu-west-1.amazonaws.com",
+    "apiId": "mwmkks635j"
+  },
+  "body": "--578de3b0e3c46.2334ba3\nContent-Disposition: form-data; name=\"foo\"\nContent-Length: 15\n\nA normal stream\n--578de3b0e3c46.2334ba3\nContent-Type: text/plain\nContent-Disposition: form-data; name=\"baz\"\nContent-Length: 6\n\nstring\n--578de3b0e3c46.2334ba3--",
+  "isBase64Encoded": false
+}

--- a/tests/Http/LambdaRequestTest.php
+++ b/tests/Http/LambdaRequestTest.php
@@ -69,8 +69,27 @@ class LambdaRequestTest extends TestCase
 
         $request = SfRequest::create('/hello-world', 'GET', [], ['PHPSESSID' => '7tk4oc6dsa6e4chai4sljcffha'], [], [], '');
         $request->headers->add($this->getDefaultHeaders());
-
         yield 'lambdaRequest0.json' => [$dir . 'lambdaRequest0.json', $request];
+
+        $request = SfRequest::create('/multipart-post', 'POST', [], [], [], [], '--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="foo"
+Content-Length: 15
+
+A normal stream
+--578de3b0e3c46.2334ba3
+Content-Type: text/plain
+Content-Disposition: form-data; name="baz"
+Content-Length: 6
+
+string
+--578de3b0e3c46.2334ba3--');
+
+        $request->headers->add([
+            "Content-Type"=> "multipart/form-data; boundary=\"578de3b0e3c46.2334ba3\"",
+            "Host"=> "example.com"
+        ]);
+
+        yield 'lambdaRequest1.json' => [$dir . 'lambdaRequest1.json', $request];
     }
 
     public function psr7RequestProvider()

--- a/tests/Http/LambdaRequestTest.php
+++ b/tests/Http/LambdaRequestTest.php
@@ -89,6 +89,36 @@ class LambdaRequestTest extends TestCase
         $request = $request->withCookieParams(['PHPSESSID' => '7tk4oc6dsa6e4chai4sljcffha']);
 
         yield 'lambdaRequest0.json' => [$dir . 'lambdaRequest0.json', $request];
+
+        $request = new Psr7Request('POST', '/multipart-post', [
+            "Content-Type"=> "multipart/form-data; boundary=\"578de3b0e3c46.2334ba3\"",
+            "Host"=> "example.com"
+        ],
+            $this->createStream('--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="foo"
+Content-Length: 15
+
+A normal stream
+--578de3b0e3c46.2334ba3
+Content-Type: text/plain
+Content-Disposition: form-data; name="baz"
+Content-Length: 6
+
+string
+--578de3b0e3c46.2334ba3--'),
+            '1.1',
+            [
+                'SERVER_PROTOCOL' => '1.1',
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_TIME' => 1568562989871,
+                'QUERY_STRING' => 'foo[]=bar&foo[]=baz&foobar=baz&test',
+                'DOCUMENT_ROOT' => getcwd(),
+                'REQUEST_URI' => '/multipart-post',
+                'HTTP_HOST' => 'example.com',
+        ]);
+        $request = $request->withParsedBody(['foo'=>'A normal stream', 'baz'=>'string']);
+        $request = $request->withQueryParams(['foo'=>['bar','baz'], 'foobar'=>'baz', 'test'=>'']);
+        yield 'lambdaRequest1.json' => [$dir . 'lambdaRequest1.json', $request];
     }
 
     private function getRequestFromJsonFile(string $file): LambdaRequest

--- a/tests/Http/LambdaRequestTest.php
+++ b/tests/Http/LambdaRequestTest.php
@@ -85,8 +85,8 @@ string
 --578de3b0e3c46.2334ba3--');
 
         $request->headers->add([
-            "Content-Type"=> "multipart/form-data; boundary=\"578de3b0e3c46.2334ba3\"",
-            "Host"=> "example.com"
+            'Content-Type'=> 'multipart/form-data; boundary="578de3b0e3c46.2334ba3"',
+            'Host'=> 'example.com',
         ]);
 
         yield 'lambdaRequest1.json' => [$dir . 'lambdaRequest1.json', $request];
@@ -109,10 +109,13 @@ string
 
         yield 'lambdaRequest0.json' => [$dir . 'lambdaRequest0.json', $request];
 
-        $request = new Psr7Request('POST', '/multipart-post', [
-            "Content-Type"=> "multipart/form-data; boundary=\"578de3b0e3c46.2334ba3\"",
-            "Host"=> "example.com"
-        ],
+        $request = new Psr7Request(
+            'POST',
+            '/multipart-post',
+            [
+                'Content-Type'=> 'multipart/form-data; boundary="578de3b0e3c46.2334ba3"',
+                'Host'=> 'example.com',
+            ],
             $this->createStream('--578de3b0e3c46.2334ba3
 Content-Disposition: form-data; name="foo"
 Content-Length: 15
@@ -134,9 +137,10 @@ string
                 'DOCUMENT_ROOT' => getcwd(),
                 'REQUEST_URI' => '/multipart-post',
                 'HTTP_HOST' => 'example.com',
-        ]);
-        $request = $request->withParsedBody(['foo'=>'A normal stream', 'baz'=>'string']);
-        $request = $request->withQueryParams(['foo'=>['bar','baz'], 'foobar'=>'baz', 'test'=>'']);
+            ]
+        );
+        $request = $request->withParsedBody(['foo' => 'A normal stream', 'baz' => 'string']);
+        $request = $request->withQueryParams(['foo' => ['bar', 'baz'], 'foobar' => 'baz', 'test' => '']);
         yield 'lambdaRequest1.json' => [$dir . 'lambdaRequest1.json', $request];
     }
 

--- a/tests/Http/LambdaRequestTest.php
+++ b/tests/Http/LambdaRequestTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bref\Test\Http;
+
+use Bref\Http\LambdaRequest;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\HttpFoundation\Request as SfRequest;
+
+class LambdaRequestTest extends TestCase
+{
+    /**
+     * This make sure we always pass the raw response
+     * @dataProvider rawEventProvider
+     */
+    public function testGetRawEvent(string $file, array $expected)
+    {
+        $request = $this->getRequestFromJsonFile($file);
+
+        $this->assertEquals($expected, $request->getRawEvent());
+    }
+
+    /**
+     * @dataProvider symfonyRequestProvider
+     */
+    public function testGetSymfonyEvent(string $file, SfRequest $expected)
+    {
+        $request = $this->getRequestFromJsonFile($file);
+
+        $this->assertEquals($expected, $request->getSymfonyRequest());
+    }
+
+    /**
+     * @dataProvider psr7RequestProvider
+     */
+    public function testGetPsr7Event(string $file, RequestInterface $expected)
+    {
+        $request = $this->getRequestFromJsonFile($file);
+
+        $this->assertEquals($expected, $request->getPsr7Request());
+    }
+
+
+    /**
+     * This will automatically find all lambdaRequest*.json files in the fixture folder.
+     */
+    public function rawEventProvider()
+    {
+        $dir = dirname(__DIR__) . '/Fixture/Http/';
+        foreach (glob($dir.'lambdaRequest*.json') as $path) {
+            yield basename($path) => [$path, json_decode(file_get_contents($path), true)];
+        }
+    }
+
+    public function symfonyRequestProvider()
+    {
+
+    }
+    public function psr7RequestProvider()
+    {
+
+    }
+
+    private function getRequestFromJsonFile(string $file): LambdaRequest
+    {
+        $array = json_decode(file_get_contents($file), true);
+
+        return LambdaRequest::create($array);
+    }
+}

--- a/tests/Http/LambdaRequestTest.php
+++ b/tests/Http/LambdaRequestTest.php
@@ -71,7 +71,7 @@ class LambdaRequestTest extends TestCase
         $request->headers->add($this->getDefaultHeaders());
         yield 'lambdaRequest0.json' => [$dir . 'lambdaRequest0.json', $request];
 
-        $request = SfRequest::create('/multipart-post', 'POST', [], [], [], [], '--578de3b0e3c46.2334ba3
+        $request = SfRequest::create('/multipart-post?foo[]=bar&foo[]=baz&foobar=baz&test', 'POST', [], [], [], [], '--578de3b0e3c46.2334ba3
 Content-Disposition: form-data; name="foo"
 Content-Length: 15
 

--- a/tests/Http/LambdaRequestTest.php
+++ b/tests/Http/LambdaRequestTest.php
@@ -57,11 +57,23 @@ class LambdaRequestTest extends TestCase
 
     public function symfonyRequestProvider()
     {
+        $dir = dirname(__DIR__) . '/Fixture/Http/';
+
+        yield 'lambdaRequest0.json' => [
+            $dir.'lambdaRequest0.json',
+            SfRequest::create('/hello-world', 'GET')
+        ];
 
     }
+
     public function psr7RequestProvider()
     {
+        $dir = dirname(__DIR__) . '/Fixture/Http/';
 
+        yield 'lambdaRequest0.json' => [
+            $dir.'lambdaRequest0.json',
+            new Psr7Request('GET', '/hello-world')
+        ];
     }
 
     private function getRequestFromJsonFile(string $file): LambdaRequest

--- a/tests/Http/LambdaRequestTest.php
+++ b/tests/Http/LambdaRequestTest.php
@@ -1,19 +1,21 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Bref\Test\Http;
 
 use Bref\Http\LambdaRequest;
+use GuzzleHttp\Psr7\ServerRequest as Psr7Request;
+use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Psr7\Request as Psr7Request;
-use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Symfony\Component\HttpFoundation\Request as SfRequest;
+use function GuzzleHttp\Psr7\stream_for;
 
 class LambdaRequestTest extends TestCase
 {
     /**
      * This make sure we always pass the raw response
+     *
      * @dataProvider rawEventProvider
      */
     public function testGetRawEvent(string $file, array $expected)
@@ -30,19 +32,25 @@ class LambdaRequestTest extends TestCase
     {
         $request = $this->getRequestFromJsonFile($file);
 
-        $this->assertEquals($expected, $request->getSymfonyRequest());
+        $output = $request->getSymfonyRequest();
+        $this->assertEquals($expected, $output);
     }
 
     /**
      * @dataProvider psr7RequestProvider
      */
-    public function testGetPsr7Event(string $file, RequestInterface $expected)
+    public function testGetPsr7Event(string $file, ServerRequestInterface $expected)
     {
         $request = $this->getRequestFromJsonFile($file);
+        $psr7Request = $request->getPsr7Request();
 
-        $this->assertEquals($expected, $request->getPsr7Request());
+        // Compare request but not bodies
+        $dummyStream = stream_for('');
+        $this->assertEquals($expected->withBody($dummyStream), $psr7Request->withBody($dummyStream));
+
+        // Compare bodies
+        $this->assertEquals($expected->getBody()->__toString(), $psr7Request->getBody()->__toString());
     }
-
 
     /**
      * This will automatically find all lambdaRequest*.json files in the fixture folder.
@@ -50,7 +58,7 @@ class LambdaRequestTest extends TestCase
     public function rawEventProvider()
     {
         $dir = dirname(__DIR__) . '/Fixture/Http/';
-        foreach (glob($dir.'lambdaRequest*.json') as $path) {
+        foreach (glob($dir . 'lambdaRequest*.json') as $path) {
             yield basename($path) => [$path, json_decode(file_get_contents($path), true)];
         }
     }
@@ -59,21 +67,28 @@ class LambdaRequestTest extends TestCase
     {
         $dir = dirname(__DIR__) . '/Fixture/Http/';
 
-        yield 'lambdaRequest0.json' => [
-            $dir.'lambdaRequest0.json',
-            SfRequest::create('/hello-world', 'GET')
-        ];
+        $request = SfRequest::create('/hello-world', 'GET', [], ['PHPSESSID' => '7tk4oc6dsa6e4chai4sljcffha'], [], [], '');
+        $request->headers->add($this->getDefaultHeaders());
 
+        yield 'lambdaRequest0.json' => [$dir . 'lambdaRequest0.json', $request];
     }
 
     public function psr7RequestProvider()
     {
         $dir = dirname(__DIR__) . '/Fixture/Http/';
 
-        yield 'lambdaRequest0.json' => [
-            $dir.'lambdaRequest0.json',
-            new Psr7Request('GET', '/hello-world')
-        ];
+        $request = new Psr7Request('GET', '/hello-world', $this->getDefaultHeaders(), $this->createStream(''), '1.1', [
+            'SERVER_PROTOCOL' => '1.1',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_TIME' => 1568547468262,
+            'QUERY_STRING' => '',
+            'DOCUMENT_ROOT' => getcwd(),
+            'REQUEST_URI' => '/hello-world',
+            'HTTP_HOST' => 'abc123.execute-api.eu-west-1.amazonaws.com',
+        ]);
+        $request = $request->withCookieParams(['PHPSESSID' => '7tk4oc6dsa6e4chai4sljcffha']);
+
+        yield 'lambdaRequest0.json' => [$dir . 'lambdaRequest0.json', $request];
     }
 
     private function getRequestFromJsonFile(string $file): LambdaRequest
@@ -81,5 +96,42 @@ class LambdaRequestTest extends TestCase
         $array = json_decode(file_get_contents($file), true);
 
         return LambdaRequest::create($array);
+    }
+
+    private function getDefaultHeaders()
+    {
+        return [
+            'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3',
+            'Accept-Encoding' => 'gzip, deflate, br',
+            'Accept-Language' => 'en-US,en;q=0.9,sv;q=0.8,la;q=0.7',
+            'CloudFront-Forwarded-Proto' => 'https',
+            'CloudFront-Is-Desktop-Viewer' => 'true',
+            'CloudFront-Is-Mobile-Viewer' => 'false',
+            'CloudFront-Is-SmartTV-Viewer' => 'false',
+            'CloudFront-Is-Tablet-Viewer' => 'false',
+            'CloudFront-Viewer-Country' => 'SE',
+            'Cookie' => 'PHPSESSID=7tk4oc6dsa6e4chai4sljcffha',
+            'Host' => 'abc123.execute-api.eu-west-1.amazonaws.com',
+            'sec-fetch-mode' => 'navigate',
+            'sec-fetch-site' => 'none',
+            'sec-fetch-user' => '?1',
+            'upgrade-insecure-requests' => '1',
+            'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.75 Safari/537.36',
+            'Via' => '2.0 0123456789.cloudfront.net (CloudFront)',
+            'X-Amz-Cf-Id' => 'uT34zMm8aYW-q3RC_Z6_NMYu5kQxoxpMJOPfJy-Vd1hqjp9ak5VxLg==',
+            'X-Amzn-Trace-Id' => 'Root=1-5d7e228c-2e1603a0d1c5aec07d8e1eb0',
+            'X-Forwarded-For' => '22.22.22.22, 11.11.11.11',
+            'X-Forwarded-Port' => '443',
+            'X-Forwarded-Proto' => 'https',
+        ];
+    }
+
+    private function createStream(string $body): StreamInterface
+    {
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $body);
+        rewind($stream);
+
+        return new Stream($stream);
     }
 }

--- a/tests/Http/LambdaResponseTest.php
+++ b/tests/Http/LambdaResponseTest.php
@@ -3,9 +3,11 @@
 namespace Bref\Test\Http;
 
 use Bref\Http\LambdaResponse;
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Symfony\Component\HttpFoundation\Response as SfResponse;
 use PHPUnit\Framework\TestCase;
-use Zend\Diactoros\Response\EmptyResponse;
-use Zend\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class LambdaResponseTest extends TestCase
 {
@@ -22,38 +24,77 @@ class LambdaResponseTest extends TestCase
         ], $response->toApiGatewayFormat());
     }
 
-    public function test I can create a response from a PSR7 response()
+    /**
+     * @dataProvider Psr7Provider
+     */
+    public function testFromPsr7Response(ResponseInterface $psr7Response, array $output)
     {
-        $psr7Response = new JsonResponse(['foo' => 'bar'], 404);
-
         $response = LambdaResponse::fromPsr7Response($psr7Response);
-        self::assertSame([
-            'isBase64Encoded' => false,
-            'statusCode' => 404,
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
-            'body' => json_encode(['foo' => 'bar']),
-        ], $response->toApiGatewayFormat());
+        self::assertSame($output, $response->toApiGatewayFormat());
     }
 
-    public function test nested arrays in headers are flattened()
+    public function psr7Provider()
     {
-        $psr7Response = new EmptyResponse;
-        $psr7Response = $psr7Response->withHeader('foo', ['bar', 'baz']);
-
-        $response = LambdaResponse::fromPsr7Response($psr7Response);
-        self::assertSame([
-            'isBase64Encoded' => false,
-            'statusCode' => 204,
-            'headers' => ['Foo' => 'baz'],
-            'body' => '',
-        ], $response->toApiGatewayFormat());
+        yield 'It can convert PSR7 request' => [
+            new Psr7Response(404, ['Content-Type' => 'application/json'], json_encode(['foo' => 'bar'])),
+            [
+                'isBase64Encoded' => false,
+                'statusCode' => 404,
+                'headers' => [
+                    'content-type' => 'application/json',
+                ],
+                'body' => json_encode(['foo' => 'bar']),
+            ]
+        ];
+        yield 'Nested arrays in headers are flattened' => [
+            new Psr7Response(204, ['Foo' => ['Bar', 'baz']]),
+            [
+                'isBase64Encoded' => false,
+                'statusCode' => 204,
+                'headers' => ['foo' => 'Bar; baz'],
+                'body' => '',
+            ]
+        ];
     }
+
+
+    /**
+     * @dataProvider symfonyProvider
+     */
+    public function testFromSymfonyResponse(SfResponse $sfResponse, array $output)
+    {
+        $response = LambdaResponse::fromSymfonyResponse($sfResponse);
+        self::assertSame($output, $response->toApiGatewayFormat());
+    }
+
+    public function symfonyProvider()
+    {
+        yield 'It can convert PSR7 request' => [
+            SfResponse::create(json_encode(['Foo' => 'bar']), 404, ['Content-Type' => 'application/json',]),
+            [
+                'isBase64Encoded' => false,
+                'statusCode' => 404,
+                'headers' => [
+                    'content-type' => 'application/json',
+                ],
+                'body' => json_encode(['foo' => 'bar']),
+            ]
+        ];
+        yield 'Nested arrays in headers are flattened' => [
+            SfResponse::create('', 204, ['Foo' => ['Bar', 'baz']]),
+            [
+                'isBase64Encoded' => false,
+                'statusCode' => 204,
+                'headers' => ['foo' => 'Bar; baz'],
+                'body' => '',
+            ]
+        ];
+    }
+
 
     public function test empty headers are considered objects()
     {
-        $response = LambdaResponse::fromPsr7Response(new EmptyResponse);
+        $response = LambdaResponse::fromPsr7Response(new Psr7Response());
 
         // Make sure that the headers are `"headers":{}` (object) and not `"headers":[]` (array)
         self::assertEquals('{"isBase64Encoded":false,"statusCode":204,"headers":{},"body":""}', json_encode($response->toApiGatewayFormat()));

--- a/tests/Http/LambdaResponseTest.php
+++ b/tests/Http/LambdaResponseTest.php
@@ -79,7 +79,7 @@ class LambdaResponseTest extends TestCase
                 'isBase64Encoded' => false,
                 'statusCode' => 404,
                 'headers' => [
-                    'content-type' => 'application/json'
+                    'content-type' => 'application/json',
                 ],
                 'body' => json_encode(['Foo' => 'bar']),
             ],

--- a/tests/Http/LambdaResponseTest.php
+++ b/tests/Http/LambdaResponseTest.php
@@ -4,10 +4,9 @@ namespace Bref\Test\Http;
 
 use Bref\Http\LambdaResponse;
 use GuzzleHttp\Psr7\Response as Psr7Response;
-use Symfony\Component\HttpFoundation\Response as SfResponse;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Symfony\Component\HttpFoundation\Response as SfResponse;
 
 class LambdaResponseTest extends TestCase
 {
@@ -44,7 +43,7 @@ class LambdaResponseTest extends TestCase
                     'content-type' => 'application/json',
                 ],
                 'body' => json_encode(['foo' => 'bar']),
-            ]
+            ],
         ];
         yield 'Nested arrays in headers are flattened' => [
             new Psr7Response(204, ['Foo' => ['Bar', 'baz']]),
@@ -53,10 +52,9 @@ class LambdaResponseTest extends TestCase
                 'statusCode' => 204,
                 'headers' => ['foo' => 'Bar; baz'],
                 'body' => '',
-            ]
+            ],
         ];
     }
-
 
     /**
      * @dataProvider symfonyProvider
@@ -70,7 +68,7 @@ class LambdaResponseTest extends TestCase
     public function symfonyProvider()
     {
         yield 'It can convert PSR7 request' => [
-            SfResponse::create(json_encode(['Foo' => 'bar']), 404, ['Content-Type' => 'application/json',]),
+            SfResponse::create(json_encode(['Foo' => 'bar']), 404, ['Content-Type' => 'application/json']),
             [
                 'isBase64Encoded' => false,
                 'statusCode' => 404,
@@ -78,7 +76,7 @@ class LambdaResponseTest extends TestCase
                     'content-type' => 'application/json',
                 ],
                 'body' => json_encode(['foo' => 'bar']),
-            ]
+            ],
         ];
         yield 'Nested arrays in headers are flattened' => [
             SfResponse::create('', 204, ['Foo' => ['Bar', 'baz']]),
@@ -87,14 +85,13 @@ class LambdaResponseTest extends TestCase
                 'statusCode' => 204,
                 'headers' => ['foo' => 'Bar; baz'],
                 'body' => '',
-            ]
+            ],
         ];
     }
 
-
     public function test empty headers are considered objects()
     {
-        $response = LambdaResponse::fromPsr7Response(new Psr7Response());
+        $response = LambdaResponse::fromPsr7Response(new Psr7Response);
 
         // Make sure that the headers are `"headers":{}` (object) and not `"headers":[]` (array)
         self::assertEquals('{"isBase64Encoded":false,"statusCode":204,"headers":{},"body":""}', json_encode($response->toApiGatewayFormat()));

--- a/tests/Runtime/PhpFpm/request.php
+++ b/tests/Runtime/PhpFpm/request.php
@@ -11,6 +11,7 @@ echo json_encode([
         // Delete the file and remove the random name as we can't assert that in the tests
         unlink($file['tmp_name']);
         unset($file['tmp_name']);
+
         return $file;
     }, $_FILES),
     '$_COOKIE' => $_COOKIE,

--- a/tests/Sam/PhpFpm/index.php
+++ b/tests/Sam/PhpFpm/index.php
@@ -3,12 +3,14 @@
 if ($_GET['extensions'] ?? false) {
     header('Content-Type: application/json');
     echo json_encode(get_loaded_extensions(), JSON_PRETTY_PRINT);
+
     return;
 }
 
 if ($_GET['php-config'] ?? false) {
     header('Content-Type: application/json');
     echo json_encode(ini_get_all(null, false), JSON_PRETTY_PRINT);
+
     return;
 }
 
@@ -19,6 +21,7 @@ if ($_GET['env'] ?? false) {
         '$_SERVER' => $_SERVER['FOO'] ?? null,
         'getenv' => getenv('FOO'),
     ], JSON_PRETTY_PRINT);
+
     return;
 }
 

--- a/tests/Server.php
+++ b/tests/Server.php
@@ -109,6 +109,7 @@ class Server
         }
         $response = self::getClient()->request('GET', 'guzzle-server/requests');
         $data = json_decode((string) $response->getBody(), true);
+
         return array_map(
             function ($message) {
                 $uri = $message['uri'];
@@ -122,6 +123,7 @@ class Server
                     $message['body'],
                     $message['version']
                 );
+
                 return $response->withUri(
                     $response->getUri()
                         ->withScheme('http')
@@ -174,6 +176,7 @@ class Server
                 'connect_timeout' => 5,
                 'timeout'         => 5,
             ]);
+
             return true;
         } catch (\Throwable $e) {
             return false;
@@ -188,6 +191,7 @@ class Server
                 'sync'     => true,
             ]);
         }
+
         return self::$client;
     }
 }


### PR DESCRIPTION
So, the other day I got an idea. What if we removed PHP FPM that must be way quicker, right? To only have a PHP script that keeps the Lambda alive and listens to new requests. Very much inspired by https://github.com/PHPFastCGI/FastCGIDaemon.

I started to do some tests and this is what I've come up with. This PR is working but incomplete. 

------------

I've got 3 scenarios:
- One baseline running **PHP-FPM** in a normal way. 
- One were I load my application every time a new request comes in. I call this **HTTP Function**. See example [handler](https://github.com/Nyholm/small-symfony-project/blob/master/public/lambda.php).
- One were I keep my application in memory between request. I call this **Keep Alive**. This require a new runtime layer (in this PR). See example [handler](https://github.com/Nyholm/small-symfony-project/blob/master/public/lambda_keep_alive.php). This will of course suffer from potential memory leaks. 


Running my [Small Symfony project controller](https://github.com/Nyholm/small-symfony-project/blob/master/src/Controller/HelloController.php) I get the following results. I was about to be super scientific with 10x10 repetitive runs on each scenario but it was quite easy to see a pattern after just a few runs.


  | First request | Average (10 reqs.) | Memory
-- | -- | -- | --
PHP-FPM | 1719 ms | 8 ms  | 133 mb
HTTP Function | 1890 ms | 70 ms | 133 mb
Keep alive | 1861 ms | 5 ms | 133 mb

So, no real difference in memory.
Keep Alive is faster on the average run. It will be even faster compared to PHP-FPM on a larger application. 

I cannot figure out why my first request is slower on Keep Alive. I was just it would be a little quicker since we don't have to boot PHP-FPM. 

---------

Is the Keep Alive layer interesting to keep working with?

