### PR TITLE
Encode body responses in base64 only when configured

### DIFF
--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -116,7 +116,7 @@ In some cases however, you will need to serve images (or other assets) via PHP. 
 
 ## Binary responses
 
-By default API Gateway **does not support binary HTTP responses** like images, PDF, binary files… To achieve this, you need to enable the option for binary responses in `serverless.yml`:
+By default API Gateway **does not support binary HTTP responses** like images, PDF, binary files… To achieve this, you need to enable the option for binary responses in `serverless.yml` as well as define the `BREF_BINARY_RESPONSES` environment variable:
 
 ```yaml
 provider:
@@ -124,24 +124,11 @@ provider:
     apiGateway:
         binaryMediaTypes:
             - '*/*'
+    environment:
+        BREF_BINARY_RESPONSES: 1
 ```
 
-This will make API Gateway support binary responses for all responses. Your application can now return binary responses as usual.
-
-**However, you must define a `Content-Type` header on binary responses.** If you don't, you may get the following error: *Failed encoding Lambda JSON response: Malformed UTF-8 characters, possibly incorrectly encoded*. [Symfony's helpers](https://symfony.com/doc/current/components/http_foundation.html#serving-files) or [Laravel's helpers](https://laravel.com/docs/5.8/responses#file-downloads) will take care of that for you. If you don't use them, here are some examples:
-
-```php
-// Vanilla PHP example with a JPEG image response:
-header('Content-Type: image/jpeg');
-header('Content-Length: ' . filesize($filename));
-fpassthru(fopen($filename, 'rb'));
-
-// PSR-7 example:
-return $response
-    ->withHeader('Content-Type', 'image/jpeg')
-    ->withHeader('Content-Length', (string) filesize($filename))
-    ->withBody(new Stream($filename));
-```
+This will make API Gateway support binary responses, and Bref will automatically encode responses to base64 (which is what API Gateway now expects).
 
 ## Cold starts
 

--- a/src/Http/LambdaResponse.php
+++ b/src/Http/LambdaResponse.php
@@ -60,6 +60,8 @@ final class LambdaResponse
 
     public function toApiGatewayFormat(bool $multiHeaders = false): array
     {
+        $base64Encoding = (bool) getenv('BREF_BINARY_RESPONSES');
+
         // The headers must be a JSON object. If the PHP array is empty it is
         // serialized to `[]` (we want `{}`) so we force it to an empty object.
         $headers = empty($this->headers) ? new \stdClass : $this->headers;
@@ -70,10 +72,10 @@ final class LambdaResponse
         // This is the format required by the AWS_PROXY lambda integration
         // See https://stackoverflow.com/questions/43708017/aws-lambda-api-gateway-error-malformed-lambda-proxy-response
         return [
-            'isBase64Encoded' => false,
+            'isBase64Encoded' => $base64Encoding,
             'statusCode' => $this->statusCode,
             $headersKey => $headers,
-            'body' => $this->body,
+            'body' => $base64Encoding ? base64_encode($this->body) : $this->body,
         ];
     }
 }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -243,19 +243,6 @@ final class LambdaRuntime
      */
     private function postJson(string $url, $data): void
     {
-        $contentType = $data['multiValueHeaders']['content-type'][0] ?? null;
-        /**
-         * API Gateway does not support binary content in HTTP responses.
-         * What we do is:
-         * - if we are certain the response is not binary (either JSON or the content type starts with `text/*`) we don't encode
-         * - else we encode all other responses to base64
-         * API Gateway checks `isBase64Encoded` and decodes what we returned if necessary.
-         */
-        if ($contentType && strpos($contentType, 'application/json') !== 0 && strpos($contentType, 'text/') !== 0) {
-            $data['body'] = base64_encode($data['body']);
-            $data['isBase64Encoded'] = true;
-        }
-
         $jsonData = json_encode($data);
         if ($jsonData === false) {
             throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());


### PR DESCRIPTION
This pull request fixes the issues of base64 encoded responses brought up in #482. 

It turns out we failed at properly implementing a solution with binary responses: the solution we added introduced a regression. We merged #494 which mitigated the impact, but this wasn't covering all cases. It turns out that covering all cases is impossible. Sorry about the back and forth!

This pull request implements a solution in a different direction. It requires slightly more effort from users, but at least it is completely predictable.

From now on, to support binary responses, users will have to add 2 things instead of 1 to `serverless.yml`.

Before this PR:

```yaml
provider:
    # ...
    apiGateway:
        binaryMediaTypes:
            - '*/*'
```

After this PR:

```yaml
provider:
    # ...
    apiGateway:
        binaryMediaTypes:
            - '*/*'
    environment:
        BREF_BINARY_RESPONSES: 1
```

I wish things could be made simpler, but I cannot see a reliable way out of this. I am thinking of making the Serverless plugin take care of that later (auto-defining the environment variable), but first let's fix the issue.