### PR TITLE
Added note about trusted proxies and hosts

### DIFF
--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -158,8 +158,10 @@ Modify `public/index.php` accordingly.
 
 ```diff
 +// Get user IP:
-+$context = json_decode($_SERVER['LAMBDA_CONTEXT'], true);
-+$_SERVER['HTTP_X_FORWARDED_FOR'] = $context['identity']['sourceIp'] ?? '';
++if (isset($_SERVER['LAMBDA_CONTEXT'])) {
++    $context = json_decode($_SERVER['LAMBDA_CONTEXT'], true);
++    $_SERVER['HTTP_X_FORWARDED_FOR'] = $context['identity']['sourceIp'] ?? '';
++}
 
 $kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
 $request = Request::createFromGlobals();


### PR DESCRIPTION
Trusted proxies are for: 
- Getting users IP
- Generating links with HTTPS

Trusted hosts are for: 
- Getting correct host name

This update is probably needed for Laravel too. I leave that some someone else to contribute. 