### PR TITLE
Add xdebug to php-fpm-dev container

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -128,6 +128,35 @@ In the example above, a `public/assets/style.css` file will be accessible at `ht
 
 > Be aware that serving assets in production will not work like this out of the box. You will need [to use a S3 bucket](/docs/runtimes/http.md#assets).
 
+### Xdebug
+
+The docker container `bref/php-<version>-fpm-dev` comes with xdebug pre-installed. In order to enable it you can create a
+folder `php/conf.dev.d` in your project and include an ini file enabling xdebug:
+
+```ini
+zend_extension=xdebug.so
+```
+
+Now start the debug session by issueing a request to your application in the [browser](https://xdebug.org/docs/remote#starting).
+
+#### OSX
+
+As Docker on Mac uses a virtual machine for running docker it can be tricky to listen to the xdebug port.
+By creating an alias for the loopback interface on the host with
+
+```bash
+sudo ifconfig lo0 alias 10.254.254.254
+```
+
+you can use this configuration start listening to xdebug connections in your preferred IDE:
+
+```ini
+[xdebug]
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 0
+xdebug.remote_host = '10.254.254.254'
+```
+
 ## Console applications
 
 Console applications can be tested just like before: by running the command in your terminal.

--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -1,13 +1,27 @@
 ARG PHP_VERSION
-FROM bref/php-$PHP_VERSION-fpm
+FROM bref/build-php-$PHP_VERSION as build_extensions
 
+RUN pecl install xdebug
+RUN cp $(php -r "echo ini_get('extension_dir');")/xdebug.so /tmp
+
+FROM bref/php-${PHP_VERSION}-fpm as build_dev
+
+USER root
+COPY --from=build_extensions /tmp/*.so /tmp/
+RUN cp /tmp/*.so $(php -r "echo ini_get('extension_dir');")
+
+FROM bref/php-${PHP_VERSION}-fpm
+
+COPY --from=build_dev  /opt /opt
 # Override the config so that PHP-FPM listens on port 9000
 COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
 
-EXPOSE 9000
+EXPOSE 9001
 
 # Clear the parent entrypoint
 ENTRYPOINT []
+
+ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d:/var/task/php/conf.dev.d"
 
 # Run PHP-FPM
 # opcache.validate_timestamps=1 : cancels the flag in the base configuration so that files are reloaded

--- a/runtime/layers/fpm-dev/php-fpm.conf
+++ b/runtime/layers/fpm-dev/php-fpm.conf
@@ -11,7 +11,7 @@ pm = static
 ; We only need one child because a lambda can process only one request at a time
 pm.max_children = 1
 user = nobody
-listen = 9000
+listen = 9001
 ; Allows PHP processes to access the lambda's environment variables
 clear_env = no
 ; Forward stderr of PHP processes to stderr of PHP-FPM (so that it can be sent to cloudwatch)


### PR DESCRIPTION
Replace for #469 

For better development experience using the fpm docker container I added xdebug to the docker container.

As the container images are build using an intermediary container I added the install step here and delete the xdebug.so from the resulting container if necessary.

As xdebug uses by default the port 9000 i changed the fpm port in the dev container to 9001 one to reduce the configuration overhead for the users.