### PR TITLE
Expose the request context in the FPM layer via a global variable

### DIFF
--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -212,7 +212,7 @@ final class PhpFpm
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
             $requestContext = [];
-            foreach ($event['requestContext'] as $key => $value) {
+            foreach (json_decode(json_encode($event['requestContext']),true) as $key => $value) {
                 $requestContext[strtoupper($key)] = $value;
                 $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
             }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -213,7 +213,7 @@ final class PhpFpm
         if ($event['requestContext'] ?? false) {
 
             $changeToAssoc = $event['requestContext'];
-            echo $changeToAssoc;
+            print_r($changeToAssoc);
             $requestContext = [];
             foreach (json_decode(json_encode($event['requestContext']),true) as $key => $value) {
                 $requestContext[strtoupper($key)] = $value;

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,13 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', json_decode(json_encode($event['requestContext']), true));
+
+            $requestContext = [];
+
+            foreach ($event['requestContext'] as $key => $value) {
+                $requestContext[$key] = $value[0];
+                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $requestContext);
+            }
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,10 +211,12 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
+
+            $changeToAssoc = json_decode($event['requestContext'], true);
+            echo $changeToAssoc;
             $requestContext = [];
             foreach (json_decode(json_encode($event['requestContext']),true) as $key => $value) {
                 $requestContext[strtoupper($key)] = $value;
-                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
             }
             $request->addCustomVars(['REQUEST_CONTEXT' => $requestContext]);
 

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,11 +211,9 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', print_r($event['requestContext']));
-//
-//            foreach ($event['requestContext'] as $key => $value) {
-//                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
-//            }
+            foreach ($event['requestContext'] as $key => $value) {
+                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
+            }
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,9 +211,11 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
+            $requestContext = [];
             foreach ($event['requestContext'] as $key => $value) {
-                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
+                $requestContext[strtoupper($key)] = $value;
             }
+            $request->setCustomVar('REQUEST_CONTEXT', $requestContext);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -214,7 +214,7 @@ final class PhpFpm
 //            foreach ($event['requestContext'] as $key => $value) {
 //                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
 //            }
-            $request->setCustomVar('REQUEST_CONTEXT', []);
+            $request->addCustomVars(['test' => 'test']);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -214,7 +214,7 @@ final class PhpFpm
 //            foreach ($event['requestContext'] as $key => $value) {
 //                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
 //            }
-            $request->addCustomVars(['test' => 'test']);
+            $request->addCustomVars(['REQUEST_CONTEXT' => []]);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -362,18 +362,18 @@ final class PhpFpm
     /**
      * Recursively loop through a data object and create env variables
      */
-    private function setArrayValue(string $name,  array $array,  $request): void
+    private function setArrayValue(string $name, array $array, $request): void
     {
-        if(!is_array($array)){
+        if (!is_array($array)) {
             $request->setCustomVar(strtoupper($name), $array);
         }
 
         foreach ($array as $key => $value) {
-            if(!is_array($value)){
+            if (!is_array($value)) {
                 $request->setCustomVar(strtoupper($name . '_' . $key), $value);
             }
 
-            if(is_array($value)){
+            if (is_array($value)) {
                 $this->setArrayValue(strtoupper($name . '_' .$key), $value, $request);
             }
         }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,8 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', json_decode($event['requestContext'], true));
+            abort($event['requestContext']);
+            $request->setCustomVar('REQUEST_CONTEXT', json_decode(json_encode($event['requestContext']), true);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,7 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', json_decode(json_encode($event['requestContext']), true));
+            $request->setCustomVar('REQUEST_CONTEXT', $event['requestContext']);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -209,7 +209,8 @@ final class PhpFpm
         $request->setServerPort((int) ($headers['x-forwarded-port'][0] ?? 80));
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
-
+        $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
+        
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = ['application/x-www-form-urlencoded'];

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -361,13 +361,9 @@ final class PhpFpm
 
     /**
      * Recursively loop through a data object and create env variables
-     *
-     * @param string $name
-     * @param array $array
-     * @param $request
      */
-    private function setArrayValue(string $name, array $array, $request): void {
-
+    private function setArrayValue(string $name,  array $array,  $request): void
+    {
         if(!is_array($array)){
             $request->setCustomVar(strtoupper($name), $array);
         }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -212,7 +212,7 @@ final class PhpFpm
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
             foreach ($event['requestContext'] as $key => $value) {
-                $request->setCustomVar('REQUEST_CONTEXT_' . $key, $value);
+                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
             }
         }
         // See https://stackoverflow.com/a/5519834/245552

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,9 +211,11 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            foreach ($event['requestContext'] as $key => $value) {
-                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
-            }
+            $request->setCustomVar('REQUEST_CONTEXT', print_r($event['requestContext']));
+//
+//            foreach ($event['requestContext'] as $key => $value) {
+//                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
+//            }
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,10 +211,9 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-//            foreach ($event['requestContext'] as $key => $value) {
-//                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
-//            }
-            $request->addCustomVars(['REQUEST_CONTEXT' => array()]);
+            foreach ($event['requestContext'] as $key => $value) {
+                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
+            }
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,7 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', $event['requestContext']);
+            $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -173,7 +173,7 @@ final class PhpFpm
     private function eventToFastCgiRequest(array $event): ProvidesRequestData
     {
         $requestBody = $event['body'] ?? '';
-        $requestContext = ($event['requestContext']) ? json_encode($event['requestContext']) : '';
+        $requestContext = $event['requestContext'] ? json_encode($event['requestContext']) : '';
         if ($event['isBase64Encoded'] ?? false) {
             $requestBody = base64_decode($requestBody);
         }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,14 +211,8 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $requestContext = [];
             foreach ($event['requestContext'] as $key => $value) {
-                $requestContext[$key] = $value[0];
-                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $requestContext);
-                $request->setCustomVar('TEST', [
-                    ['yes' => 'no'],
-                    ['yes' => true]
-                ]);
+                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
             }
         }
         // See https://stackoverflow.com/a/5519834/245552

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -214,7 +214,9 @@ final class PhpFpm
 //            foreach ($event['requestContext'] as $key => $value) {
 //                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
 //            }
-            $request->setCustomVar('REQUEST_CONTEXT', 'test');
+            $request->addCustomVars(['test' => [
+                ['yes' => 'test']
+            ]);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,11 +211,7 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $requestContext = [];
-            foreach ($event['requestContext'] as $key => $value) {
-                $requestContext[strtoupper($key)] = $value;
-            }
-            $request->setCustomVar('REQUEST_CONTEXT', print_r($requestContext));
+            $request->setCustomVar('REQUEST_CONTEXT', json_decode($event['requestContext'], true));
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -214,7 +214,7 @@ final class PhpFpm
 //            foreach ($event['requestContext'] as $key => $value) {
 //                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
 //            }
-            $request->addCustomVars(['REQUEST_CONTEXT' => []]);
+            $request->addCustomVars(['REQUEST_CONTEXT' => array()]);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -174,7 +174,6 @@ final class PhpFpm
     {
         $requestBody = $event['body'] ?? '';
         $requestContext = json_encode($event['requestContext']) ?? '';
-        
         if ($event['isBase64Encoded'] ?? false) {
             $requestBody = base64_decode($requestBody);
         }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -216,7 +216,7 @@ final class PhpFpm
 //            }
             $request->addCustomVars(['test' => [
                 ['yes' => 'test']
-            ]);
+            ]]);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -210,17 +210,11 @@ final class PhpFpm
         $request->setServerPort((int) ($headers['x-forwarded-port'][0] ?? 80));
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
-        if ($event['requestContext'] ?? false) {
-
-            $changeToAssoc = $event['requestContext'];
-            print_r($changeToAssoc);
-            $requestContext = [];
-            foreach (json_decode(json_encode($event['requestContext']),true) as $key => $value) {
-                $requestContext[strtoupper($key)] = $value;
-            }
-            $request->addCustomVars(['REQUEST_CONTEXT' => $requestContext]);
-
-        }
+//        if ($event['requestContext'] ?? false) {
+//            foreach ($event['requestContext'] as $key => $value) {
+//                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
+//            }
+//        }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = ['application/x-www-form-urlencoded'];

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -173,6 +173,8 @@ final class PhpFpm
     private function eventToFastCgiRequest(array $event): ProvidesRequestData
     {
         $requestBody = $event['body'] ?? '';
+        $requestContext = json_encode($event['requestContext']) ?? '';
+        
         if ($event['isBase64Encoded'] ?? false) {
             $requestBody = base64_decode($requestBody);
         }
@@ -209,7 +211,7 @@ final class PhpFpm
         $request->setServerPort((int) ($headers['x-forwarded-port'][0] ?? 80));
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
-        $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
+        $request->setCustomVar('REQUEST_CONTEXT', $requestContext);
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = ['application/x-www-form-urlencoded'];

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -215,9 +215,7 @@ final class PhpFpm
             foreach ($event['requestContext'] as $key => $value) {
                 $requestContext[strtoupper($key)] = $value;
             }
-
-            var_dump($requestContext);
-            $request->setCustomVar('REQUEST_CONTEXT', $requestContext);
+            $request->setCustomVar('REQUEST_CONTEXT', print_r($requestContext));
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,9 +211,13 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
+            $requestContext = [];
             foreach ($event['requestContext'] as $key => $value) {
+                $requestContext[strtoupper($key)] = $value;
                 $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
             }
+            $request->addCustomVars($requestContext);
+
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,8 +211,7 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            abort($event['requestContext']);
-            $request->setCustomVar('REQUEST_CONTEXT', json_decode(json_encode($event['requestContext']), true);
+            $request->setCustomVar('REQUEST_CONTEXT', json_decode(json_encode($event['requestContext']), true));
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -214,9 +214,7 @@ final class PhpFpm
 //            foreach ($event['requestContext'] as $key => $value) {
 //                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
 //            }
-            $request->addCustomVars(['test' => [
-                ['yes' => 'test']
-            ]]);
+            $request->setCustomVar('REQUEST_CONTEXT', []);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,9 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', $event['requestContext']);
+            foreach ($event['requestContext'] as $key => $value) {
+                $request->setCustomVar('REQUEST_CONTEXT_' . $key, $value);
+            }
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -173,11 +173,6 @@ final class PhpFpm
     private function eventToFastCgiRequest(array $event): ProvidesRequestData
     {
         $requestBody = $event['body'] ?? '';
-        $requestContext = $event['requestContext'] ?? '';
-
-        if ($event['requestContext'] ?? false) {
-            $requestContext = json_encode($event['requestContext']);
-        }
 
         if ($event['isBase64Encoded'] ?? false) {
             $requestBody = base64_decode($requestBody);
@@ -215,7 +210,9 @@ final class PhpFpm
         $request->setServerPort((int) ($headers['x-forwarded-port'][0] ?? 80));
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
-        $request->setCustomVar('REQUEST_CONTEXT', $requestContext);
+        if ($event['requestContext'] ?? false) {
+            $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']);
+        }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = ['application/x-www-form-urlencoded'];

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,7 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
+            $request->setCustomVar('REQUEST_CONTEXT', $event['requestContext']);
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,7 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
+            $request->setCustomVar('REQUEST_CONTEXT', json_decode(json_encode($event['requestContext']), true));
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -210,7 +210,6 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
-        
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = ['application/x-www-form-urlencoded'];

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -210,11 +210,12 @@ final class PhpFpm
         $request->setServerPort((int) ($headers['x-forwarded-port'][0] ?? 80));
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
-//        if ($event['requestContext'] ?? false) {
+        if ($event['requestContext'] ?? false) {
 //            foreach ($event['requestContext'] as $key => $value) {
 //                $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
 //            }
-//        }
+            $request->setCustomVar('REQUEST_CONTEXT', 'test');
+        }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {
             $headers['content-type'] = ['application/x-www-form-urlencoded'];

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -173,7 +173,12 @@ final class PhpFpm
     private function eventToFastCgiRequest(array $event): ProvidesRequestData
     {
         $requestBody = $event['body'] ?? '';
-        $requestContext = $event['requestContext'] ? json_encode($event['requestContext']) : '';
+        $requestContext = $event['requestContext'] ?? '';
+
+        if ($event['requestContext'] ?? false) {
+            $requestContext = json_encode($event['requestContext']);
+        }
+
         if ($event['isBase64Encoded'] ?? false) {
             $requestBody = base64_decode($requestBody);
         }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -362,19 +362,19 @@ final class PhpFpm
     /**
      * Recursively loop through a data object and create env variables
      */
-    private function setArrayValue(string $name, array $array, $request): void
+    private function setArrayValue(string $name, array $array, FastCgiRequest $request): void
     {
-        if (!is_array($array)) {
+        if (! is_array($array)) {
             $request->setCustomVar(strtoupper($name), $array);
         }
 
         foreach ($array as $key => $value) {
-            if (!is_array($value)) {
+            if (! is_array($value)) {
                 $request->setCustomVar(strtoupper($name . '_' . $key), $value);
             }
 
             if (is_array($value)) {
-                $this->setArrayValue(strtoupper($name . '_' .$key), $value, $request);
+                $this->setArrayValue(strtoupper($name . '_' . $key), $value, $request);
             }
         }
     }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,12 +211,14 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-
             $requestContext = [];
-
             foreach ($event['requestContext'] as $key => $value) {
                 $requestContext[$key] = $value[0];
                 $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $requestContext);
+                $request->setCustomVar('TEST', [
+                    ['yes' => 'no'],
+                    ['yes' => true]
+                ]);
             }
         }
         // See https://stackoverflow.com/a/5519834/245552

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -211,7 +211,7 @@ final class PhpFpm
         $request->setCustomVar('PATH_INFO', $event['path'] ?? '/');
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
-            $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']);
+            $request->setCustomVar('REQUEST_CONTEXT', json_encode($event['requestContext']));
         }
         // See https://stackoverflow.com/a/5519834/245552
         if (! empty($requestBody) && $method !== 'TRACE' && ! isset($headers['content-type'])) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -212,7 +212,7 @@ final class PhpFpm
         $request->setCustomVar('QUERY_STRING', $queryString);
         if ($event['requestContext'] ?? false) {
 
-            $changeToAssoc = json_decode($event['requestContext'], true);
+            $changeToAssoc = $event['requestContext'];
             echo $changeToAssoc;
             $requestContext = [];
             foreach (json_decode(json_encode($event['requestContext']),true) as $key => $value) {

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -173,7 +173,7 @@ final class PhpFpm
     private function eventToFastCgiRequest(array $event): ProvidesRequestData
     {
         $requestBody = $event['body'] ?? '';
-        $requestContext = json_encode($event['requestContext']) ?? '';
+        $requestContext = ($event['requestContext']) ? json_encode($event['requestContext']) : '';
         if ($event['isBase64Encoded'] ?? false) {
             $requestBody = base64_decode($requestBody);
         }

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -215,6 +215,8 @@ final class PhpFpm
             foreach ($event['requestContext'] as $key => $value) {
                 $requestContext[strtoupper($key)] = $value;
             }
+
+            var_dump($requestContext);
             $request->setCustomVar('REQUEST_CONTEXT', $requestContext);
         }
         // See https://stackoverflow.com/a/5519834/245552

--- a/src/Runtime/PhpFpm.php
+++ b/src/Runtime/PhpFpm.php
@@ -216,7 +216,7 @@ final class PhpFpm
                 $requestContext[strtoupper($key)] = $value;
                 $request->setCustomVar('REQUEST_CONTEXT_' . strtoupper($key), $value);
             }
-            $request->addCustomVars($requestContext);
+            $request->addCustomVars(['REQUEST_CONTEXT' => $requestContext]);
 
         }
         // See https://stackoverflow.com/a/5519834/245552

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -41,7 +41,10 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT_PROTOCOL' => 'HTTP/1.1',
+                'REQUEST_CONTEXT' => [
+                    ['PROTOCOL' => 'HTTP/1.1'],
+                    ['test' => 'test2'],
+                ],
             ],
             'HTTP_RAW_BODY' => '',
         ]);

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -132,7 +132,12 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'foo' => 'baz', // the 2nd value is preserved only by API Gateway
             ],
             'requestContext' => [
-                'foo' => 'baz', // the 2nd value is preserved only by API Gateway
+                'foo' => 'baz',
+                'baz' => 'far',
+                'data' => [
+                    'recurse1' => 1,
+                    'recurse2' => 2
+                ],
             ],
         ];
         $this->assertGlobalVariables($event, [
@@ -155,6 +160,9 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'REQUEST_CONTEXT_FOO' => 'baz',
+                'REQUEST_CONTEXT_BAZ' => 'far',
+                'REQUEST_CONTEXT_DATA_RECURSE1' => 1,
+                'REQUEST_CONTEXT_DATA_RECURSE2' => 2,
             ],
             'HTTP_RAW_BODY' => '',
 

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -41,6 +41,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '{"protocol":"HTTP\/1.1"}'
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -153,9 +154,10 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '{"foo":"baz"}',
             ],
             'HTTP_RAW_BODY' => '',
-            'REQUEST_CONTEXT' => '{"foo":"baz"}',
+
         ]);
     }
 

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -155,7 +155,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
             ],
             'HTTP_RAW_BODY' => '',
-            'REQUEST_CONTEXT' => '{ \"foo\": \"baz\" }',
+            'REQUEST_CONTEXT' => '{"foo":"baz"}',
         ]);
     }
 

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -41,7 +41,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '{"protocol":"HTTP\/1.1"}'
+                'REQUEST_CONTEXT' => '{"protocol":"HTTP\/1.1"}',
             ],
             'HTTP_RAW_BODY' => '',
         ]);

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -117,6 +117,48 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'HTTP_RAW_BODY' => '',
         ]);
     }
