### PR TITLE
Rebase: Expose the request context in the FPM layer via a global variable

### DIFF
--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -179,7 +179,7 @@ final class FpmHandler extends HttpHandler
         $request->setServerPort($event->getServerPort());
         $request->setCustomVar('PATH_INFO', $event->getPath());
         $request->setCustomVar('QUERY_STRING', $event->getQueryString());
-        $request->setCustomVar('REQUEST_CONTEXT', json_encode($event->getRequestContext()));
+        $request->setCustomVar('LAMBDA_CONTEXT', json_encode($event->getRequestContext()));
 
         $contentType = $event->getContentType();
         if ($contentType) {

--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -179,9 +179,8 @@ final class FpmHandler extends HttpHandler
         $request->setServerPort($event->getServerPort());
         $request->setCustomVar('PATH_INFO', $event->getPath());
         $request->setCustomVar('QUERY_STRING', $event->getQueryString());
-        if ($event['requestContext'] ?? false) {
-            $this->setArrayValue('REQUEST_CONTEXT', $event['requestContext'], $request);
-        }
+        $request->setCustomVar('REQUEST_CONTEXT', json_encode($event->getRequestContext()));
+
         $contentType = $event->getContentType();
         if ($contentType) {
             $request->setContentType($contentType);
@@ -273,25 +272,5 @@ final class FpmHandler extends HttpHandler
         }
 
         return array_change_key_case($responseHeaders, CASE_LOWER);
-    }
-
-    /**
-     * Recursively loop through a data object and create env variables
-     */
-    private function setArrayValue(string $name, array $array, FastCgiRequest $request): void
-    {
-        if (! is_array($array)) {
-            $request->setCustomVar(strtoupper($name), $array);
-        }
-
-        foreach ($array as $key => $value) {
-            if (! is_array($value)) {
-                $request->setCustomVar(strtoupper($name . '_' . $key), $value);
-            }
-
-            if (is_array($value)) {
-                $this->setArrayValue(strtoupper($name . '_' . $key), $value, $request);
-            }
-        }
     }
 }

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -118,6 +118,11 @@ final class HttpRequestEvent implements LambdaEvent
         return $query;
     }
 
+    public function getRequestContext(): array
+    {
+        return $this->event['requestContext'] ?? [];
+    }
+
     public function getCookies(): array
     {
         if (! isset($this->headers['cookie'])) {

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -50,7 +50,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '{"protocol":"HTTP\/1.1"}',
+                'LAMBDA_CONTEXT' => '{"protocol":"HTTP\/1.1"}',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -86,7 +86,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar&bim=baz',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -124,7 +124,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -170,7 +170,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '{"foo":"baz","baz":"far","data":{"recurse1":1,"recurse2":2}}',
+                'LAMBDA_CONTEXT' => '{"foo":"baz","baz":"far","data":{"recurse1":1,"recurse2":2}}',
             ],
             'HTTP_RAW_BODY' => '',
 
@@ -210,7 +210,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -240,7 +240,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'HTTP_X_MY_HEADER' => 'Hello world',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -273,7 +273,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'HTTP_X_MY_HEADER' => 'Hello world',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -305,7 +305,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '14',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '"Hello world!"',
         ]);
@@ -342,7 +342,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'HTTP_CONTENT_LENGTH' => '15',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => 'foo=bar&bim=baz',
         ]);
@@ -394,7 +394,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '14',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '"Hello world!"',
         ]);
@@ -427,7 +427,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'text/plain; charset=UTF-8',
                 'HTTP_CONTENT_LENGTH' => '10',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => 'Hello 🌍',
         ]);
@@ -460,7 +460,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '2',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '{}',
         ]);
@@ -508,7 +508,7 @@ baz\r
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'multipart/form-data; boundary=testBoundary',
                 'HTTP_CONTENT_LENGTH' => '152',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -564,7 +564,7 @@ Content-Disposition: form-data; name=\"delete[categories][]\"\r
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'multipart/form-data; boundary=testBoundary',
                 'HTTP_CONTENT_LENGTH' => '186',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -597,7 +597,7 @@ Content-Disposition: form-data; name=\"delete[categories][]\"\r
                 'HTTP_COOKIE' => 'tz=Europe%2FParis; four=two; theme=light',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -660,7 +660,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'multipart/form-data; boundary=testBoundary',
                 'HTTP_CONTENT_LENGTH' => '323',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -697,7 +697,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'HTTP_CONTENT_LENGTH' => '7',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => 'foo=bar',
         ]);
@@ -727,7 +727,7 @@ Year,Make,Model
                 'HTTP_HOST' => 'www.example.com',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -752,7 +752,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -777,7 +777,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -802,7 +802,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -827,7 +827,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT' => '[]',
+                'LAMBDA_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -50,7 +50,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT_PROTOCOL' => 'HTTP/1.1',
+                'REQUEST_CONTEXT' => '{"protocol":"HTTP\/1.1"}',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -86,6 +86,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar&bim=baz',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -123,6 +124,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -168,10 +170,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'foo=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
-                'REQUEST_CONTEXT_FOO' => 'baz',
-                'REQUEST_CONTEXT_BAZ' => 'far',
-                'REQUEST_CONTEXT_DATA_RECURSE1' => 1,
-                'REQUEST_CONTEXT_DATA_RECURSE2' => 2,
+                'REQUEST_CONTEXT' => '{"foo":"baz","baz":"far","data":{"recurse1":1,"recurse2":2}}',
             ],
             'HTTP_RAW_BODY' => '',
 
@@ -211,6 +210,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => 'vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -240,6 +240,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'HTTP_X_MY_HEADER' => 'Hello world',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -272,6 +273,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'HTTP_X_MY_HEADER' => 'Hello world',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -303,6 +305,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '14',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '"Hello world!"',
         ]);
@@ -339,6 +342,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'HTTP_CONTENT_LENGTH' => '15',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => 'foo=bar&bim=baz',
         ]);
@@ -390,6 +394,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '14',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '"Hello world!"',
         ]);
@@ -422,6 +427,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'text/plain; charset=UTF-8',
                 'HTTP_CONTENT_LENGTH' => '10',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => 'Hello 🌍',
         ]);
@@ -454,6 +460,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/json',
                 'HTTP_CONTENT_LENGTH' => '2',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '{}',
         ]);
@@ -501,6 +508,7 @@ baz\r
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'multipart/form-data; boundary=testBoundary',
                 'HTTP_CONTENT_LENGTH' => '152',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -556,6 +564,7 @@ Content-Disposition: form-data; name=\"delete[categories][]\"\r
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'multipart/form-data; boundary=testBoundary',
                 'HTTP_CONTENT_LENGTH' => '186',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -588,6 +597,7 @@ Content-Disposition: form-data; name=\"delete[categories][]\"\r
                 'HTTP_COOKIE' => 'tz=Europe%2FParis; four=two; theme=light',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -650,6 +660,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'multipart/form-data; boundary=testBoundary',
                 'HTTP_CONTENT_LENGTH' => '323',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -686,6 +697,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'HTTP_CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'HTTP_CONTENT_LENGTH' => '7',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => 'foo=bar',
         ]);
@@ -715,6 +727,7 @@ Year,Make,Model
                 'HTTP_HOST' => 'www.example.com',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -739,6 +752,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -763,6 +777,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -787,6 +802,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -811,6 +827,7 @@ Year,Make,Model
                 'QUERY_STRING' => '',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);


### PR DESCRIPTION
Rebased #501, used JSON instead of adding many global variables. 

It is not possible to add an array, because it needs to be serialised and sent to PHP FPM. 

This will fix #506 and fix #500