### PR TITLE
Use AsyncAws instead of AWS SDK

### DIFF
--- a/bref
+++ b/bref
@@ -2,8 +2,10 @@
 <?php
 declare(strict_types=1);
 
-use Aws\CloudFormation\CloudFormationClient;
-use Aws\CloudFormation\Exception\CloudFormationException;
+use AsyncAws\CloudFormation\CloudFormationClient;
+use AsyncAws\CloudFormation\Result\Output;
+use AsyncAws\CloudFormation\Result\StackEvent;
+use AsyncAws\Core\Exception\Http\HttpException;
 use Bref\Console\LoadingAnimation;
 use Bref\Console\OpenUrl;
 use Bref\Lambda\InvocationFailed;
@@ -152,7 +154,6 @@ $app->command('invoke function [--region=] [-e|--event=]', function (string $fun
 $app->command('deployment stack-name [--region=]', function (string $stackName, ?string $region, SymfonyStyle $io) {
     $region = ($region ?: getenv('AWS_DEFAULT_REGION')) ?: 'us-east-1';
     $cloudFormation = new CloudFormationClient([
-        'version' => 'latest',
         'region' => $region,
     ]);
 
@@ -160,16 +161,21 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
         $result = $cloudFormation->describeStacks([
             'StackName' => $stackName,
         ]);
-        $stacks = $result->get('Stacks');
-        if (!isset($stacks[0])) {
+        $stack = null;
+        foreach ($result->getStacks() as $currentStack) {
+            $stack = $currentStack;
+            break;
+        }
+
+        if ($stack === null) {
             $io->error(sprintf('The stack %s cannot be found in region %s', $stackName, $region));
             return 1;
         }
-        $stack = $stacks[0];
-    } catch (CloudFormationException $e) {
+
+    } catch (HttpException $e) {
         $io->error([
             "Error while fetching information about the stack `$stackName` in region `$region`:",
-            sprintf('"%s"', $e->getAwsErrorMessage()),
+            sprintf('"%s"', $e->getAwsMessage()),
             "In case the stack was not found make sure that `$region` is the correct region.",
         ]);
         return 1;
@@ -180,14 +186,14 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
     $result = $cloudFormation->describeStackEvents([
         'StackName' => $stackName,
     ]);
-    $events = $result->get('StackEvents');
+    $events = iterator_to_array($result->getStackEvents(true));
 
     // Last events last
     $events = array_reverse($events);
     // Keep only events from the last 24 hours
     $oneDayAgo = new DateTimeImmutable('-1 day');
-    $events = array_filter($events, function (array $event) use ($oneDayAgo) {
-        return $event['Timestamp'] >= $oneDayAgo;
+    $events = array_filter($events, function (StackEvent $event) use ($oneDayAgo) {
+        return $event->getTimestamp() >= $oneDayAgo;
     });
 
     if (empty($events)) {
@@ -196,9 +202,9 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
         $errors = [];
         foreach ($events as $event) {
             /** @var DateTimeInterface $time */
-            $time = $event['Timestamp'];
+            $time = $event->getTimestamp();
 
-            $status = $event['ResourceStatus'];
+            $status = $event->getResourceStatus();
             $error = false;
             if (strpos($status, 'FAILED') !== false) {
                 $error = true;
@@ -209,11 +215,11 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
                 '<comment>%s</comment> %s %s',
                 $time->format('M j G:H'),
                 $error ? "<error>$status</error>" : $status,
-                $event['ResourceType']
+                $event->getResourceType()
             ));
 
-            if (isset($event['ResourceStatusReason'])) {
-                $io->write(" <info>{$event['ResourceStatusReason']}</info>");
+            if (null !== $event->getResourceStatusReason()) {
+                $io->write(" <info>{$event->getResourceStatusReason()}</info>");
             }
             $io->writeln('');
         }
@@ -225,26 +231,27 @@ $app->command('deployment stack-name [--region=]', function (string $stackName, 
             $io->writeln('<error>Summary of the errors found:</error>');
             foreach ($errors as $event) {
                 /** @var DateTimeInterface $time */
-                $time = $event['Timestamp'];
+                $time = $event->getTimestamp();
                 $io->writeln(sprintf(
                     '<comment>%s</comment> <info>%s</info> %s',
                     $time->format('M j G:H'),
-                    $event['ResourceType'],
-                    $event['ResourceStatusReason'] ?? ''
+                    $event->getResourceType() ?? '',
+                    $event->getResourceStatusReason() ?? ''
                 ));
             }
         }
     }
 
-    if (isset($stack['Outputs']) && !empty($stack['Outputs'])) {
+    $outputs = $stack->getOutputs();
+    if (!empty($outputs)) {
         $io->section('Outputs');
-        $io->listing(array_map(function (array $output): string {
+        $io->listing(array_map(function (Output $output): string {
             return sprintf(
                 '%s: <info>%s</info>',
-                $output['Description'] ?? $output['OutputKey'],
-                $output['OutputValue']
+                $output->getDescription() ?? $output->getOutputKey(),
+                $output->getOutputValue() ?? ''
             );
-        }, $stack['Outputs']));
+        }, $outputs));
     }
 
     return 0;

--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "hollodotme/fast-cgi-client": "^3.0",
         "riverline/multipart-parser": "^2.0.6",
         "psr/http-server-handler": "^1.0",
-        "async-aws/cloud-formation": "^0.1.0",
-        "async-aws/lambda": "^0.1.0"
+        "async-aws/cloud-formation": "^0.2",
+        "async-aws/lambda": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
+        "zendframework/zend-diactoros": "^1.6|^2.0",
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.11.5",
         "guzzlehttp/guzzle": "^6.3"

--- a/composer.json
+++ b/composer.json
@@ -28,15 +28,15 @@
         "mnapoli/silly": "^1.7",
         "symfony/filesystem": "^3.1|^4.0|^5.0",
         "symfony/process": "^3.3|^4.0|^5.0",
-        "aws/aws-sdk-php": "^3.44",
         "psr/http-message": "^1.0",
         "hollodotme/fast-cgi-client": "^3.0",
         "riverline/multipart-parser": "^2.0.6",
-        "psr/http-server-handler": "^1.0"
+        "psr/http-server-handler": "^1.0",
+        "async-aws/cloud-formation": "^0.1.0",
+        "async-aws/lambda": "^0.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
-        "zendframework/zend-diactoros": "^1.6|^2.0",
         "doctrine/coding-standard": "^5.0",
         "phpstan/phpstan": "^0.11.5",
         "guzzlehttp/guzzle": "^6.3"

--- a/src/Lambda/InvocationResult.php
+++ b/src/Lambda/InvocationResult.php
@@ -2,14 +2,14 @@
 
 namespace Bref\Lambda;
 
-use Aws\Result;
+use AsyncAws\Lambda\Result\InvocationResponse;
 
 /**
  * The result of a successful lambda invocation.
  */
 final class InvocationResult
 {
-    /** @var Result */
+    /** @var InvocationResponse */
     private $result;
 
     /** @var mixed */
@@ -18,7 +18,7 @@ final class InvocationResult
     /**
      * @param mixed $payload
      */
-    public function __construct(Result $result, $payload)
+    public function __construct(InvocationResponse $result, $payload)
     {
         $this->result = $result;
         $this->payload = $payload;
@@ -26,7 +26,7 @@ final class InvocationResult
 
     public function getLogs(): string
     {
-        return base64_decode($this->result->get('LogResult'));
+        return base64_decode($this->result->getLogResult());
     }
 
     /**

--- a/src/Lambda/SimpleLambdaClient.php
+++ b/src/Lambda/SimpleLambdaClient.php
@@ -2,8 +2,7 @@
 
 namespace Bref\Lambda;
 
-use Aws\Lambda\LambdaClient;
-use Psr\Http\Message\StreamInterface;
+use AsyncAws\Lambda\LambdaClient;
 
 /**
  * A simpler alternative to the official LambdaClient from the AWS SDK.
@@ -16,7 +15,6 @@ final class SimpleLambdaClient
     public function __construct(string $region)
     {
         $this->lambda = new LambdaClient([
-            'version' => 'latest',
             'region' => $region,
         ]);
     }
@@ -35,13 +33,10 @@ final class SimpleLambdaClient
             'Payload' => $event ?? '',
         ]);
 
-        /** @var StreamInterface $resultPayload */
-        $resultPayload = $rawResult->get('Payload');
-        $resultPayload = json_decode($resultPayload->getContents(), true);
-
+        $resultPayload = json_decode($rawResult->getPayload(), true);
         $invocationResult = new InvocationResult($rawResult, $resultPayload);
 
-        $error = $rawResult->get('FunctionError');
+        $error = $rawResult->getFunctionError();
         if ($error) {
             throw new InvocationFailed($invocationResult);
         }


### PR DESCRIPTION
I have been hesitating of making this PR. I wrote the code a few days ago... anyhow here I am. 

Yes. Im replacing the AWS SDK with a brand new library nobody ever heard of. Except for being cool, async and awesome. There are some real benefits for Bref using Async AWS. 

### Vendor weight

AWS PHP SDK and its dependencies is about 20MB in the vendor folder. Using this PR removes 17MB of code. That is because Async AWS is using a subtree split so you can decide what services you want to download. Bref is only using CloudFormation and Lambda. 

### PSR-7 

One may think that PSR-7 is the worst PSR or you may love it. No matter what you think. Bref does not need to require both Guzzlehttp/psr7 and zendframework/zend-diactoros. That is at least one PSR-7 implementation too much. If we remove AWS SDK we can let the user decide both **if** they want a PSR-7 implementation installed and **which** implementation. 

(Nyholm/psr7 is the best btw). 

--------------

Is this a high risk using Async AWS package? No not really. Your application will run fine since that is using pure `curl` to talk with Lambda. 

The only thing Bref is currently using AWS SDK for is the `./bref deployment` command, `./bref invoke` command and some maintainer tasks (listing published layers). 

With that said; Async AWS is well tested just as the official SDK.  

See https://github.com/async-aws/aws

------------

It is only one TODO in this PR. That is to update to the next stable version of async-aws. That should just be a `composer update` or a bump with version number. 