### PR TITLE
Cloudwatch logs formatted similar to native Runtime, v2

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -214,18 +214,17 @@ final class LambdaRuntime
         );
 
         // Log the exception in CloudWatch
-        printf(
-            '{"errorType": "%s", "errorMessage": "%s", "stack": %s}',
-            get_class($error),
-            $errorMessage,
-            json_encode(explode(PHP_EOL, $error->getTraceAsString()))
-        );
+        echo json_encode([
+            'errorType' => get_class($error),
+            'errorMessage' => $errorMessage,
+            'stack' => explode(PHP_EOL, $error->getTraceAsString()),
+        ]);
 
         // Send an "error" Lambda response
         $url = "http://{$this->apiUrl}/2018-06-01/runtime/invocation/$invocationId/error";
         $this->postJson($url, [
-            'errorMessage' => $error->getMessage(),
             'errorType' => get_class($error),
+            'errorMessage' => $error->getMessage(),
             'stackTrace' => explode(PHP_EOL, $error->getTraceAsString()),
         ]);
     }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -206,13 +206,19 @@ final class LambdaRuntime
             $errorMessage = $error->getMessage();
         }
 
-        // Log the exception in CloudWatch
-        printf(
-            "Fatal error: %s in %s:%d\nStack trace:\n%s",
+        $errorMessage = sprintf(
+            'Fatal error: %s in %s:%d',
             $errorMessage,
             $error->getFile(),
-            $error->getLine(),
-            $error->getTraceAsString()
+            $error->getLine()
+        );
+
+        // Log the exception in CloudWatch
+        printf(
+            '{"errorType": "%s", "errorMessage": "%s", "stack": %s}',
+            get_class($error),
+            $errorMessage,
+            json_encode(explode(PHP_EOL, $error->getTraceAsString()))
         );
 
         // Send an "error" Lambda response

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -200,20 +200,19 @@ final class LambdaRuntime
      */
     private function signalFailure(string $invocationId, \Throwable $error): void
     {
-        if ($error instanceof Exception) {
-            $errorMessage = 'Uncaught ' . get_class($error) . ': ' . $error->getMessage();
-        } else {
-            $errorMessage = $error->getMessage();
+        $errorMessage = $error->getMessage();
+        if (! $error instanceof Exception) {
+            $errorMessage = sprintf(
+                'Fatal error: %s in %s:%d',
+                $error->getMessage(),
+                $error->getFile(),
+                $error->getLine()
+            );
         }
 
-        $errorMessage = sprintf(
-            'Fatal error: %s in %s:%d',
-            $errorMessage,
-            $error->getFile(),
-            $error->getLine()
-        );
-
         // Log the exception in CloudWatch
+        // We use the same log format as what we can see when throwing an exception in the NodeJS runtime
+        // See https://github.com/brefphp/bref/pull/579
         echo json_encode([
             'errorType' => get_class($error),
             'errorMessage' => $errorMessage,

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -19,12 +19,14 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
     {
         parent::setUp();
 
+        ob_start();
         $this->fakeContext = new Context('abc', time(), 'abc', 'abc');
     }
 
     public function tearDown()
     {
         $this->fpm->stop();
+        ob_end_clean();
     }
 
     public function test simple request()

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -306,7 +306,7 @@ ERROR;
             new Response( // lambda event
                 200,
                 [
-                    'lambda-runtime-aws-request-id' => 1,
+                    'lambda-runtime-aws-request-id' => '1',
                     'lambda-runtime-invoked-function-arn' => 'test-function-name',
                 ],
                 json_encode($event)
@@ -331,9 +331,6 @@ ERROR;
         $this->assertEquals($result, json_decode($eventResponse->getBody()->__toString(), true));
     }
 
-    /**
-     * @param mixed $result
-     */
     private function assertInvocationErrorResult(string $errorClass, string $errorMessage)
     {
         $requests = Server::received();
@@ -360,7 +357,16 @@ ERROR;
     private function assertErrorInLogs(string $errorClass, string $errorMessage): void
     {
         // Decode the logs from stdout
-        $invocationResult = json_decode($this->getActualOutput(), true);
+        $stdout = $this->getActualOutput();
+
+        [$requestId, $message, $json] = explode("\t", $stdout);
+
+        $this->assertSame('Invoke Error', $message);
+
+        // Check the request ID matches a UUID
+        $this->assertNotEmpty($requestId);
+
+        $invocationResult = json_decode($json, true);
         $this->assertSame([
             'errorType',
             'errorMessage',

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -31,6 +31,7 @@ class LambdaRuntimeTest extends TestCase
 
     protected function setUp()
     {
+        ob_start();
         Server::start();
         $this->runtime = new LambdaRuntime('localhost:8126');
     }
@@ -38,6 +39,7 @@ class LambdaRuntimeTest extends TestCase
     protected function tearDown()
     {
         Server::stop();
+        ob_end_clean();
     }
 
     public function test basic behavior()
@@ -63,6 +65,18 @@ class LambdaRuntimeTest extends TestCase
             'hello' => 'world',
             'received-function-arn' => 'test-function-name',
         ]);
+    }
+
+    public function test exceptions in the handler result in an invocation error()
+    {
+        $this->givenAnEvent(['Hello' => 'world!']);
+
+        $this->runtime->processNextEvent(function () {
+            throw new \RuntimeException('This is an exception');
+        });
+
+        $this->assertInvocationErrorResult('RuntimeException', 'This is an exception');
+        $this->assertErrorInLogs('RuntimeException', 'This is an exception');
     }
 
     public function test an error is thrown if the runtime API returns a wrong response()
@@ -141,9 +155,11 @@ class LambdaRuntimeTest extends TestCase
         $this->assertSame('POST', $eventFailureLog->getMethod());
         $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/1/error', $eventFailureLog->getUri()->__toString());
 
-        $error = json_decode((string) $eventFailureLog->getBody());
-        $this->expectOutputRegex('/^Fatal error: Uncaught Exception: Error while calling the Lambda runtime API: The requested URL returned error: 400 Bad Request/');
-        $this->assertSame('Error while calling the Lambda runtime API: The requested URL returned error: 400 Bad Request', $error->errorMessage);
+        // Check the lambda result contains the error message
+        $error = json_decode((string) $eventFailureLog->getBody(), true);
+        $this->assertSame('Error while calling the Lambda runtime API: The requested URL returned error: 400 Bad Request', $error['errorMessage']);
+
+        $this->assertErrorInLogs('Exception', 'Error while calling the Lambda runtime API: The requested URL returned error: 400 Bad Request');
     }
 
     public function test function results that cannot be encoded are reported as invocation errors()
@@ -154,18 +170,13 @@ class LambdaRuntimeTest extends TestCase
             return "\xB1\x31";
         });
 
-        $requests = Server::received();
-        $this->assertCount(2, $requests);
-
-        [$eventRequest, $eventFailureLog] = $requests;
-        $this->assertSame('GET', $eventRequest->getMethod());
-        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/next', $eventRequest->getUri()->__toString());
-        $this->assertSame('POST', $eventFailureLog->getMethod());
-        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/1/error', $eventFailureLog->getUri()->__toString());
-
-        $error = json_decode((string) $eventFailureLog->getBody());
-        $this->expectOutputRegex('/^Fatal error: Uncaught Exception: The Lambda response cannot be encoded to JSON/');
-        $this->assertSame("The Lambda response cannot be encoded to JSON.\nThis error usually happens when you try to return binary content. If you are writing a HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses\nHere is the original JSON error: 'Malformed UTF-8 characters, possibly incorrectly encoded'", $error->errorMessage);
+        $message = <<<ERROR
+The Lambda response cannot be encoded to JSON.
+This error usually happens when you try to return binary content. If you are writing a HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses
+Here is the original JSON error: 'Malformed UTF-8 characters, possibly incorrectly encoded'
+ERROR;
+        $this->assertInvocationErrorResult('Exception', $message);
+        $this->assertErrorInLogs('Exception', $message);
     }
 
     public function test generic event handler()
@@ -282,11 +293,8 @@ class LambdaRuntimeTest extends TestCase
 
         $this->runtime->processNextEvent(null);
 
-        $requests = Server::received();
-        $this->assertCount(2, $requests);
-        $error = json_decode((string) $requests[1]->getBody(), true);
-        $this->expectOutputRegex('/^Fatal error: Uncaught Exception: The lambda handler must be a callable or implement handler interfaces/');
-        $this->assertSame('The lambda handler must be a callable or implement handler interfaces', $error['errorMessage']);
+        $this->assertInvocationErrorResult('Exception', 'The lambda handler must be a callable or implement handler interfaces');
+        $this->assertErrorInLogs('Exception', 'The lambda handler must be a callable or implement handler interfaces');
     }
 
     /**
@@ -321,5 +329,45 @@ class LambdaRuntimeTest extends TestCase
         $this->assertSame('POST', $eventResponse->getMethod());
         $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/1/response', $eventResponse->getUri()->__toString());
         $this->assertEquals($result, json_decode($eventResponse->getBody()->__toString(), true));
+    }
+
+    /**
+     * @param mixed $result
+     */
+    private function assertInvocationErrorResult(string $errorClass, string $errorMessage)
+    {
+        $requests = Server::received();
+        $this->assertCount(2, $requests);
+
+        [$eventRequest, $eventResponse] = $requests;
+        $this->assertSame('GET', $eventRequest->getMethod());
+        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/next', $eventRequest->getUri()->__toString());
+        $this->assertSame('POST', $eventResponse->getMethod());
+        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/1/error', $eventResponse->getUri()->__toString());
+
+        // Check the content of the result of the lambda
+        $invocationResult = json_decode($eventResponse->getBody()->__toString(), true);
+        $this->assertSame([
+            'errorType',
+            'errorMessage',
+            'stackTrace',
+        ], array_keys($invocationResult));
+        $this->assertEquals($errorClass, $invocationResult['errorType']);
+        $this->assertEquals($errorMessage, $invocationResult['errorMessage']);
+        $this->assertInternalType('array', $invocationResult['stackTrace']);
+    }
+
+    private function assertErrorInLogs(string $errorClass, string $errorMessage): void
+    {
+        // Decode the logs from stdout
+        $invocationResult = json_decode($this->getActualOutput(), true);
+        $this->assertSame([
+            'errorType',
+            'errorMessage',
+            'stack',
+        ], array_keys($invocationResult));
+        $this->assertEquals($errorClass, $invocationResult['errorType']);
+        $this->assertEquals($errorMessage, $invocationResult['errorMessage']);
+        $this->assertInternalType('array', $invocationResult['stack']);
     }
 }


