### PR TITLE
Handle binary responses (encode body)

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -244,7 +244,7 @@ final class LambdaRuntime
     private function postJson(string $url, $data): void
     {
         $contentType = $data['multiValueHeaders']['content-type'][0] ?? null;
-        if ($contentType && ($contentType === 'application/json' || substr($contentType, 0, 4) !== 'text')) {
+        if ($contentType && ($contentType !== 'application/json' && substr($contentType, 0, 4) !== 'text')) {
             $data['body'] = base64_encode($data['body']);
             $data['isBase64Encoded'] = true;
         }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -243,6 +243,12 @@ final class LambdaRuntime
      */
     private function postJson(string $url, $data): void
     {
+        $contentType = $data['multiValueHeaders']['content-type'][0] ?? null;
+        if($contentType && substr($contentType, 0, 4) !== 'text') {
+            $data['body'] = base64_encode($data['body']);
+            $data['isBase64Encoded'] = true;
+        }
+
         $jsonData = json_encode($data);
         if ($jsonData === false) {
             throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -244,7 +244,7 @@ final class LambdaRuntime
     private function postJson(string $url, $data): void
     {
         $contentType = $data['multiValueHeaders']['content-type'][0] ?? null;
-        if ($contentType && substr($contentType, 0, 4) !== 'text') {
+        if ($contentType && ($contentType === 'application/json' || substr($contentType, 0, 4) !== 'text')) {
             $data['body'] = base64_encode($data['body']);
             $data['isBase64Encoded'] = true;
         }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -244,7 +244,7 @@ final class LambdaRuntime
     private function postJson(string $url, $data): void
     {
         $contentType = $data['multiValueHeaders']['content-type'][0] ?? null;
-        if($contentType && substr($contentType, 0, 4) !== 'text') {
+        if ($contentType && substr($contentType, 0, 4) !== 'text') {
             $data['body'] = base64_encode($data['body']);
             $data['isBase64Encoded'] = true;
         }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -244,7 +244,7 @@ final class LambdaRuntime
     private function postJson(string $url, $data): void
     {
         $contentType = $data['multiValueHeaders']['content-type'][0] ?? null;
-        if ($contentType && ($contentType !== 'application/json' && substr($contentType, 0, 4) !== 'text')) {
+        if ($contentType && $contentType !== 'application/json' && substr($contentType, 0, 4) !== 'text') {
             $data['body'] = base64_encode($data['body']);
             $data['isBase64Encoded'] = true;
         }


### PR DESCRIPTION
I've added this in to allow PDF and Excel documents to be outputted by a lambda function (via the API Gateway), as a http response. (They can already be generated internally and saved/emailed ... just not output as the http response).

Previously a lambda error would occur (from memory this was shown as a JSON error "Internal server error" (or something similar) - it's detailed more in #288.
In summary this was because Bref could not encode binary data as JSON for the response to the lambda invocation endpoint.

I've implemented this by looking at the content-type included in the response, and base64 encoding any non-text response - content types of text/* ... (internally it just checks that the content-type header starts with 'text'.
I had a bit of a shortage of time so wasn't able to get the unit-tests running (I don't have the php-fpm executable installed), but hopefully this shouldn't cause any issues.

No changes to the PHP applications are required (after updating the bref package to include this change), apart from configuring API Gateway to allow Binary responses for the certain content-types which are needed ... '*/*' can also be used to allow everything. At the time of testing I used */* as API Gateway was being difficult with having specific content-types entered ... I have a feeling the 'Accept' header (with the content-type you're requesting) needs to be included if you don't use a wildcard content-type).

The serverless (framework) plugin provides an easy way of setting this;
https://github.com/maciejtreder/serverless-apigw-binary

The approach of using the 'text/*' content-type was borrowed from the laravel-bref-bridge (was mentioned in #288;
https://github.com/stechstudio/laravel-bref-bridge/blob/9b4762f09cd6a8384fb6273506d04ee903d0bbec/src/Services/Bootstrap.php#L266-L278