### PR TITLE
Adds suport for custom vendor autoloading

### DIFF
--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -8,8 +8,13 @@ error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
-/** @noinspection PhpIncludeInspection */
-require $appRoot . '/vendor/autoload.php';
+if (getenv('BREF_CUSTOM_AUTOLOAD')) {
+    /** @noinspection PhpIncludeInspection */
+    require getenv('BREF_CUSTOM_AUTOLOAD');
+} else {
+    /** @noinspection PhpIncludeInspection */
+    require $appRoot . '/vendor/autoload.php';
+}
 
 $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 

--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -8,9 +8,9 @@ error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
-if (getenv('BREF_CUSTOM_AUTOLOAD')) {
+if (getenv('BREF_AUTOLOAD_PATH')) {
     /** @noinspection PhpIncludeInspection */
-    require getenv('BREF_CUSTOM_AUTOLOAD');
+    require getenv('BREF_AUTOLOAD_PATH');
 } else {
     /** @noinspection PhpIncludeInspection */
     require $appRoot . '/vendor/autoload.php';

--- a/runtime/layers/fpm/bootstrap
+++ b/runtime/layers/fpm/bootstrap
@@ -9,9 +9,9 @@ error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
-if (getenv('BREF_CUSTOM_AUTOLOAD')) {
+if (getenv('BREF_AUTOLOAD_PATH')) {
     /** @noinspection PhpIncludeInspection */
-    require getenv('BREF_CUSTOM_AUTOLOAD');
+    require getenv('BREF_AUTOLOAD_PATH');
 } else {
     /** @noinspection PhpIncludeInspection */
     require $appRoot . '/vendor/autoload.php';

--- a/runtime/layers/fpm/bootstrap
+++ b/runtime/layers/fpm/bootstrap
@@ -9,8 +9,13 @@ error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
-/** @noinspection PhpIncludeInspection */
-require $appRoot . '/vendor/autoload.php';
+if (getenv('BREF_CUSTOM_AUTOLOAD')) {
+    /** @noinspection PhpIncludeInspection */
+    require getenv('BREF_CUSTOM_AUTOLOAD');
+} else {
+    /** @noinspection PhpIncludeInspection */
+    require $appRoot . '/vendor/autoload.php';
+}
 
 $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 


### PR DESCRIPTION
In order to keep the function code small, you can package your vendor dependencies in a custom layer. See here for more documentation: https://serverless.com/framework/docs/providers/aws/guide/layers/

Layers are version just like lambda. Chris Munns has an excellent talk about layers, including a demo, here: https://www.youtube.com/watch?v=gCQHulp3aVo

However, the current bootstrap file is hardcoded to look in the projects vendor path.

```php
require $appRoot . '/vendor/autoload.php'; // $appRoot is '/var/task'
```

In order to include composer as a layer, we need to override the path to load from vendor. This PR adds support for checking if `BREF_AUTOLOAD_PATH` is available as an environment variable and loads from that path instead of the default project root. 

In this example, I would define `BREF_AUTOLOAD_PATH` as `/opt/vendor/autoload.php`. 

One major plus size to this is the functions code is reduced drastically (in my case it went from 40 Mb to 123 Kb). This also enables the function code to be edited using the Lambda editor (not that you should but could).