### PR TITLE
Add DynamoDB typed events

### DIFF
--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -136,6 +136,6 @@ $result = json_decode($result->get('Payload')->getContents(), true);
 
 Functions are perfect to react to events emitted by other AWS services.
 
-For example, you can write code that processes new SQS events, SNS messages, new uploaded files on S3, etc.
+For example, you can write code that processes new SQS events, SNS messages, new uploaded files on S3, DynamoDb insert and update events, etc.
 
 This can be achieve by configuring which events will trigger your function via `serverless.yml`. Learn more about this [in the Serverless documentation](https://serverless.com/framework/docs/providers/aws/events/).

--- a/src/Event/DynamoDb/DynamoDbEvent.php
+++ b/src/Event/DynamoDb/DynamoDbEvent.php
@@ -27,7 +27,7 @@ final class DynamoDbEvent implements LambdaEvent
     }
 
     /**
-     * @return array
+     * @return DynamoDbRecord[]
      */
     public function getRecords(): array
     {

--- a/src/Event/DynamoDb/DynamoDbEvent.php
+++ b/src/Event/DynamoDb/DynamoDbEvent.php
@@ -14,13 +14,12 @@ final class DynamoDbEvent implements LambdaEvent
     private $event;
 
     /**
-     * DynamoDbEvent constructor.
-     * @param $event
+     * @param mixed $event
      * @throws InvalidLambdaEvent
      */
     public function __construct($event)
     {
-        if (!is_array($event) || !isset($event['Records'])) {
+        if (! is_array($event) || ! isset($event['Records'])) {
             throw new InvalidLambdaEvent('DynamoDB', $event);
         }
 

--- a/src/Event/DynamoDb/DynamoDbEvent.php
+++ b/src/Event/DynamoDb/DynamoDbEvent.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\DynamoDb;
+
+use Bref\Event\InvalidLambdaEvent;
+use Bref\Event\LambdaEvent;
+
+/**
+ * Represents a Lambda event when Lambda is invoked by DynamoDB Streams.
+ */
+final class DynamoDbEvent implements LambdaEvent
+{
+    /** @var array */
+    private $event;
+
+    /**
+     * DynamoDbEvent constructor.
+     * @param $event
+     * @throws InvalidLambdaEvent
+     */
+    public function __construct($event)
+    {
+        if (!is_array($event) || !isset($event['Records'])) {
+            throw new InvalidLambdaEvent('DynamoDB', $event);
+        }
+
+        $this->event = $event;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRecords(): array
+    {
+        return array_map(
+            function ($record): DynamoDbRecord {
+                try {
+                    return new DynamoDbRecord($record);
+                } catch (\InvalidArgumentException $e) {
+                    throw new InvalidLambdaEvent('DynamoDb', $this->event);
+                }
+            },
+            $this->event['Records']
+        );
+    }
+
+    public function toArray(): array
+    {
+        return $this->event;
+    }
+}

--- a/src/Event/DynamoDb/DynamoDbHandler.php
+++ b/src/Event/DynamoDb/DynamoDbHandler.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\DynamoDb;
+
+use Bref\Context\Context;
+use Bref\Event\Handler;
+
+/**
+ * Handles DynamoDb events.
+ */
+abstract class DynamoDbHandler implements Handler
+{
+    abstract public function handleDynamoDb(DynamoDbEvent $event, Context $context): void;
+
+    /** {@inheritDoc} */
+    public function handle($event, Context $context): void
+    {
+        $this->handleDynamoDb(new DynamoDbEvent($event), $context);
+    }
+}

--- a/src/Event/DynamoDb/DynamoDbHandler.php
+++ b/src/Event/DynamoDb/DynamoDbHandler.php
@@ -6,7 +6,7 @@ use Bref\Context\Context;
 use Bref\Event\Handler;
 
 /**
- * Handles DynamoDb events.
+ * Handles DynamoDB events.
  */
 abstract class DynamoDbHandler implements Handler
 {

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -43,25 +43,16 @@ final class DynamoDbRecord
         return $this->record['dynamodb']['OldImage'] ?? null;
     }
 
-    /**
-     * @return string
-     */
     public function getSequenceNumber(): string
     {
         return $this->record['dynamodb']['SequenceNumber'];
     }
 
-    /**
-     * @return int
-     */
     public function getSizeBytes(): int
     {
         return $this->record['dynamodb']['SizeBytes'];
     }
-
-    /**
-     * @return string
-     */
+    
     public function getStreamViewType(): string
     {
         return $this->record['dynamodb']['StreamViewType'];

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -8,12 +8,11 @@ final class DynamoDbRecord
     private $record;
 
     /**
-     * DynamoDbRecord constructor.
-     * @param $record
+     * @param mixed $record
      */
     public function __construct($record)
     {
-        if (!is_array($record) || !isset($record['eventSource']) || $record['eventSource'] !== 'aws:dynamodb') {
+        if (! is_array($record) || ! isset($record['eventSource']) || $record['eventSource'] !== 'aws:dynamodb') {
             throw new \InvalidArgumentException('Event source must come from DynamoDB');
         }
 

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -20,25 +20,35 @@ final class DynamoDbRecord
     }
 
     /**
-     * @return array
+     * Returns the key attributes of the modified item.
      */
-    public function getKeys()
+    public function getKeys(): array
     {
         return $this->record['dynamodb']['Keys'];
     }
 
     /**
-     * @return array|null
+     * Returns the new version of the DynamoDB item.
+     *
+     * Warning: this can be null depending on the `StreamViewType`.
+     *
+     * @see getStreamViewType()
+     * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html
      */
-    public function getNewImage()
+    public function getNewImage(): ?array
     {
         return $this->record['dynamodb']['NewImage'];
     }
 
     /**
-     * @return array|null
+     * Returns the old version of the DynamoDB item.
+     *
+     * Warning: this can be null depending on the `StreamViewType`.
+     *
+     * @see getStreamViewType()
+     * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html
      */
-    public function getOldImage()
+    public function getOldImage(): ?array
     {
         return $this->record['dynamodb']['OldImage'] ?? null;
     }
@@ -53,6 +63,9 @@ final class DynamoDbRecord
         return $this->record['dynamodb']['SizeBytes'];
     }
 
+    /**
+     * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_StreamSpecification.html
+     */
     public function getStreamViewType(): string
     {
         return $this->record['dynamodb']['StreamViewType'];

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -19,31 +19,49 @@ final class DynamoDbRecord
         $this->record = $record;
     }
 
+    /**
+     * @return mixed
+     */
     public function getKeys()
     {
         return $this->record['dynamodb']['Keys'];
     }
 
+    /**
+     * @return mixed
+     */
     public function getNewImage()
     {
         return $this->record['dynamodb']['NewImage'];
     }
 
+    /**
+     * @return mixed|null
+     */
     public function getOldImage()
     {
         return $this->record['dynamodb']['OldImage'] ?? null;
     }
 
+    /**
+     * @return mixed
+     */
     public function getSequenceNumber()
     {
         return $this->record['dynamodb']['SequenceNumber'];
     }
 
+    /**
+     * @return mixed
+     */
     public function getSizeBytes()
     {
         return $this->record['dynamodb']['SizeBytes'];
     }
 
+    /**
+     * @return mixed
+     */
     public function getStreamViewType()
     {
         return $this->record['dynamodb']['StreamViewType'];

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\DynamoDb;
+
+final class DynamoDbRecord
+{
+    /** @var array */
+    private $record;
+
+    /**
+     * DynamoDbRecord constructor.
+     * @param $record
+     */
+    public function __construct($record)
+    {
+        if (!is_array($record) || !isset($record['eventSource']) || $record['eventSource'] !== 'aws:dynamodb') {
+            throw new \InvalidArgumentException;
+        }
+
+        $this->record = $record;
+    }
+
+    public function getKeys()
+    {
+        return $this->record['dynamodb']['Keys'];
+    }
+}

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -19,6 +19,11 @@ final class DynamoDbRecord
         $this->record = $record;
     }
 
+    public function getEventName(): string
+    {
+        return $this->record['eventName'];
+    }
+
     /**
      * Returns the key attributes of the modified item.
      */

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -14,7 +14,7 @@ final class DynamoDbRecord
     public function __construct($record)
     {
         if (!is_array($record) || !isset($record['eventSource']) || $record['eventSource'] !== 'aws:dynamodb') {
-            throw new \InvalidArgumentException;
+            throw new \InvalidArgumentException('Event source must come from DynamoDB');
         }
 
         $this->record = $record;
@@ -23,5 +23,30 @@ final class DynamoDbRecord
     public function getKeys()
     {
         return $this->record['dynamodb']['Keys'];
+    }
+
+    public function getNewImage()
+    {
+        return $this->record['dynamodb']['NewImage'];
+    }
+
+    public function getOldImage()
+    {
+        return $this->record['dynamodb']['OldImage'] ?? null;
+    }
+
+    public function getSequenceNumber()
+    {
+        return $this->record['dynamodb']['SequenceNumber'];
+    }
+
+    public function getSizeBytes()
+    {
+        return $this->record['dynamodb']['SizeBytes'];
+    }
+
+    public function getStreamViewType()
+    {
+        return $this->record['dynamodb']['StreamViewType'];
     }
 }

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -44,25 +44,25 @@ final class DynamoDbRecord
     }
 
     /**
-     * @return mixed
+     * @return string
      */
-    public function getSequenceNumber()
+    public function getSequenceNumber(): string
     {
         return $this->record['dynamodb']['SequenceNumber'];
     }
 
     /**
-     * @return mixed
+     * @return int
      */
-    public function getSizeBytes()
+    public function getSizeBytes(): int
     {
         return $this->record['dynamodb']['SizeBytes'];
     }
 
     /**
-     * @return mixed
+     * @return string
      */
-    public function getStreamViewType()
+    public function getStreamViewType(): string
     {
         return $this->record['dynamodb']['StreamViewType'];
     }

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -28,7 +28,7 @@ final class DynamoDbRecord
     }
 
     /**
-     * @return mixed
+     * @return array|null
      */
     public function getNewImage()
     {
@@ -36,7 +36,7 @@ final class DynamoDbRecord
     }
 
     /**
-     * @return mixed|null
+     * @return array|null
      */
     public function getOldImage()
     {

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -20,7 +20,7 @@ final class DynamoDbRecord
     }
 
     /**
-     * @return mixed
+     * @return array
      */
     public function getKeys()
     {

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -52,7 +52,7 @@ final class DynamoDbRecord
     {
         return $this->record['dynamodb']['SizeBytes'];
     }
-    
+
     public function getStreamViewType(): string
     {
         return $this->record['dynamodb']['StreamViewType'];

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -42,7 +42,7 @@ final class DynamoDbRecord
      */
     public function getNewImage(): ?array
     {
-        return $this->record['dynamodb']['NewImage'];
+        return $this->record['dynamodb']['NewImage'] ?? null;
     }
 
     /**

--- a/tests/Event/DynamoDb/DynamoDbEventTest.php
+++ b/tests/Event/DynamoDb/DynamoDbEventTest.php
@@ -29,4 +29,79 @@ class DynamoDbEventTest extends TestCase
         $this->assertSame(26, $record->getSizeBytes());
         $this->assertSame('NEW_AND_OLD_IMAGES', $record->getStreamViewType());
     }
+
+    public function test_old_image()
+    {
+        // Arrange
+        $event = json_decode(file_get_contents(__DIR__ . '/dynamodb.json'), true);
+        $keys = ['Id' => ['N' => '101']];
+        $newImage = [
+            'Message' => ['S' => 'New item!'],
+            'Id' => ['N' => '101'],
+        ];
+        $eventName = 'INSERT';
+
+        // Act
+        $event = new DynamoDbEvent($event);
+        $record = $event->getRecords()[0];
+
+        // Assert
+        $this->assertSame($eventName, $record->getEventName());
+        $this->assertSame($keys, $record->getKeys());
+        $this->assertSame($newImage, $record->getNewImage());
+        $this->assertNull($record->getOldImage());
+        $this->assertSame('111', $record->getSequenceNumber());
+        $this->assertSame(26, $record->getSizeBytes());
+        $this->assertSame('NEW_IMAGE', $record->getStreamViewType());
+    }
+
+    public function test_new_and_old_images()
+    {
+        // Arrange
+        $event = json_decode(file_get_contents(__DIR__ . '/dynamodb.json'), true);
+        $keys = ['Id' => ['N' => '101']];
+        $newImage = [
+            'Message' => ['S' => 'This item has changed'],
+            'Id' => ['N' => '101'],
+        ];
+        $oldImage = [
+            'Message' => ['S' => 'New item!'],
+            'Id' => ['N' => '101'],
+        ];
+        $eventName = 'MODIFY';
+
+        // Act
+        $event = new DynamoDbEvent($event);
+        $record = $event->getRecords()[1];
+
+        // Assert
+        $this->assertSame($eventName, $record->getEventName());
+        $this->assertSame($keys, $record->getKeys());
+        $this->assertSame($newImage, $record->getNewImage());
+        $this->assertSame($oldImage, $record->getOldImage());
+        $this->assertSame('222', $record->getSequenceNumber());
+        $this->assertSame(59, $record->getSizeBytes());
+        $this->assertSame('NEW_AND_OLD_IMAGES', $record->getStreamViewType());
+    }
+
+    public function test_keys_only()
+    {
+        // Arrange
+        $event = json_decode(file_get_contents(__DIR__ . '/dynamodb.json'), true);
+        $keys = ['Id' => ['N' => '101']];
+        $eventName = 'REMOVE';
+
+        // Act
+        $event = new DynamoDbEvent($event);
+        $record = $event->getRecords()[3];
+
+        // Assert
+        $this->assertSame($eventName, $record->getEventName());
+        $this->assertSame($keys, $record->getKeys());
+        $this->assertNull($record->getNewImage());
+        $this->assertNull($record->getOldImage());
+        $this->assertSame('444', $record->getSequenceNumber());
+        $this->assertSame(38, $record->getSizeBytes());
+        $this->assertSame('KEYS_ONLY', $record->getStreamViewType());
+    }
 }

--- a/tests/Event/DynamoDb/DynamoDbEventTest.php
+++ b/tests/Event/DynamoDb/DynamoDbEventTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test\Event\DynamoDb;
+
+use Bref\Event\DynamoDb\DynamoDbEvent;
+use PHPUnit\Framework\TestCase;
+
+class DynamoDbEventTest extends TestCase
+{
+    public function test_canonical_case()
+    {
+        // Arrange
+        $event = json_decode(file_get_contents(__DIR__ . '/dynamodb.json'), true);
+
+        // Act
+        $event = new DynamoDbEvent($event);
+        $records = $event->getRecords()[0];
+
+        // Assert
+        $this->assertSame(['Id' => ['N' => '101']], $records->getKeys());
+    }
+}

--- a/tests/Event/DynamoDb/DynamoDbEventTest.php
+++ b/tests/Event/DynamoDb/DynamoDbEventTest.php
@@ -27,7 +27,7 @@ class DynamoDbEventTest extends TestCase
         $this->assertNull($record->getOldImage());
         $this->assertSame('111', $record->getSequenceNumber());
         $this->assertSame(26, $record->getSizeBytes());
-        $this->assertSame('NEW_AND_OLD_IMAGES', $record->getStreamViewType());
+        $this->assertSame('NEW_IMAGE', $record->getStreamViewType());
     }
 
     public function test_old_image()

--- a/tests/Event/DynamoDb/DynamoDbEventTest.php
+++ b/tests/Event/DynamoDb/DynamoDbEventTest.php
@@ -19,15 +19,14 @@ class DynamoDbEventTest extends TestCase
 
         // Act
         $event = new DynamoDbEvent($event);
-        $newRecord = $event->getRecords()[0];
-        $updatedRecord = $event->getRecords()[1];
+        $record = $event->getRecords()[0];
 
         // Assert
-        $this->assertSame($keys, $newRecord->getKeys());
-        $this->assertSame($newImage, $newRecord->getNewImage());
-        $this->assertNull($newRecord->getOldImage());
-        $this->assertSame('111', $newRecord->getSequenceNumber());
-        $this->assertSame(26, $newRecord->getSizeBytes());
-        $this->assertSame('NEW_AND_OLD_IMAGES', $newRecord->getStreamViewType());
+        $this->assertSame($keys, $record->getKeys());
+        $this->assertSame($newImage, $record->getNewImage());
+        $this->assertNull($record->getOldImage());
+        $this->assertSame('111', $record->getSequenceNumber());
+        $this->assertSame(26, $record->getSizeBytes());
+        $this->assertSame('NEW_AND_OLD_IMAGES', $record->getStreamViewType());
     }
 }

--- a/tests/Event/DynamoDb/DynamoDbEventTest.php
+++ b/tests/Event/DynamoDb/DynamoDbEventTest.php
@@ -11,12 +11,23 @@ class DynamoDbEventTest extends TestCase
     {
         // Arrange
         $event = json_decode(file_get_contents(__DIR__ . '/dynamodb.json'), true);
+        $keys = ['Id' => ['N' => '101']];
+        $newImage = [
+            'Message' => ['S' => 'New item!'],
+            'Id' => ['N' => '101'],
+        ];
 
         // Act
         $event = new DynamoDbEvent($event);
-        $records = $event->getRecords()[0];
+        $newRecord = $event->getRecords()[0];
+        $updatedRecord = $event->getRecords()[1];
 
         // Assert
-        $this->assertSame(['Id' => ['N' => '101']], $records->getKeys());
+        $this->assertSame($keys, $newRecord->getKeys());
+        $this->assertSame($newImage, $newRecord->getNewImage());
+        $this->assertNull($newRecord->getOldImage());
+        $this->assertSame('111', $newRecord->getSequenceNumber());
+        $this->assertSame(26, $newRecord->getSizeBytes());
+        $this->assertSame('NEW_AND_OLD_IMAGES', $newRecord->getStreamViewType());
     }
 }

--- a/tests/Event/DynamoDb/dynamodb.json
+++ b/tests/Event/DynamoDb/dynamodb.json
@@ -1,0 +1,90 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventName": "INSERT",
+      "eventVersion": "1.0",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "NewImage": {
+          "Message": {
+            "S": "New item!"
+          },
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SequenceNumber": "111",
+        "SizeBytes": 26,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "stream-ARN"
+    },
+    {
+      "eventID": "2",
+      "eventName": "MODIFY",
+      "eventVersion": "1.0",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "NewImage": {
+          "Message": {
+            "S": "This item has changed"
+          },
+          "Id": {
+            "N": "101"
+          }
+        },
+        "OldImage": {
+          "Message": {
+            "S": "New item!"
+          },
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SequenceNumber": "222",
+        "SizeBytes": 59,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "stream-ARN"
+    },
+    {
+      "eventID": "3",
+      "eventName": "REMOVE",
+      "eventVersion": "1.0",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "OldImage": {
+          "Message": {
+            "S": "This item has changed"
+          },
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SequenceNumber": "333",
+        "SizeBytes": 38,
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "eventSourceARN": "stream-ARN"
+    }
+  ]
+}

--- a/tests/Event/DynamoDb/dynamodb.json
+++ b/tests/Event/DynamoDb/dynamodb.json
@@ -22,7 +22,7 @@
         },
         "SequenceNumber": "111",
         "SizeBytes": 26,
-        "StreamViewType": "NEW_AND_OLD_IMAGES"
+        "StreamViewType": "NEW_IMAGE"
       },
       "eventSourceARN": "stream-ARN"
     },
@@ -74,7 +74,7 @@
         },
         "OldImage": {
           "Message": {
-            "S": "This item has changed"
+            "S": "This item has been deleted"
           },
           "Id": {
             "N": "101"
@@ -82,7 +82,25 @@
         },
         "SequenceNumber": "333",
         "SizeBytes": 38,
-        "StreamViewType": "NEW_AND_OLD_IMAGES"
+        "StreamViewType": "OLD_IMAGE"
+      },
+      "eventSourceARN": "stream-ARN"
+    },
+    {
+      "eventID": "4",
+      "eventName": "REMOVE",
+      "eventVersion": "1.0",
+      "eventSource": "aws:dynamodb",
+      "awsRegion": "us-east-1",
+      "dynamodb": {
+        "Keys": {
+          "Id": {
+            "N": "101"
+          }
+        },
+        "SequenceNumber": "444",
+        "SizeBytes": 38,
+        "StreamViewType": "KEYS_ONLY"
       },
       "eventSourceARN": "stream-ARN"
     }


### PR DESCRIPTION
There are some considerations that are different for DynamoDB than other events. This major concern is marshaling of items from DynamoDB.

DynamoDB stores attributes as types, this has more context: https://aws.amazon.com/blogs/developer/dynamodb-json-and-array-marshaling-for-php/

There are a few things that should be discussed before continuing work, should the records returned from the event be automatically be unmarshaled? If they are not unmarshaled in the Bref DynamoDbRecord, the user/function will still need to unmarshal the record. Is it safe to assume that we should always unmarshal the record? 

Right now there is only one test (until we determine the behavior) that checks for the "normal form" record. https://github.com/brefphp/bref/blob/0f59619ba4329920c90d1e775cba25a60f50e985/tests/Event/DynamoDb/DynamoDbEventTest.php#L20