+    
+    
+    public function test request with requestContext array support()
+    {
+        $event = [
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            // See https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/
+            'multiValueQueryStringParameters' => [
+                'foo' => ['bar', 'baz'],
+            ],
+            'queryStringParameters' => [
+                'foo' => 'baz', // the 2nd value is preserved only by API Gateway
+            ],
+            'requestContext' => [
+                'foo' => 'baz', // the 2nd value is preserved only by API Gateway
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                // TODO The feature is not implemented yet
+                'foo' => 'bar',
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'foo' => 'bar',
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?foo=bar',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'foo=bar',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+            ],
+            'HTTP_RAW_BODY' => '',
+            'REQUEST_CONTEXT' => '{ \"foo\": \"baz\" }'
+        ]);
+    }
 
     public function test request with arrays in query string()
     {

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -136,7 +136,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'baz' => 'far',
                 'data' => [
                     'recurse1' => 1,
-                    'recurse2' => 2
+                    'recurse2' => 2,
                 ],
             ],
         ];

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -41,7 +41,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '{"protocol":"HTTP\/1.1"}',
+                'REQUEST_CONTEXT_PROTOCOL' => 'HTTP/1.1',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -154,7 +154,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '{"foo":"baz"}',
+                'REQUEST_CONTEXT_FOO' => 'baz',
             ],
             'HTTP_RAW_BODY' => '',
 

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -117,7 +117,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
             'HTTP_RAW_BODY' => '',
         ]);
     }
