### PR TITLE
Add the XSL extension

### DIFF
--- a/runtime/php-intermediary.Dockerfile
+++ b/runtime/php-intermediary.Dockerfile
@@ -342,6 +342,17 @@ RUN set -xe; cd ${POSTGRES_BUILD_DIR}/src/backend && make generated-headers
 RUN set -xe; cd ${POSTGRES_BUILD_DIR}/src/include && make install
 
 ###############################################################################
+# XSL Build
+# https://www.php.net/manual/en/book.xsl.php
+# Needs:
+#   - libxslt
+# Needed by:
+#   - php
+
+# Install libxslt first
+RUN LD_LIBRARY_PATH= yum install -y libxslt-devel
+
+###############################################################################
 # PHP Build
 # https://github.com/php/php-src/releases
 # Needs:
@@ -425,7 +436,9 @@ RUN set -xe \
         --enable-soap \
         --with-gd \
         --with-png-dir=${INSTALL_DIR} \
-        --with-jpeg-dir=${INSTALL_DIR}
+        --with-jpeg-dir=${INSTALL_DIR} \
+        --with-xsl=${INSTALL_DIR}
+
 RUN make -j $(nproc)
 # Run `make install` and override PEAR's PHAR URL because pear.php.net is down
 RUN set -xe; \


### PR DESCRIPTION
This PR add [XSL extension](https://www.php.net/manual/fr/book.xsl.php) to PHP layers, close #455 

~By the way, is there a way to test if it was enabled correctly? 
I was able to build layers correctly but how can I verify if PHP has been builded with XSL support (`php -i | grep xsl`)?~ 
**EDIT:** I've published my own layer (`arn:aws:lambda:eu-west-2:993232162575:layer:php-73-with-xsl:1`) and it works fine, I don't have the error `Warning: Use of undefined constant XSL_SECPREF_READ_FILE` anymore. :tada: 

Thanks!

### Layers sizes

**Before:**
```
-rw-r--r-- 1 hugo hugo      770 oct.  23 09:05 console.zip
-rw-r--r-- 1 hugo hugo 35476622 oct.  23 10:10 php-72-fpm.zip
-rw-r--r-- 1 hugo hugo 25933483 oct.  23 10:10 php-72.zip
-rw-r--r-- 1 hugo hugo 35749019 oct.  23 10:11 php-73-fpm.zip
-rw-r--r-- 1 hugo hugo 26091660 oct.  23 10:10 php-73.zip
```

**After:**
```
-rw-r--r-- 1 hugo hugo      770 oct.  23 10:28 console.zip
-rw-r--r-- 1 hugo hugo 35504938 oct.  23 10:29 php-72-fpm.zip
-rw-r--r-- 1 hugo hugo 25947667 oct.  23 10:28 php-72.zip
-rw-r--r-- 1 hugo hugo 35778292 oct.  23 10:29 php-73-fpm.zip
-rw-r--r-- 1 hugo hugo 26106921 oct.  23 10:28 php-73.zip
```

**Delta:**
- php-72-fpm.zip is 28,316 bytes larger = + 0.07981594188%
- php-72.zip: is 14,184 bytes larger = + 0.05469377175%
- php-73-fpm.zip: is 29,273 bytes larger = + 0.08188476444%
- php-73.zip: is 15,261 bytes larger = + 0.05848995426%

@mnapoli On PR #452 you said that you needed to check out the unzipped sizes before merging the PR (https://github.com/brefphp/bref/pull/452#issuecomment-534421935), maybe I can prepare that for you or it's not necessary since delta is between ~0.05%/~0.08%?