### PR TITLE
Refactor the PSR-7 logic

### DIFF
--- a/src/Event/Http/HttpResponse.php
+++ b/src/Event/Http/HttpResponse.php
@@ -4,8 +4,6 @@ namespace Bref\Event\Http;
 
 /**
  * Formats the response expected by AWS Lambda and the API Gateway integration.
- *
- * @internal
  */
 final class HttpResponse
 {

--- a/src/Event/Http/HttpResponse.php
+++ b/src/Event/Http/HttpResponse.php
@@ -2,8 +2,6 @@
 
 namespace Bref\Event\Http;
 
-use Psr\Http\Message\ResponseInterface;
-
 /**
  * Formats the response expected by AWS Lambda and the API Gateway integration.
  *
@@ -20,48 +18,40 @@ final class HttpResponse
     /** @var string */
     private $body;
 
-    public function __construct(string $body, array $headers, int $statusCode = 200)
+    public function __construct(string $body, array $headers = [], int $statusCode = 200)
     {
         $this->body = $body;
         $this->headers = $headers;
         $this->statusCode = $statusCode;
     }
 
-    public static function fromPsr7Response(ResponseInterface $response): self
-    {
-        // The lambda proxy integration does not support arrays in headers
-        $headers = [];
-        foreach ($response->getHeaders() as $name => $values) {
-            // See https://github.com/zendframework/zend-diactoros/blob/754a2ceb7ab753aafe6e3a70a1fb0370bde8995c/src/Response/SapiEmitterTrait.php#L96
-            $name = str_replace('-', ' ', $name);
-            $name = ucwords($name);
-            $name = str_replace(' ', '-', $name);
-            foreach ($values as $value) {
-                $headers[$name] = $value;
-            }
-        }
-
-        $response->getBody()->rewind();
-        $body = $response->getBody()->getContents();
-
-        return new self($body, $headers, $response->getStatusCode());
-    }
-
     public function toApiGatewayFormat(bool $multiHeaders = false): array
     {
         $base64Encoding = (bool) getenv('BREF_BINARY_RESPONSES');
 
+        $headers = [];
+        foreach ($this->headers as $name => $values) {
+            // Capitalize header keys
+            // See https://github.com/zendframework/zend-diactoros/blob/754a2ceb7ab753aafe6e3a70a1fb0370bde8995c/src/Response/SapiEmitterTrait.php#L96
+            $name = str_replace('-', ' ', $name);
+            $name = ucwords($name);
+            $name = str_replace(' ', '-', $name);
+
+            if ($multiHeaders) {
+                // Make sure the values are always arrays
+                $headers[$name] = is_array($values) ? $values : [$values];
+            } else {
+                // Make sure the values are never arrays
+                $headers[$name] = is_array($values) ? end($values) : $values;
+            }
+        }
+
         // The headers must be a JSON object. If the PHP array is empty it is
         // serialized to `[]` (we want `{}`) so we force it to an empty object.
-        $headers = empty($this->headers) ? new \stdClass : $this->headers;
+        $headers = empty($headers) ? new \stdClass : $headers;
 
         // Support for multi-value headers
         $headersKey = $multiHeaders ? 'multiValueHeaders' : 'headers';
-        if ($multiHeaders) {
-            $headers = array_map(function ($value): array {
-                return is_array($value) ? $value : [$value];
-            }, $headers);
-        }
 
         // This is the format required by the AWS_PROXY lambda integration
         // See https://stackoverflow.com/questions/43708017/aws-lambda-api-gateway-error-malformed-lambda-proxy-response

--- a/src/Event/Http/Psr15Handler.php
+++ b/src/Event/Http/Psr15Handler.php
@@ -17,12 +17,10 @@ class Psr15Handler extends HttpHandler
 
     public function handleRequest(HttpRequestEvent $event, Context $context): HttpResponse
     {
-        $request = Psr7RequestFactory::fromEvent($event);
-        $request = $request->withAttribute('lambda-event', $event);
-        $request = $request->withAttribute('lambda-context', $context);
+        $request = Psr7Bridge::convertRequest($event, $context);
 
         $response = $this->psr15Handler->handle($request);
 
-        return HttpResponse::fromPsr7Response($response);
+        return Psr7Bridge::convertResponse($response);
     }
 }

--- a/tests/Event/Http/HttpResponseTest.php
+++ b/tests/Event/Http/HttpResponseTest.php
@@ -4,8 +4,6 @@ namespace Bref\Test\Event\Http;
 
 use Bref\Event\Http\HttpResponse;
 use PHPUnit\Framework\TestCase;
-use Zend\Diactoros\Response\EmptyResponse;
-use Zend\Diactoros\Response\JsonResponse;
 
 class HttpResponseTest extends TestCase
 {
@@ -27,30 +25,30 @@ class HttpResponseTest extends TestCase
         ], $response->toApiGatewayFormat());
     }
 