-    
+
     public function test request with requestContext array support()
     {
         $event = [
@@ -155,7 +155,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
             ],
             'HTTP_RAW_BODY' => '',
-            'REQUEST_CONTEXT' => '{ \"foo\": \"baz\" }'
+            'REQUEST_CONTEXT' => '{ \"foo\": \"baz\" }',
         ]);
     }
 

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -118,7 +118,6 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
     
-    
     public function test request with requestContext array support()
     {
         $event = [

--- a/tests/Runtime/PhpFpmTest.php
+++ b/tests/Runtime/PhpFpmTest.php
@@ -41,10 +41,7 @@ class PhpFpmTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => [
-                    ['PROTOCOL' => 'HTTP/1.1'],
-                    ['test' => 'test2'],
-                ],
+                'REQUEST_CONTEXT_PROTOCOL' => 'HTTP/1.1',
             ],
             'HTTP_RAW_BODY' => '',
         ]);


### PR DESCRIPTION
This request context is needed if a user is using the authentication type of IAM_ROLE, when a user authenticates.

When using the IAM_ROLE authentication type with serverless, a user will pass their v4 signature token to API Gateway. API Gateway will then check and authorise the user which then invokes the lambda function, when invoking the lambda function API Gateway will pass in an updated requestContext object which contains Cognito information about the user. This prevents the requirement of having to pass user ID's publicly.