### PR DESCRIPTION
This PR starts from #579 and adds tests + adds a few things.

## The problem

To reuse what @deleugpn described in #579: current errors in PHP lambdas appear like this in logs (CloudWatch):

![](https://user-images.githubusercontent.com/9533181/75883578-85360e00-5e23-11ea-8d6e-5f51ec3834d0.png)

This is hard to read, **and** this is not consistent with official runtimes like NodeJS. NodeJS logs an exception like this:

![](https://user-images.githubusercontent.com/9533181/75883649-a26adc80-5e23-11ea-88a3-9dd6741386fe.png)

## This PR

With these changes, here is how logs will look like:

![Capture d’écran 2020-03-14 à 12 21 53](https://user-images.githubusercontent.com/720328/76681007-69cebe00-65ee-11ea-9c81-e893c2821fbd.png)

In short, the error is formatted in JSON. Looking good!

Other changes:

- the log message is simpler: it is the error/exception message only
  - it no longer contains `Fatal error:` (the log line contains `Invoke Error`, so that's less noise)
  - it no longer contains `Uncaught exception:`: we don't want users to think "oh I need to catch exceptions" -> exceptions should not be caught, instead Lambda will handle them
  - it no longer contains the file + line number: the first line of the stack trace already contains that
- the log line now contains the "Request ID" (or invocation ID), because:
  - it is closer to NodeJS's output
  - it allows us to easily find the logs of a single invocation
  - all this stems from https://github.com/brefphp/logger/issues/3
- I updated tests and added more of them (as well as made them more readable)

Bonus: how the execution result looks in `serverless invoke`:

![Capture d’écran 2020-03-14 à 12 19 08](https://user-images.githubusercontent.com/720328/76680987-0fcdf880-65ee-11ea-855e-2596df75b96d.png)

How the logs look in `serverless logs` (yuck…):

![Capture d’écran 2020-03-14 à 12 19 56](https://user-images.githubusercontent.com/720328/76680993-296f4000-65ee-11ea-86e1-1a99d30966c6.png)

