### PR TITLE
Fix error reporting configuration for PHP 7.4

### DIFF
--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -2,6 +2,11 @@
 ; errors will be output in the HTTP response
 display_errors=0
 
+; Since PHP 7.4 the default value is E_ALL
+; We override it to set the recommended configuration value for production.
+; See https://github.com/php/php-src/blob/d91abf76e01a3c39424e8192ad049f473f900936/php.ini-production#L463
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
+
 memory_limit=3008M
 
 opcache.enable=1

--- a/runtime/layers/function/php.ini
+++ b/runtime/layers/function/php.ini
@@ -1,4 +1,10 @@
+; On the CLI we want errors to be sent to stdout -> those will end up in CloudWatch
 display_errors=1
+
+; Since PHP 7.4 the default value is E_ALL
+; We override it to set the recommended configuration value for production.
+; See https://github.com/php/php-src/blob/d91abf76e01a3c39424e8192ad049f473f900936/php.ini-production#L463
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 
 memory_limit=3008M
 


### PR DESCRIPTION
Since PHP 7.4 the default value is E_ALL.

We override it to set the recommended configuration value for production.

See https://github.com/php/php-src/blob/d91abf76e01a3c39424e8192ad049f473f900936/php.ini-production#L463