### PR TITLE
Improve error message when returning binary responses

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -245,7 +245,10 @@ final class LambdaRuntime
     {
         $jsonData = json_encode($data);
         if ($jsonData === false) {
-            throw new \Exception('Failed encoding Lambda JSON response: ' . json_last_error_msg());
+            throw new \Exception(sprintf(
+                "The Lambda response cannot be encoded to JSON.\nThis error usually happens when you try to return binary content. If you are writing a HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses\nHere is the original JSON error: '%s'",
+                json_last_error_msg()
+            ));
         }
 
         if ($this->returnHandler === null) {

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -194,7 +194,7 @@ class LambdaRuntimeTest extends TestCase
         $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/1/error', $eventFailureLog->getUri()->__toString());
 
         $error = json_decode((string) $eventFailureLog->getBody());
-        $this->expectOutputRegex('/^Fatal error: Uncaught Exception: Failed encoding Lambda JSON response: Malformed UTF-8 characters, possibly incorrectly encoded/');
-        $this->assertSame('Failed encoding Lambda JSON response: Malformed UTF-8 characters, possibly incorrectly encoded', $error->errorMessage);
+        $this->expectOutputRegex('/^Fatal error: Uncaught Exception: The Lambda response cannot be encoded to JSON/');
+        $this->assertSame("The Lambda response cannot be encoded to JSON.\nThis error usually happens when you try to return binary content. If you are writing a HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses\nHere is the original JSON error: 'Malformed UTF-8 characters, possibly incorrectly encoded'", $error->errorMessage);
     }
 }


### PR DESCRIPTION
Following #505 I want to help users understand the error when trying to return a binary response for the first time.

Here is the new error message:

> Fatal error: Uncaught Exception: The Lambda response cannot be encoded to JSON.
> This error usually happens when you try to return binary content. If you are writing a HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses
Here is the original JSON error: 'Malformed UTF-8 characters, possibly incorrectly encoded' in /var/task/src/Runtime/LambdaRuntime.php:248


