### PR TITLE
Add additional AWS regions to database docs

### DIFF
--- a/docs/environment/database.md
+++ b/docs/environment/database.md
@@ -33,7 +33,7 @@ Running in a VPC has a big caveat: the lambda suffers from much longer **cold st
 
 On average cold starts due to VPC are around **5 seconds**. This can be a deal-breaker for scenarios like real-time APIs.
 
-> 🎉 AWS [fixed this for Regions: US East (Ohio), EU (Frankfurt), and Asia Pacific (Tokyo)](https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/). We will keep this page updated when it is resolved for all regions.
+> 🎉 AWS [fixed this for Regions: US East (Ohio), US West (N. California), South America (San Paulo), EU (Ireland), EU (Paris), EU (Frankfurt), Asia Pacific (Mumbai), Asia Pacific (Seoul), Asia Pacific (Singapore), Asia Pacific (Sydney), and Asia Pacific (Tokyo)](https://aws.amazon.com/blogs/compute/announcing-improved-vpc-networking-for-aws-lambda-functions/). We will keep this page updated when it is resolved for all regions.
 
 A common workaround is to ["ping" the lambda function every 5 minutes](/docs/runtimes/http.html#cold-starts) to avoid cold starts. This [might not work](https://hackernoon.com/im-afraid-you-re-thinking-about-aws-lambda-cold-starts-all-wrong-7d907f278a4f) for applications with very variable loads.
 


### PR DESCRIPTION
Add additional AWS regions where the networking limitation has been improved, as per an update to the linked AWS doc on 6th November.