### PR TITLE
add test to check if extensions are loadable

### DIFF
--- a/runtime/helpers/extensions-test.sh
+++ b/runtime/helpers/extensions-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if php -m 2>&1 >/dev/null | grep -q 'Unable'; then
+   php -m 2>&1 >/dev/null | grep 'Unable to load dynamic library'
+   exit 1
+fi

--- a/runtime/helpers/php/conf.d/php.ini
+++ b/runtime/helpers/php/conf.d/php.ini
@@ -1,0 +1,7 @@
+extension=intl
+extension=apcu
+extension=redis
+extension=pdo_pgsql
+extension=pdo_mysql
+extension=mongodb
+extension=pthreads

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -24,6 +24,12 @@ foreach ($allLayers as $layer) {
     $phpVersion = trim(`docker run --rm --entrypoint php $layer -v`);
     assertContains('PHP 7.', $phpVersion);
     echo '.';
+
+    exec("docker run --rm -v \${PWD}/helpers:/var/task/ --entrypoint /var/task/extensions-test.sh $layer", $output, $exitCode);
+    if ($exitCode !== 0) {
+        throw new Exception(implode(PHP_EOL, $output), $exitCode);
+    }
+    echo '.';
 }
 
 // FPM layers


### PR DESCRIPTION
In order to prevent broken extensions we also instantiate the containers once with all extensions enabled to check if there are some errors.

Replaces #492 