### PR TITLE
Fix wrong directory name for OpenSSL build

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -131,7 +131,7 @@ RUN set -xe; \
 #   - curl
 #   - php
 ENV VERSION_OPENSSL=1.1.1a
-ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/xml2
+ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.haxx.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"
 


### PR DESCRIPTION
While it has no impact in the end, the wrong directory irked me while debugging the MongoDB build issue.