### PR TITLE
Fix #461 Build the fpm-dev images from the lambci images

### DIFF
--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -9,4 +9,6 @@ FROM lambci/lambda:provided
 COPY --from=0  /opt /opt
 
 EXPOSE 9000
+# Clear the parent entrypoint
+ENTRYPOINT []
 CMD /opt/bin/php-fpm --nodaemonize --fpm-config /opt/bref/etc/php-fpm.conf

--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -2,5 +2,11 @@ ARG LAYER_IMAGE
 FROM $LAYER_IMAGE
 
 COPY ./php-fpm.conf /opt/bref/etc/php-fpm.conf
+
+# Build the final image from the lambci image that is close to the production environment
+FROM lambci/lambda:provided
+
+COPY --from=0  /opt /opt
+
 EXPOSE 9000
 CMD /opt/bin/php-fpm --nodaemonize --fpm-config /opt/bref/etc/php-fpm.conf


### PR DESCRIPTION
It seems the AmazonLinux images do not have exactly the same libraries as the actual Lambda instances.

We build all docker images from `lambci/lambda` (which is supposed to contain everything) but we didn't build `fpm-dev` from that image as well.

This fixes the inconsistency, which should fix #461.