### PR TITLE
Bump to postgres 10.7

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -356,7 +356,7 @@ RUN set -xe; \
 #   - OpenSSL
 # Needed by:
 #   - php
-ENV VERSION_POSTGRES=9.6.11
+ENV VERSION_POSTGRES=.10.7
 ENV POSTGRES_BUILD_DIR=${BUILD_DIR}/postgres
 
 RUN set -xe; \


### PR DESCRIPTION
The Aurora serverless requires 10.7.

Im not sure what kind of effects this got.. Can you still be using AWS postgres database running 9.6.11?