### PR TITLE
Set script_name environment variable

### DIFF
--- a/tests/Runtime/PhpFpm/gateway_event_resource.json
+++ b/tests/Runtime/PhpFpm/gateway_event_resource.json
@@ -1,0 +1,135 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/product/some-product-sku",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.5",
+    "cache-control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "DE",
+    "Cookie": "PHPSESSID=somerandomsessionid",
+    "dnt": "1",
+    "Host": "somelambdaid.execute-api.eu-west-1.amazonaws.com",
+    "upgrade-insecure-requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0",
+    "Via": "2.0 e7c35757c4581d46396ae4c0a48815ef.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "3lgjjl2A8V_r5Dv1K-wkJ3TmLrU1l1C4JBHWeMrbKOfz6SqYlSg-xg==",
+    "X-Amzn-Trace-Id": "Root=1-5dad6134-d1720e0d36c31b53431891ad",
+    "X-Forwarded-For": "37.44.1.50, 216.137.60.81",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https",
+    "Referer": "https://somelambdaid.execute-api.eu-west-1.amazonaws.com/dev/products"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    ],
+    "Accept-Encoding": [
+      "gzip, deflate, br"
+    ],
+    "Accept-Language": [
+      "en-US,en;q=0.5"
+    ],
+    "cache-control": [
+      "max-age=0"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-Country": [
+      "DE"
+    ],
+    "Cookie": [
+      "PHPSESSID=somerandomsessionid"
+    ],
+    "dnt": [
+      "1"
+    ],
+    "Host": [
+      "somelambdaid.execute-api.eu-west-1.amazonaws.com"
+    ],
+    "upgrade-insecure-requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0"
+    ],
+    "Via": [
+      "2.0 e7c35757c4581d46396ae4c0a48815ef.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "3lgjjl2A8V_r5Dv1K-wkJ3TmLrU1l1C4JBHWeMrbKOfz6SqYlSg-xg=="
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-5dad6134-d1720e0d36c31b53431891ad"
+    ],
+    "X-Forwarded-For": [
+      "37.44.1.50, 216.137.60.81"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ],
+    "Referer": [
+      "https://somelambdaid.execute-api.eu-west-1.amazonaws.com/dev/products"
+    ]
+  },
+  "queryStringParameters": null,
+  "multiValueQueryStringParameters": null,
+  "pathParameters": {
+    "proxy": "product/some-product-sku"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "3oj4v9",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "extendedRequestId": "B5wgQH1yDoEF0Rw=",
+    "requestTime": "21/Oct/2019:07:41:40 +0000",
+    "path": "/dev/product/some-product-sku",
+    "accountId": "564387806506",
+    "protocol": "HTTP/1.1",
+    "stage": "dev",
+    "domainPrefix": "somelambdaid",
+    "requestTimeEpoch": 1571643700752,
+    "requestId": "ec75a99d-059f-4483-9a71-7383032ac78a",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "37.44.1.50",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0",
+      "user": null
+    },
+    "domainName": "somelambdaid.execute-api.eu-west-1.amazonaws.com",
+    "apiId": "somelambdaid"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/tests/Runtime/PhpFpm/gateway_event_root.json
+++ b/tests/Runtime/PhpFpm/gateway_event_root.json
@@ -1,0 +1,129 @@
+{
+  "resource": "/",
+  "path": "/",
+  "httpMethod": "GET",
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Accept-Language": "en-US,en;q=0.5",
+    "cache-control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "DE",
+    "Cookie": "PHPSESSID=somerandomsessionid",
+    "dnt": "1",
+    "Host": "somelambdaid.execute-api.eu-west-1.amazonaws.com",
+    "upgrade-insecure-requests": "1",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0",
+    "Via": "2.0 80c1ad5f9352d00b95a9da73eb6b6be5.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "F6CrxygBiGd1YxIZok_jTICo9VXuKLFpvuGr_PPBhK3zzJJKfrDDTA==",
+    "X-Amzn-Trace-Id": "Root=1-5dad6df3-095ca844b74899945c8500b8",
+    "X-Forwarded-For": "37.44.1.50, 70.132.1.91",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    ],
+    "Accept-Encoding": [
+      "gzip, deflate, br"
+    ],
+    "Accept-Language": [
+      "en-US,en;q=0.5"
+    ],
+    "cache-control": [
+      "max-age=0"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-Country": [
+      "DE"
+    ],
+    "Cookie": [
+      "PHPSESSID=somerandomsessionid"
+    ],
+    "dnt": [
+      "1"
+    ],
+    "Host": [
+      "somelambdaid.execute-api.eu-west-1.amazonaws.com"
+    ],
+    "upgrade-insecure-requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0"
+    ],
+    "Via": [
+      "2.0 80c1ad5f9352d00b95a9da73eb6b6be5.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "F6CrxygBiGd1YxIZok_jTICo9VXuKLFpvuGr_PPBhK3zzJJKfrDDTA=="
+    ],
+    "X-Amzn-Trace-Id": [
+      "Root=1-5dad6df3-095ca844b74899945c8500b8"
+    ],
+    "X-Forwarded-For": [
+      "37.44.1.50, 70.132.1.91"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "queryStringParameters": null,
+  "multiValueQueryStringParameters": null,
+  "pathParameters": null,
+  "stageVariables": null,
+  "requestContext": {
+    "resourceId": "mb7wxtgd0i",
+    "resourcePath": "/",
+    "httpMethod": "GET",
+    "extendedRequestId": "B54eGHv3DoEFp3w=",
+    "requestTime": "21/Oct/2019:08:36:03 +0000",
+    "path": "/dev",
+    "accountId": "564387806506",
+    "protocol": "HTTP/1.1",
+    "stage": "dev",
+    "domainPrefix": "somelambdaid",
+    "requestTimeEpoch": 1571646963727,
+    "requestId": "ef6ffaa2-60f8-40da-8ca5-301692edee41",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "sourceIp": "37.44.1.50",
+      "principalOrgId": null,
+      "accessKey": null,
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0",
+      "user": null
+    },
+    "domainName": "somelambdaid.execute-api.eu-west-1.amazonaws.com",
+    "apiId": "somelambdaid"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -759,6 +759,233 @@ Year,Make,Model
         ]);
     }
 
