### PR TITLE
Use PHP 7.4.2

### DIFF
--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=7.4.0
+ENV VERSION_PHP=7.4.2
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php


### PR DESCRIPTION
PHP 7.4.2 will be released the 23rd of Januari. It contains some bugfixes that allow us to use preloading on an actual project. 

I am super excited to try it out. I've actually already started writing a blog post about it. Could we please merge this PR after PHP 7.4.2 is released so I can finish my blog post and brag about performance on Lambda?