### PR TITLE
Update docs to reflect Laravel 6. fixes #528

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -61,13 +61,13 @@ functions:
 
 Now we still have a few modifications to do on the application to make it compatible with AWS Lambda.
 
-Since [the filesystem is readonly](/docs/environment/storage.md) except for `/tmp` we need to customize where the cache files are stored. Add this line in `bootstrap/app.php` after `$app = new Illuminate\Foundation\Application`:
+Since [the filesystem is readonly](/docs/environment/storage.md) except for `/tmp` we need to customize where the cache files are stored. Change the line in `bootstrap/app.php` at `$app = new Illuminate\Foundation\Application(`:
 
-```php
-/*
- * Allow overriding the storage path in production using an environment variable.
- */
-$app->useStoragePath($_ENV['APP_STORAGE'] ?? $app->storagePath());
+```diff
+$app = new Illuminate\Foundation\Application(
+-    realpath(__DIR__.'/../')
++    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
+);
 ```
 
 We will also need to customize the location for compiled views, as well as customize a few variables in the `.env` file:

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -25,12 +25,6 @@ provider:
     name: aws
     region: us-east-1
     runtime: provided
-    environment:
-        # Laravel environment variables
-        APP_STORAGE: /tmp
-        LOG_CHANNEL: stderr
-        SESSION_DRIVER: array
-        VIEW_COMPILED_PATH: /tmp/storage/framework/views
 
 plugins:
     - ./vendor/bref/bref
@@ -59,20 +53,11 @@ functions:
             - ${bref:layer.console} # The "console" layer
 ```
 
-Now we still have a few modifications to do on the application to make it compatible with AWS Lambda.
-
-Since [the filesystem is readonly](/docs/environment/storage.md) except for `/tmp` we need to customize where the cache files are stored. Change the line in `bootstrap/app.php` at `$app = new Illuminate\Foundation\Application(`:
-
-```diff
-$app = new Illuminate\Foundation\Application(
--    realpath(__DIR__.'/../')
-+    $_ENV['APP_BASE_PATH'] ?? dirname(__DIR__)
-);
-```
-
 We will also need to customize the location for compiled views, as well as customize a few variables in the `.env` file:
 
 ```dotenv
+APP_STORAGE=/tmp
+
 VIEW_COMPILED_PATH=/tmp/storage/framework/views
 
 # We cannot store sessions to disk: if you don't need sessions (e.g. API)

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -6,7 +6,7 @@ introduction: Learn how to deploy serverless Laravel applications on AWS Lambda 
 
 This guide helps you run Laravel applications on AWS Lambda using Bref. These instructions are kept up to date to target the latest Laravel version.
 
-A demo application is available on GitHub at [github.com/mnapoli/bref-laravel-demo](https://github.com/mnapoli/bref-laravel-demo).
+A demo application is available on GitHub at [github.com/brefphp/examples](https://github.com/brefphp/examples).
 
 ## Setup
 

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -27,10 +27,20 @@ provider:
     runtime: provided
     environment:
         # Laravel environment variables
-        APP_STORAGE: '/tmp'
+        APP_STORAGE: /tmp
+        LOG_CHANNEL: stderr
+        SESSION_DRIVER: array
+        VIEW_COMPILED_PATH: /tmp/storage/framework/views
 
 plugins:
     - ./vendor/bref/bref
+
+package:
+  exclude:
+    - node_modules/**
+    - public/storage
+    - storage/**
+    - tests/**
 
 functions:
     website:

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -56,8 +56,6 @@ functions:
 We will also need to customize the location for compiled views, as well as customize a few variables in the `.env` file:
 
 ```dotenv
-APP_STORAGE=/tmp
-
 VIEW_COMPILED_PATH=/tmp/storage/framework/views
 
 # We cannot store sessions to disk: if you don't need sessions (e.g. API)


### PR DESCRIPTION
The Laravel docs are slightly incorrect. This was also pointed out in #528. 
Ive also updated the docs in regards to the serverless.yml file, so the environment vars are shown and excluded packages to keep the build size down. 

