### PR TITLE
Add welcome screen when creating the first lambda

### DIFF
--- a/template/http/index.php
+++ b/template/http/index.php
@@ -1,3 +1,26 @@
 <?php
 
-echo 'Hello world!';
+// This is a PHP file example.
+// Replace it with your application.
+
+// Below is a welcome page written in HTML.
+
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Welcome!</title>
+    <link href="https://fonts.googleapis.com/css?family=Dosis:300&display=swap" rel="stylesheet">
+    <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="flex h-screen">
+    <div class="rounded-full mx-auto self-center relative" style="height: 400px; width: 400px; background: linear-gradient(123.19deg, #266488 3.98%, #258ECB 94.36%)">
+        <h1 class="font-light absolute w-full text-center text-blue-200" style="font-family: Dosis; font-size: 45px; top: 35%">Hello there,</h1>
+        <div class="w-full relative absolute" style="top: 60%; height: 50%">
+            <div class="absolute inset-x-0 bg-white" style="bottom: 0; height: 55%"></div>
+            <svg viewBox="0 0 1280 311" fill="none" xmlns="http://www.w3.org/2000/svg"><g clip-path="url(#clip0)"><path d="M1214 177L1110.5 215.5L943.295 108.5L807.5 168.5L666 66.5L581 116L517 49.5L288.5 184L163.5 148L-34.5 264.5V311H1317V258.5L1214 177Z" fill="white"/><path d="M1214 177L1110.5 215.5L943.295 108.5L807.5 168.5L666 66.5L581 116L517 49.5L288.5 184L163.5 148L-34.5 264.5L163.5 161L275 194L230.5 281.5L311 189L517 61L628 215.5L600 132.5L666 77L943.295 295L833 184L943.295 116L1172 275L1121 227L1214 189L1298 248L1317 258.5L1214 177Z" fill="#DCEFFA"/></g><defs><clipPath id="clip0"><rect width="1280" height="311" fill="white"/></clipPath></defs></svg>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This PR replaces the example HTTP lambda that is deployed when getting started with Bref.

Currently, the HTTP lambda displays `Hello world` without any formatting.

With this PR, the lambda will display a nicer page showing this:

<img width="711" alt="Capture d’écran 2020-01-31 à 22 41 27" src="https://user-images.githubusercontent.com/720328/73576507-e3657f00-447a-11ea-8e0c-a35d8e62be51.png">

Hopefully deploying our first lambda will feel more like a "win" ;)