When using the layer without fpm & using the lambda function you can retrieve the event. 

Due to how FPM creates a local web server, handling the event is not accessible with the lambda function provided by bref. As the lambda function getting the LambdaApi request throws a no access error.

See below the example of the request context below contains information about the Cognito user, however in the fpmphp file there has unfortunately been no object added to this. I have written a pull request and adjusted a previous test that actually contained a requestContext but hadn't been tested to account for it.

> requestContext": {
        "resourceId": "n52n1n689a",
        "resourcePath": "/",
        "httpMethod": "GET",
        "extendedRequestId": "C9gIXGW7joEFVxA=",
        "requestTime": "10/Nov/2019:20:59:33 +0000",
        "path": "/users",
        "accountId": "<REMOVED>",
        "protocol": "HTTP/1.1",
        "stage": "dev",
        "domainPrefix": "secure-api",
        "requestTimeEpoch": 1573419573440,
        "requestId": "d679114c-4a3d-42d8-862a-892d036f7e2f",
        "identity": {
            "cognitoIdentityPoolId": "<REMOVED>",
            "accountId": "<REMOVED>",
            "cognitoIdentityId": "<REMOVED>",
            "caller": "<REMOVED>",
            "sourceIp": "<REMOVED>",
            "principalOrgId": "<REMOVED>",
            "accessKey": "<REMOVED>",
            "cognitoAuthenticationType": "authenticated",
            "cognitoAuthenticationProvider": "<REMOVED>",
            "userArn": "<REMOVED>",
            "userAgent": "<REMOVED>",
            "user": "<REMOVED>"
        },
        "domainName": "<REMOVED>",
        "apiId": "<REMOVED>"
    },`
