### PR TITLE
Cloudwatch logs formatted similar to native Runtime

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -206,13 +206,19 @@ final class LambdaRuntime
             $errorMessage = $error->getMessage();
         }
 
-        // Log the exception in CloudWatch
-        printf(
-            "Fatal error: %s in %s:%d\nStack trace:\n%s",
+        $errorMessage = sprintf(
+            'Fatal error: %s in %s:%d',
             $errorMessage,
             $error->getFile(),
-            $error->getLine(),
-            $error->getTraceAsString()
+            $error->getLine()
+        );
+
+        // Log the exception in CloudWatch
+        printf(
+            '{"errorType": "%s", "errorMessage": "%s", "stack": %s}',
+            get_class($error),
+            $errorMessage,
+            json_encode(explode(PHP_EOL, $error->getTraceAsString()))
         );
 
         // Send an "error" Lambda response


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

Looking through CloudWatch logs is a bit cumbersome, specially because every line of the stack makes a new row. This makes it particularly hard to **search** on CloudWatch, since a search result won't include the stack trace because it lost context. Example:

![image](https://user-images.githubusercontent.com/9533181/75883578-85360e00-5e23-11ea-8d6e-5f51ec3834d0.png)

This pull request changes the log to be a single JSON row, more in line with how NodeJS, Java & Python does it: 

![image](https://user-images.githubusercontent.com/9533181/75883649-a26adc80-5e23-11ea-88a3-9dd6741386fe.png)

If merged, this is how the PHP logs would look like:

![image](https://user-images.githubusercontent.com/9533181/75883689-b4e51600-5e23-11ea-8fa1-a7f7072a1541.png)

