### PR TITLE
Migrate example to AsyncAws

### DIFF
--- a/docs/case-studies.md
+++ b/docs/case-studies.md
@@ -31,6 +31,11 @@ These help learn for real use cases about costs, performances and migration effo
 - [MyBuilder](https://mybuilder.com)
 
   MyBuilder is an online marketplace matching tradespeople with home owners. They used Lambda with Bref to create a highly scalable on-demand microservice to generate PDF reports. The solution involved [creating their own layer](https://tech.mybuilder.com/compiling-wkhtmltopdf-aws-lambda-with-bref-easier-than-you-think/) to include a self-compiled binary file to use alongside Bref's base PHP layer.
+  
+- [PDF reporting generation](https://devops-life.com/blog/2020/03/06/how-serverless-saved-us-for-$2-with-bref-sh/)
+
+Feedback to understand the benefits of going serverless with a real use case (PDF generation);
+They generated 2,000 PDFs in <2 min for 2$ using Symfony applications shipped inside lambdas using Bref.sh
 
 ## Others
 

--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -116,6 +116,12 @@ Run `serverless invoke --help` to learn more about the `invoke` command.
 
 A PHP function can be triggered from another PHP application using the AWS PHP SDK:
 
+You first need to install the AWS PHP SDK by running
+
+```bash
+$ composer require aws/aws-sdk-php
+```
+
 ```php
 $lambda = new \Aws\Lambda\LambdaClient([
     'version' => 'latest',
@@ -131,6 +137,8 @@ $result = $lambda->invoke([
 
 $result = json_decode($result->get('Payload')->getContents(), true);
 ```
+
+Alternativly, you can achieve the same result with the lighter [AsyncAws Lambda](https://github.com/async-aws/lambda) package.
 
 ### From other AWS services
 


### PR DESCRIPTION
Update Function Invocation PHP example to use AsyncAws for consitency with internal library.

This also Adds a `composer require ` section in the documentation.

Fixes this comment https://github.com/brefphp/bref/pull/575#issuecomment-596228502