### PR TITLE
Fix php-7*-fpm-dev images that were missing php.ini

### DIFF
--- a/demo/http.php
+++ b/demo/http.php
@@ -25,4 +25,9 @@ if (isset($_GET['weird'])) {
     exit(0);
 }
 
+if (isset($_GET['phpinfo'])) {
+    phpinfo();
+    exit(0);
+}
+
 echo 'Hello world!';

--- a/demo/http.php
+++ b/demo/http.php
@@ -30,4 +30,10 @@ if (isset($_GET['phpinfo'])) {
     exit(0);
 }
 
+if (isset($_GET['tmp'])) {
+    file_put_contents('/tmp/test.txt', 'hello');
+    echo file_get_contents('/tmp/test.txt');
+    exit(0);
+}
+
 echo 'Hello world!';

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -30,10 +30,10 @@ compiler: compiler.Dockerfile
 build: compiler
 	docker build -f ${PWD}/php-intermediary.Dockerfile -t bref/php-72-intermediary:latest $(shell helpers/docker_args.sh versions.ini php72) .
 	cd layers/fpm ; docker build -t bref/php-72-fpm:$(TAG) --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
-	cd layers/fpm-dev ; docker build -t bref/php-72-fpm-dev:$(TAG) --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
+	cd layers/fpm-dev ; docker build -t bref/php-72-fpm-dev:$(TAG) --build-arg LAYER_IMAGE=bref/php-72-fpm:$(TAG) . ; cd ../..
 	cd layers/function ; docker build -t bref/php-72:$(TAG) --build-arg LAYER_IMAGE=bref/php-72-intermediary:latest . ; cd ../..
 	docker build -f ${PWD}/php-intermediary.Dockerfile -t bref/php-73-intermediary:latest $(shell helpers/docker_args.sh versions.ini php73) .
 	cd layers/fpm ; docker build -t bref/php-73-fpm:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
-	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
+	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-fpm:$(TAG) . ; cd ../..
 	cd layers/function ; docker build -t bref/php-73:$(TAG) --build-arg LAYER_IMAGE=bref/php-73-intermediary:latest . ; cd ../..
 	cd layers/web; docker build -t bref/fpm-dev-gateway:$(TAG) . ; cd ../..

--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -1,14 +1,14 @@
 ARG LAYER_IMAGE
 FROM $LAYER_IMAGE
 
-COPY ./php-fpm.conf /opt/bref/etc/php-fpm.conf
-
-# Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
-
-COPY --from=0  /opt /opt
+# Override the config so that PHP-FPM listens on port 9000
+COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
 
 EXPOSE 9000
+
 # Clear the parent entrypoint
 ENTRYPOINT []
-CMD /opt/bin/php-fpm --nodaemonize --fpm-config /opt/bref/etc/php-fpm.conf
+
+# Run PHP-FPM
+# opcache.validate_timestamps=1 : cancels the flag in the base configuration so that files are reloaded
+CMD /opt/bin/php-fpm --nodaemonize --fpm-config /opt/bref/etc/php-fpm.conf -d opcache.validate_timestamps=1 --force-stderr

--- a/runtime/layers/fpm-dev/php-fpm.conf
+++ b/runtime/layers/fpm-dev/php-fpm.conf
@@ -1,5 +1,5 @@
 ; Logging anywhere on disk doesn't make sense on lambda since instances are ephemeral
-error_log = /dev/stderr
+error_log = /dev/null
 pid = /tmp/php-fpm.pid
 ; Log above warning because PHP-FPM logs useless notices
 ; We must comment this flag else uncaught exceptions/fatal errors are not reported in the logs!


### PR DESCRIPTION
Reported by @jenschude in Slack. The `php.ini` was missing in the PHP-FPM dev image.

I have fixed this by basing the PHP-FPM dev image on the `php-73-fpm` images.