### PR TITLE
Tag docker images when tag on Github

### DIFF
--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -1,0 +1,32 @@
+name: Deploy Docker images
+
+on:
+  push:
+    tags:
+      - '*' # On all tags
+
+jobs:
+  publish:
+    name: Building images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Docker login
+        run: echo '${{ secrets.DOCKER_PASSWORD }}' | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+
+      - name: Build base image
+        run: cd runtime && make docker-base-image
+
+      - name: Build images
+        run: make docker-images
+
+      - name: Publish
+        env:
+          DOCKER_TAG: ${{ steps.get_version.outputs.VERSION }}
+        run: make publish-docker-images

--- a/.github/workflows/deploy-docker.yml
+++ b/.github/workflows/deploy-docker.yml
@@ -20,9 +20,6 @@ jobs:
       - name: Docker login
         run: echo '${{ secrets.DOCKER_PASSWORD }}' | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
 
-      - name: Build base image
-        run: cd runtime && make docker-base-image
-
       - name: Build images
         run: make docker-images
 

--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,30 @@
 
 # Build the PHP runtimes
 runtimes:
-	cd runtime && make publish
+	cd runtime ; make publish
 
+# Build all docker images
 docker-images:
-	cd runtime && make docker-images
-	docker push bref/php-72:latest
-	docker push bref/php-72-fpm:latest
-	docker push bref/php-72-fpm-dev:latest
-	docker push bref/php-73:latest
-	docker push bref/php-73-fpm:latest
-	docker push bref/php-73-fpm-dev:latest
-	docker push bref/php-74:latest
-	docker push bref/php-74-fpm:latest
-	docker push bref/php-74-fpm-dev:latest
-	docker push bref/build-php-72:latest
-	docker push bref/build-php-73:latest
-	docker push bref/build-php-74:latest
-	docker push bref/fpm-dev-gateway:latest
+	cd runtime ; make docker-images
+
+# Publish doocker images
+publish-docker-images: docker-images
+	ifndef DOCKER_TAG
+	$(error DOCKER_TAG is not set)
+	endif
+
+	for image in \
+	  "bref/php-72" "bref/php-72-fpm" "bref/php-72-fpm-dev" \
+	  "bref/php-73" "bref/php-73-fpm" "bref/php-73-fpm-dev" \
+	  "bref/php-74" "bref/php-74-fpm" "bref/php-74-fpm-dev" \
+	  "bref/build-php-72" \
+	  "bref/build-php-73" \
+	  "bref/build-php-74" \
+	  "bref/fpm-dev-gateway"; \
+	  do \
+      docker tag $$image:latest $$image:${DOCKER_TAG} ; \
+      docker push $$image ; \
+  done
 
 # Generate and deploy the production version of the website using http://couscous.io
 website:

--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,9 @@ docker-images:
 
 # Publish doocker images
 publish-docker-images: docker-images
-	ifndef DOCKER_TAG
-	$(error DOCKER_TAG is not set)
-	endif
+    # Make sure we have defined the docker tag
+	(test $(DOCKER_TAG)) && echo "Tagging images with \"${DOCKER_TAG}\"" || echo "You have to define environemnt variable DOCKER_TAG"
+	test $(DOCKER_TAG)
 
 	for image in \
 	  "bref/php-72" "bref/php-72-fpm" "bref/php-72-fpm-dev" \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -21,10 +21,12 @@ export/console.zip: layers/console/bootstrap
 	rm -f export/console.zip
 	cd layers/console && zip ../../export/console.zip bootstrap
 
-# Build Docker images
-docker-images:
+docker-base-image:
 	# Build the base environment (without PHP)
 	cd base ; docker build --file base.Dockerfile -t bref/tmp/step-1/build-environment .
+
+# Build Docker images
+docker-images: docker-base-image
 	# Build the `bref/build-php-XX` images
 	# (build only the first `FROM` section of the Dockerfile)
 	cd base ; docker build --file php-72.Dockerfile -t bref/build-php-72 --target build-environment .

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -21,12 +21,10 @@ export/console.zip: layers/console/bootstrap
 	rm -f export/console.zip
 	cd layers/console && zip ../../export/console.zip bootstrap
 
-docker-base-image:
+# Build Docker images
+docker-images:
 	# Build the base environment (without PHP)
 	cd base ; docker build --file base.Dockerfile -t bref/tmp/step-1/build-environment .
-
-# Build Docker images
-docker-images: docker-base-image
 	# Build the `bref/build-php-XX` images
 	# (build only the first `FROM` section of the Dockerfile)
 	cd base ; docker build --file php-72.Dockerfile -t bref/build-php-72 --target build-environment .


### PR DESCRIPTION
This PR make sure to tag and push docker images when we tag a release on Github. 

Before this is merged we need to update the "secure" environment variable in .travis.yaml. @mnapoli can you run the followng command and add the result to this PR? 

(From https://docs.travis-ci.com/user/encryption-keys/)

```
travis encrypt DOCKER_USERNAME=foo DOCKER_PASSWORD=bar -r brefphp/bref
```

I've tested this on my fork. See [the release](https://github.com/Nyholm/bref/releases/tag/47.11.13),  the [Travis job](https://travis-ci.org/Nyholm/bref/builds/627436966). It is only build on tags.

When I tested this I used a [different branch](https://github.com/Nyholm/bref/tree/tag-nyholm) on my fork because I wanted to test to build and push docker images. 