### PR TITLE
Remove decorate_workers_output from php-fpm.conf

### DIFF
--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -1,9 +1,12 @@
 ARG PHP_VERSION
 FROM bref/tmp/cleaned-build-php-$PHP_VERSION
+ARG PHP_VERSION
 
 COPY bootstrap /opt/bootstrap
 COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
+
+RUN if [ "$PHP_VERSION" = "72" ]; then cd /opt/bref/etc/ && sed -i '/decorate_workers_output/d' php-fpm.conf; fi;
 
 # Build the final image from the lambci image that is close to the production environment
 FROM lambci/lambda:provided

--- a/runtime/layers/fpm/php-fpm.conf
+++ b/runtime/layers/fpm/php-fpm.conf
@@ -16,7 +16,7 @@ clear_env = no
 ; Forward stderr of PHP processes to stderr of PHP-FPM (so that it can be sent to cloudwatch)
 catch_workers_output = yes
 ; New PHP 7.3 option that disables a verbose log prefix
-; Disabled for now until we switch to PHP 7.3
+; This option is removed in PHP 7.2 build
 decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
 ; See https://github.com/brefphp/bref/issues/275

--- a/runtime/layers/fpm/php-fpm.conf
+++ b/runtime/layers/fpm/php-fpm.conf
@@ -17,7 +17,7 @@ clear_env = no
 catch_workers_output = yes
 ; New PHP 7.3 option that disables a verbose log prefix
 ; Disabled for now until we switch to PHP 7.3
-;decorate_workers_output = no
+decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
 ; See https://github.com/brefphp/bref/issues/275
 rlimit_core = 1


### PR DESCRIPTION
Resolves #432 

Remove `decorate_workers_output` configuration from php-fpm.conf when PHP version is 7.2.

PHP 7.2 image build doesn't contain `decorate_workers_output`configuration anymore on `/opt/bref/etc/php-fpm.conf`:

<img width="866" alt="bref" src="https://user-images.githubusercontent.com/1071148/75631043-8f6bc880-5be7-11ea-9f18-3456c50497f2.png">