+    public function partialGatewayEvents()
+    {
+        return [
+            'hello' => [
+                [
+                    'httpMethod' => 'GET',
+                    'path' => '/hello',
+                    'requestContext' => [
+                        'protocol' => 'HTTP/1.1',
+                        'path' => '/dev/hello'
+                    ],
+                ], [
+                    '$_GET' => [],
+                    '$_POST' => [],
+                    '$_FILES' => [],
+                    '$_COOKIE' => [],
+                    '$_REQUEST' => [],
+                    '$_SERVER' => [
+                        'REQUEST_URI' => '/dev/hello',
+                        'SCRIPT_NAME' => '/dev/request.php',
+                        'PHP_SELF' => '/dev/request.php/hello',
+                        'PATH_INFO' => '/hello',
+                        'REQUEST_METHOD' => 'GET',
+                        'QUERY_STRING' => '',
+                        'CONTENT_LENGTH' => '0',
+                        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                    ],
+                    'HTTP_RAW_BODY' => '',
+                ]
+            ],
+            'hello_dir' => [
+                [
+                    'httpMethod' => 'GET',
+                    'path' => '/hello/',
+                    'requestContext' => [
+                        'protocol' => 'HTTP/1.1',
+                        'path' => '/dev/hello/'
+                    ],
+                ], [
+                    '$_GET' => [],
+                    '$_POST' => [],
+                    '$_FILES' => [],
+                    '$_COOKIE' => [],
+                    '$_REQUEST' => [],
+                    '$_SERVER' => [
+                        'REQUEST_URI' => '/dev/hello/',
+                        'SCRIPT_NAME' => '/dev/request.php',
+                        'PHP_SELF' => '/dev/request.php/hello/',
+                        'PATH_INFO' => '/hello/',
+                        'REQUEST_METHOD' => 'GET',
+                        'QUERY_STRING' => '',
+                        'CONTENT_LENGTH' => '0',
+                        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                    ],
+                    'HTTP_RAW_BODY' => '',
+                ]
+            ],
+            'root' => [
+                [
+                    'httpMethod' => 'GET',
+                    'path' => '/',
+                    'requestContext' => [
+                        'protocol' => 'HTTP/1.1',
+                        'path' => '/dev'
+                    ],
+                ], [
+                    '$_GET' => [],
+                    '$_POST' => [],
+                    '$_FILES' => [],
+                    '$_COOKIE' => [],
+                    '$_REQUEST' => [],
+                    '$_SERVER' => [
+                        'REQUEST_URI' => '/dev',
+                        'SCRIPT_NAME' => '/dev/request.php',
+                        'PHP_SELF' => '/dev/request.php/',
+                        'PATH_INFO' => '/',
+                        'REQUEST_METHOD' => 'GET',
+                        'QUERY_STRING' => '',
+                        'CONTENT_LENGTH' => '0',
+                        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                    ],
+                    'HTTP_RAW_BODY' => '',
+                ]
+            ],
+            'root_dir' => [
+                [
+                    'httpMethod' => 'GET',
+                    'path' => '/',
+                    'requestContext' => [
+                        'protocol' => 'HTTP/1.1',
+                        'path' => '/dev/'
+                    ],
+                ], [
+                    '$_GET' => [],
+                    '$_POST' => [],
+                    '$_FILES' => [],
+                    '$_COOKIE' => [],
+                    '$_REQUEST' => [],
+                    '$_SERVER' => [
+                        'REQUEST_URI' => '/dev/',
+                        'SCRIPT_NAME' => '/dev/request.php',
+                        'PHP_SELF' => '/dev/request.php/',
+                        'PATH_INFO' => '/',
+                        'REQUEST_METHOD' => 'GET',
+                        'QUERY_STRING' => '',
+                        'CONTENT_LENGTH' => '0',
+                        'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                    ],
+                    'HTTP_RAW_BODY' => '',
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @param $event
+     * @param $globals
+     * @dataProvider partialGatewayEvents
+     */
+    public function test partial gateway request($event, $globals)
+    {
+        $this->assertGlobalVariables($event, $globals);
+    }
+
+    public function test full gateway root request()
+    {
+        $file_get_contents = file_get_contents(__DIR__ . '/PhpFpm/gateway_event_root.json');
+        $event = json_decode($file_get_contents, true);
+
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [
+                'PHPSESSID' => 'somerandomsessionid'
+            ],
+            '$_REQUEST' => [],
+            '$_SERVER' => [
+                'SERVER_NAME' => 'somelambdaid.execute-api.eu-west-1.amazonaws.com',
+                'SERVER_PORT' => '443',
+                'REMOTE_PORT' => '443',
+                'REQUEST_URI' => '/dev',
+                'SCRIPT_NAME' => '/dev/request.php',
+                'PHP_SELF' => '/dev/request.php/',
+                'PATH_INFO' => '/',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => '',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'HTTP_X_FORWARDED_PROTO' => 'https',
+                'HTTP_X_FORWARDED_PORT' => '443',
+                'HTTP_X_FORWARDED_FOR' => '37.44.1.50, 70.132.1.91',
+                'HTTP_X_AMZN_TRACE_ID' => 'Root=1-5dad6df3-095ca844b74899945c8500b8',
+                'HTTP_X_AMZ_CF_ID' => 'F6CrxygBiGd1YxIZok_jTICo9VXuKLFpvuGr_PPBhK3zzJJKfrDDTA==',
+                'HTTP_VIA' => '2.0 80c1ad5f9352d00b95a9da73eb6b6be5.cloudfront.net (CloudFront)',
+                'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0',
+                'HTTP_UPGRADE_INSECURE_REQUESTS' => '1',
+                'HTTP_HOST' => 'somelambdaid.execute-api.eu-west-1.amazonaws.com',
+                'HTTP_DNT' => '1',
+                'HTTP_COOKIE' => 'PHPSESSID=somerandomsessionid',
+                'HTTP_CLOUDFRONT_VIEWER_COUNTRY' => 'DE',
+                'HTTP_CLOUDFRONT_IS_TABLET_VIEWER' => 'false',
+                'HTTP_CLOUDFRONT_IS_SMARTTV_VIEWER' => 'false',
+                'HTTP_CLOUDFRONT_IS_MOBILE_VIEWER' => 'false',
+                'HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER' => 'true',
+                'HTTP_CLOUDFRONT_FORWARDED_PROTO' => 'https',
+                'HTTP_CACHE_CONTROL' => 'max-age=0',
+                'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.5',
+                'HTTP_ACCEPT_ENCODING' => 'gzip, deflate, br',
+                'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test full gateway resource request()
+    {
+        $file_get_contents = file_get_contents(__DIR__ . '/PhpFpm/gateway_event_resource.json');
+        $event = json_decode($file_get_contents, true);
+
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [
+                'PHPSESSID' => 'somerandomsessionid'
+            ],
+            '$_REQUEST' => [],
+            '$_SERVER' => [
+                'SERVER_NAME' => 'somelambdaid.execute-api.eu-west-1.amazonaws.com',
+                'SERVER_PORT' => '443',
+                'REMOTE_PORT' => '443',
+                'REQUEST_URI' => '/dev/product/some-product-sku',
+                'SCRIPT_NAME' => '/dev/request.php',
+                'PHP_SELF' => '/dev/request.php/product/some-product-sku',
+                'PATH_INFO' => '/product/some-product-sku',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => '',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'HTTP_REFERER' => 'https://somelambdaid.execute-api.eu-west-1.amazonaws.com/dev/products',
+                'HTTP_X_FORWARDED_PROTO' => 'https',
+                'HTTP_X_FORWARDED_PORT' => '443',
+                'HTTP_X_FORWARDED_FOR' => '37.44.1.50, 216.137.60.81',
+                'HTTP_X_AMZN_TRACE_ID' => 'Root=1-5dad6134-d1720e0d36c31b53431891ad',
+                'HTTP_X_AMZ_CF_ID' => '3lgjjl2A8V_r5Dv1K-wkJ3TmLrU1l1C4JBHWeMrbKOfz6SqYlSg-xg==',
+                'HTTP_VIA' => '2.0 e7c35757c4581d46396ae4c0a48815ef.cloudfront.net (CloudFront)',
+                'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0',
+                'HTTP_UPGRADE_INSECURE_REQUESTS' => '1',
+                'HTTP_HOST' => 'somelambdaid.execute-api.eu-west-1.amazonaws.com',
+                'HTTP_DNT' => '1',
+                'HTTP_COOKIE' => 'PHPSESSID=somerandomsessionid',
+                'HTTP_CLOUDFRONT_VIEWER_COUNTRY' => 'DE',
+                'HTTP_CLOUDFRONT_IS_TABLET_VIEWER' => 'false',
+                'HTTP_CLOUDFRONT_IS_SMARTTV_VIEWER' => 'false',
+                'HTTP_CLOUDFRONT_IS_MOBILE_VIEWER' => 'false',
+                'HTTP_CLOUDFRONT_IS_DESKTOP_VIEWER' => 'true',
+                'HTTP_CLOUDFRONT_FORWARDED_PROTO' => 'https',
+                'HTTP_CACHE_CONTROL' => 'max-age=0',
+                'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.5',
+                'HTTP_ACCEPT_ENCODING' => 'gzip, deflate, br',
+                'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
     /**
      * @dataProvider provideStatusCodes
      */

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -874,11 +874,9 @@ Year,Make,Model
     }
 
     /**
-     * @param $event
-     * @param $globals
      * @dataProvider partialGatewayEvents
      */
-    public function test partial gateway request($event, $globals)
+    public function test partial gateway request(array $event, array $globals)
     {
         $this->assertGlobalVariables($event, $globals);
     }

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -768,7 +768,7 @@ Year,Make,Model
                     'path' => '/hello',
                     'requestContext' => [
                         'protocol' => 'HTTP/1.1',
-                        'path' => '/dev/hello'
+                        'path' => '/dev/hello',
                     ],
                 ], [
                     '$_GET' => [],
@@ -787,7 +787,7 @@ Year,Make,Model
                         'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                     ],
                     'HTTP_RAW_BODY' => '',
-                ]
+                ],
             ],
             'hello_dir' => [
                 [
@@ -795,7 +795,7 @@ Year,Make,Model
                     'path' => '/hello/',
                     'requestContext' => [
                         'protocol' => 'HTTP/1.1',
-                        'path' => '/dev/hello/'
+                        'path' => '/dev/hello/',
                     ],
                 ], [
                     '$_GET' => [],
@@ -814,7 +814,7 @@ Year,Make,Model
                         'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                     ],
                     'HTTP_RAW_BODY' => '',
-                ]
+                ],
             ],
             'root' => [
                 [
@@ -822,7 +822,7 @@ Year,Make,Model
                     'path' => '/',
                     'requestContext' => [
                         'protocol' => 'HTTP/1.1',
-                        'path' => '/dev'
+                        'path' => '/dev',
                     ],
                 ], [
                     '$_GET' => [],
@@ -841,7 +841,7 @@ Year,Make,Model
                         'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                     ],
                     'HTTP_RAW_BODY' => '',
-                ]
+                ],
             ],
             'root_dir' => [
                 [
@@ -849,7 +849,7 @@ Year,Make,Model
                     'path' => '/',
                     'requestContext' => [
                         'protocol' => 'HTTP/1.1',
-                        'path' => '/dev/'
+                        'path' => '/dev/',
                     ],
                 ], [
                     '$_GET' => [],
@@ -868,7 +868,7 @@ Year,Make,Model
                         'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                     ],
                     'HTTP_RAW_BODY' => '',
-                ]
+                ],
             ],
         ];
     }
@@ -891,7 +891,7 @@ Year,Make,Model
             '$_POST' => [],
             '$_FILES' => [],
             '$_COOKIE' => [
-                'PHPSESSID' => 'somerandomsessionid'
+                'PHPSESSID' => 'somerandomsessionid',
             ],
             '$_REQUEST' => [],
             '$_SERVER' => [
@@ -942,7 +942,7 @@ Year,Make,Model
             '$_POST' => [],
             '$_FILES' => [],
             '$_COOKIE' => [
-                'PHPSESSID' => 'somerandomsessionid'
+                'PHPSESSID' => 'somerandomsessionid',
             ],
             '$_REQUEST' => [],
             '$_SERVER' => [


### PR DESCRIPTION
The `/dev` prefix is not identified by the Symfony HttpFoundation cause the environment variables are not correctly setup to retrieve the base URI.

By correctly setting the script name and request uri the dev prefix is correctly identified as a base URI.

See also https://github.com/symfony/symfony/blob/16d528504cd57c4f967ea095e8c603260e119125/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php#L594-L611

I also added some tests for a full blown API gateway event