-    public function test I can create a response from a PSR7 response()
+    public function test headers are capitalized()
     {
-        $psr7Response = new JsonResponse(['foo' => 'bar'], 404);
+        $response = new HttpResponse('', [
+            'x-foo-bar' => 'baz',
+        ]);
 
-        $response = HttpResponse::fromPsr7Response($psr7Response);
-        self::assertSame([
+        self::assertEquals([
             'isBase64Encoded' => false,
-            'statusCode' => 404,
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
-            'body' => json_encode(['foo' => 'bar']),
+            'statusCode' => 200,
+            'headers' => ['X-Foo-Bar' => 'baz'],
+            'body' => '',
         ], $response->toApiGatewayFormat());
     }
 
     public function test nested arrays in headers are flattened()
     {
-        $psr7Response = new EmptyResponse;
-        $psr7Response = $psr7Response->withHeader('foo', ['bar', 'baz']);
+        $response = new HttpResponse('', [
+            'foo' => ['bar', 'baz'],
+        ]);
 
-        $response = HttpResponse::fromPsr7Response($psr7Response);
-        self::assertSame([
+        self::assertEquals([
             'isBase64Encoded' => false,
-            'statusCode' => 204,
+            'statusCode' => 200,
+            // The last value is kept (when multiheaders are not enabled)
             'headers' => ['Foo' => 'baz'],
             'body' => '',
         ], $response->toApiGatewayFormat());
@@ -58,10 +56,10 @@ class HttpResponseTest extends TestCase
 
     public function test empty headers are considered objects()
     {
-        $response = HttpResponse::fromPsr7Response(new EmptyResponse);
+        $response = new HttpResponse('');
 
         // Make sure that the headers are `"headers":{}` (object) and not `"headers":[]` (array)
-        self::assertEquals('{"isBase64Encoded":false,"statusCode":204,"headers":{},"body":""}', json_encode($response->toApiGatewayFormat()));
+        self::assertEquals('{"isBase64Encoded":false,"statusCode":200,"headers":{},"body":""}', json_encode($response->toApiGatewayFormat()));
     }
 
     /**
@@ -69,13 +67,12 @@ class HttpResponseTest extends TestCase
      */
     public function test header values are forced as arrays for multiheaders()
     {
-        $psr7Response = new EmptyResponse;
-        $psr7Response = $psr7Response->withHeader('foo', 'bar');
-
-        $response = HttpResponse::fromPsr7Response($psr7Response);
+        $response = new HttpResponse('', [
+            'foo' => 'bar',
+        ]);
         self::assertEquals([
             'isBase64Encoded' => false,
-            'statusCode' => 204,
+            'statusCode' => 200,
             'multiValueHeaders' => [
                 'Foo' => ['bar'],
             ],

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -859,11 +859,11 @@ Year,Make,Model
             'httpMethod' => 'GET',
         ]);
 
-        self::assertStringStartsWith('PHP/', $response['headers']['x-powered-by'] ?? '');
-        unset($response['headers']['x-powered-by']);
+        self::assertStringStartsWith('PHP/', $response['headers']['X-Powered-By'] ?? '');
+        unset($response['headers']['X-Powered-By']);
         self::assertEquals([
-            'content-type' => 'application/json',
-            'x-multivalue' => 'bar',
+            'Content-Type' => 'application/json',
+            'X-Multivalue' => 'bar',
         ], $response['headers']);
     }
 
@@ -874,17 +874,17 @@ Year,Make,Model
             'multiValueHeaders' => [],
         ]);
 
-        self::assertStringStartsWith('PHP/', $response['multiValueHeaders']['x-powered-by'][0] ?? '');
-        unset($response['multiValueHeaders']['x-powered-by']);
+        self::assertStringStartsWith('PHP/', $response['multiValueHeaders']['X-Powered-By'][0] ?? '');
+        unset($response['multiValueHeaders']['X-Powered-By']);
         self::assertEquals([
-            'content-type' => ['application/json'],
-            'x-multivalue' => ['foo', 'bar'],
+            'Content-Type' => ['application/json'],
+            'X-Multivalue' => ['foo', 'bar'],
         ], $response['multiValueHeaders']);
     }
 
     public function test response with cookies()
     {
-        $cookieHeader = $this->get('cookies.php')['headers']['set-cookie'];
+        $cookieHeader = $this->get('cookies.php')['headers']['Set-Cookie'];
 
         self::assertEquals('MyCookie=MyValue; expires=Fri, 12-Jan-2018 08:32:03 GMT; Max-Age=0; path=/hello/; domain=example.com; secure; HttpOnly', $cookieHeader);
     }
@@ -894,7 +894,7 @@ Year,Make,Model
         $cookieHeader = $this->get('cookies.php', [
             'httpMethod' => 'GET',
             'multiValueHeaders' => [],
-        ])['multiValueHeaders']['set-cookie'];
+        ])['multiValueHeaders']['Set-Cookie'];
 
         self::assertEquals('MyCookie=FirstValue; expires=Fri, 12-Jan-2018 08:32:03 GMT; Max-Age=0; path=/hello/; domain=example.com; secure; HttpOnly', $cookieHeader[0]);
         self::assertEquals('MyCookie=MyValue; expires=Fri, 12-Jan-2018 08:32:03 GMT; Max-Age=0; path=/hello/; domain=example.com; secure; HttpOnly', $cookieHeader[1]);
@@ -904,10 +904,10 @@ Year,Make,Model
     {
         $response = $this->get('error.php');
 
-        self::assertStringStartsWith('PHP/', $response['headers']['x-powered-by'] ?? '');
-        unset($response['headers']['x-powered-by']);
+        self::assertStringStartsWith('PHP/', $response['headers']['X-Powered-By'] ?? '');
+        unset($response['headers']['X-Powered-By']);
         self::assertEquals([
-            'content-type' => 'text/html; charset=UTF-8',
+            'Content-Type' => 'text/html; charset=UTF-8',
         ], $response['headers']);
     }
 


### PR DESCRIPTION
Logic related to PSR-7 and PSR-15 handlers was spread across multiple classes.

Because of that, some HTTP logic was applied to PHP-FPM but not to PSR-15 handlers, and vice-versa.

This PR:

- regroups global HTTP response logic into the `HttpResponse` class
- regroups PSR-7 related logic into a new `Psr7Bridge` class
- makes the `HttpResponse` class non-internal (because it can now be used by HTTP event handlers)