### PR TITLE
Fixed Query String encoding issues when using ALB

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -163,6 +163,17 @@ final class HttpRequestEvent implements LambdaEvent
             return '';
         }
 
+        $queryStringParameters = [];
+
+        foreach ($this->event['queryStringParameters'] as $key => $value) {
+            \parse_str("{$key}={$value}", $params);
+
+            $queryStringParameters = \array_merge_recursive(
+                $queryStringParameters,
+                $params
+            );
+        }
+
         /*
          * Watch out: do not use $event['queryStringParameters'] directly!
          *
@@ -172,7 +183,7 @@ final class HttpRequestEvent implements LambdaEvent
          * ?array[key]=value gives ['array[key]' => 'value'] while we want ['array' => ['key' = > 'value']]
          * In that case we should recreate the original query string and use parse_str which handles correctly arrays
          */
-        return http_build_query($this->event['queryStringParameters']);
+        return http_build_query($queryStringParameters);
     }
 
     private function extractHeaders(): array

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -69,8 +69,27 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
                 'val2' => ['bar'],
             ],
         ]);
-        $this->assertQueryString('vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar');
-        $this->assertUri('/path?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar');
+        $this->assertQueryString('vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar');
+        $this->assertUri('/path?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar');
+    }
+
+    public function test request with encoded query string()
+    {
+        $this->fromFixture(__DIR__ . '/Fixture/apigateway-query-string-encoded.json');
+
+        $this->assertQueryParameters(
+            [
+                'vars' => [
+                    'val1' => 'foo bar',
+                    'val2' => [
+                        0 => 'b a z',
+                    ],
+                ],
+            ]
+        );
+
+        $this->assertQueryString('vars%5Bval1%5D=foo+bar&vars%5Bval2%5D%5B0%5D=b+a+z');
+        $this->assertUri('/path?vars%5Bval1%5D=foo+bar&vars%5Bval2%5D%5B0%5D=b+a+z');
     }
 
     public function test request with custom header()

--- a/tests/Event/Http/Fixture/apigateway-query-string-encoded.json
+++ b/tests/Event/Http/Fixture/apigateway-query-string-encoded.json
@@ -1,0 +1,54 @@
+{
+    "resource": "/path",
+    "path": "/path",
+    "httpMethod": "GET",
+    "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Cache-Control": "no-cache",
+        "Host": "example.org",
+        "User-Agent": "PostmanRuntime/7.20.1",
+        "X-Amzn-Trace-Id": "Root=1-ffffffff-ffffffffffffffffffffffff",
+        "X-Forwarded-For": "1.1.1.1",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "queryStringParameters": {
+        "vars%5Bval1%5D": "foo%20bar",
+        "vars%5Bval2%5D%5B0%5D": "b%20a%20z"
+    },
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "xxxxxx",
+        "resourcePath": "/path",
+        "httpMethod": "PUT",
+        "extendedRequestId": "XXXXXX-xxxxxxxx=",
+        "requestTime": "24/Nov/2019:18:55:08 +0000",
+        "path": "/path",
+        "accountId": "123400000000",
+        "protocol": "HTTP/1.1",
+        "stage": "dev",
+        "domainPrefix": "dev",
+        "requestTimeEpoch": 1574621708700,
+        "requestId": "ffffffff-ffff-4fff-ffff-ffffffffffff",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "1.1.1.1",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "PostmanRuntime/7.20.1",
+            "user": null
+        },
+        "domainName": "example.org",
+        "apiId": "xxxxxxxxxx"
+    },
+    "body": "",
+    "isBase64Encoded": false
+}

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -203,11 +203,11 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 ],
             ],
             '$_SERVER' => [
-                'REQUEST_URI' => '/?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar',
+                'REQUEST_URI' => '/?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar',
                 'PHP_SELF' => '/',
                 'PATH_INFO' => '/',
                 'REQUEST_METHOD' => 'GET',
-                'QUERY_STRING' => 'vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar',
+                'QUERY_STRING' => 'vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_CONTEXT' => '[]',


### PR DESCRIPTION
Because there is an issue with query string encoding when using ALB.

https://github.com/brefphp/bref/issues/456
