### PR TITLE
Report non-zero exit code as failure in the console layer

### DIFF
--- a/demo/console.php
+++ b/demo/console.php
@@ -16,5 +16,9 @@ $silly->command('phpinfo', function (OutputInterface $output) {
     $phpinfo = ob_get_clean();
     $output->write($phpinfo);
 });
+$silly->command('error', function (OutputInterface $output) {
+    $output->writeln('There was an error!');
+    return 1;
+});
 
 $silly->run();

--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -22,19 +22,22 @@ while (true) {
     $lambdaRuntime->processNextEvent(function ($event) use ($handler): array {
         $cliOptions = $event['cli'] ?? '';
 
-        // We redirect stderr to stdout and use passthru so that everything
-        // written on the output ends up in Cloudwatch automatically
+        // We redirect stderr to stdout so that all the output is collected
         $command = "/opt/bin/php $handler " . $cliOptions . ' 2>&1';
 
         exec($command, $output, $exitCode);
 
         $output = implode("\n", $output);
 
-        // Echo $output so it is written to CLoudwatch logs as well as terminal connections.
+        // Echo the output so that it is written to CloudWatch logs
         echo $output;
 
+        if ($exitCode > 0) {
+            throw new Exception('The command exited with a non-zero status code: ' . $exitCode);
+        }
+
         return [
-            'exitCode' => $exitCode,
+            'exitCode' => $exitCode, // will always be 0
             'output' => $output,
         ];
     });


### PR DESCRIPTION
When using the [console](https://bref.sh/docs/runtimes/console.html) layer, if the executed command returns an exit code different than zero (which means an error occured), then the lambda execution **is not marked as a failure**.

This PR changes this behavior: if the script fails, then this is counted as a failure. That lets us monitor failure rates in CloudWatch.

This wasn't planned initially, as the console layer was mostly imagined to be used by a human. But using the console layer in cron is a growing usage.