### PR TITLE
Add event and context to the Psr15Handler request

### DIFF
--- a/src/Event/Http/Psr15Handler.php
+++ b/src/Event/Http/Psr15Handler.php
@@ -18,6 +18,8 @@ class Psr15Handler extends HttpHandler
     public function handleRequest(HttpRequestEvent $event, Context $context): HttpResponse
     {
         $request = Psr7RequestFactory::fromEvent($event);
+        $request = $request->withAttribute('lambdaEvent', $event);
+        $request = $request->withAttribute('lambdaContext', $context);
 
         $response = $this->psr15Handler->handle($request);
 

--- a/src/Event/Http/Psr15Handler.php
+++ b/src/Event/Http/Psr15Handler.php
@@ -18,8 +18,8 @@ class Psr15Handler extends HttpHandler
     public function handleRequest(HttpRequestEvent $event, Context $context): HttpResponse
     {
         $request = Psr7RequestFactory::fromEvent($event);
-        $request = $request->withAttribute('lambdaEvent', $event);
-        $request = $request->withAttribute('lambdaContext', $context);
+        $request = $request->withAttribute('lambda-event', $event);
+        $request = $request->withAttribute('lambda-context', $context);
 
         $response = $this->psr15Handler->handle($request);
 

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -4,6 +4,7 @@ namespace Bref\Test\Runtime;
 
 use Bref\Context\Context;
 use Bref\Event\Handler;
+use Bref\Event\Http\HttpRequestEvent;
 use Bref\Event\S3\S3Event;
 use Bref\Event\S3\S3Handler;
 use Bref\Event\Sqs\SqsEvent;
@@ -241,6 +242,8 @@ class LambdaRuntimeTest extends TestCase
 
         $this->assertEquals('GET', $handler->request->getMethod());
         $this->assertEquals('/path', (string) $handler->request->getUri());
+        $this->assertInstanceOf(HttpRequestEvent::class, $handler->request->getAttribute('lambda-event'));
+        $this->assertInstanceOf(Context::class, $handler->request->getAttribute('lambda-context'));
         $this->assertInvocationResult([
             'isBase64Encoded' => false,
             'statusCode' => 200,


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
This adds the event and context objects to the request object.

When using a custom authorizer, for example, I need access to the array located at `$event["requestContext"]["authorizer"]`. This allows me to fetch the `HttpRequestEvent` from the `ServerRequestInterface` object to get the request metadata.