### PR TITLE
Fix #146 Make layers lighter by preserving symlinks

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -10,11 +10,12 @@ layers: export/console.zip export/php-72.zip export/php-73.zip export/php-74.zip
 
 # The PHP runtimes
 export/php%.zip: docker-images
-	PHP_VERSION=$$(echo $@ | cut -d'/' -f 2 | cut -d'.' -f 1);\
-	rm -f $@;\
-	mkdir export/tmp ; cd export/tmp ;\
-	docker run --entrypoint "tar" bref/$$PHP_VERSION:latest -ch -C /opt .  |tar -x;zip --quiet --recurse-paths ../$$PHP_VERSION.zip . ;
-	rm -rf export/tmp
+	PHP_VERSION=$$(echo $@ | cut -d'/' -f 2 | cut -d'.' -f 1); \
+	rm -f $@; \
+	docker volume create bref-export; \
+	docker run --rm -v bref-export:/opt --entrypoint echo bref/$$PHP_VERSION ""; \
+	docker run --rm -v bref-export:/layer -v $$PWD/export:/export -it kramos/alpine-zip --quiet --recurse-paths --symlinks /export/$$PHP_VERSION.zip /layer
+	docker volume rm bref-export
 
 # The console runtime
 export/console.zip: layers/console/bootstrap


### PR DESCRIPTION
This change avoids symlinks to be flattened in the AWS Lambda layers.

That means that symlinks are no longer replaced by the file they point to. Those files are not duplicated anymore.

This makes the layer about twice lighter!

Here is a comparison of the zip files (before/after):

<img width="541" alt="Capture d’écran 2019-11-23 à 00 12 33" src="https://user-images.githubusercontent.com/720328/69478520-c580fb80-0df3-11ea-9161-5388c53a1ef6.png">
<img width="533" alt="Capture d’écran 2019-11-23 à 13 19 42" src="https://user-images.githubusercontent.com/720328/69478545-f3664000-0df3-11ea-9a83-01f54259796a.png">

And when unzipped:

<img width="171" alt="Capture d’écran 2019-11-23 à 00 12 53" src="https://user-images.githubusercontent.com/720328/69478519-c4e86500-0df3-11ea-93f7-95c586326080.png">

This is good news because:

- this leaves more room to the application code for the 250Mb of space available on disk on Lambda
- this leaves more room for the 50Mb max zip size for the whole application
- smaller layers mean faster cold start: it would be great to measure if we see an improvement

TODO:

- [ ] test on AWS Lambda
- [ ] test with `serverless invoke local`
- ❎ test with the "runtimes" test suite in Bref