### PR TITLE
Add support for EventBridge events

### DIFF
--- a/src/Event/EventBridge/EventBridgeEvent.php
+++ b/src/Event/EventBridge/EventBridgeEvent.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\EventBridge;
+
+use Bref\Event\InvalidLambdaEvent;
+use Bref\Event\LambdaEvent;
+use DateTimeImmutable;
+
+/**
+ * Represents a Lambda event when Lambda is invoked by EventBridge.
+ */
+final class EventBridgeEvent implements LambdaEvent
+{
+    /** @var array */
+    private $event;
+
+    /**
+     * @param mixed $event
+     */
+    public function __construct($event)
+    {
+        if (! is_array($event) || ! isset($event['detail-type'])) {
+            throw new InvalidLambdaEvent('EventBridge', $event);
+        }
+        $this->event = $event;
+    }
+
+    public function getId(): string
+    {
+        return $this->event['id'];
+    }
+
+    public function getVersion(): string
+    {
+        return $this->event['version'];
+    }
+
+    public function getAwsRegion(): string
+    {
+        return $this->event['region'];
+    }
+
+    public function getTimestamp(): DateTimeImmutable
+    {
+        // Date in RFC3339 format per https://docs.aws.amazon.com/eventbridge/latest/APIReference/eventbridge-api.pdf
+        return DateTimeImmutable::createFromFormat(DATE_RFC3339, $this->event['time']);
+    }
+
+    public function getAwsAccountId(): string
+    {
+        return $this->event['account'];
+    }
+
+    public function getSource(): string
+    {
+        return $this->event['source'];
+    }
+
+    public function getDetailType(): string
+    {
+        return $this->event['detail-type'];
+    }
+
+    /**
+     * Returns the content of the EventBridge message.
+     *
+     * Note that when publishing an event from PHP, we JSON-encode the 'detail' field.
+     * However, this method will not return a JSON string: it will return the decoded content.
+     * This is how EventBridge works: we publish a message with JSON-encoded data. EventBridge decodes it
+     * and triggers listeners with the decoded data.
+     *
+     * @return mixed
+     */
+    public function getDetail()
+    {
+        return $this->event['detail'];
+    }
+
+    public function toArray(): array
+    {
+        return $this->event;
+    }
+}

--- a/src/Event/EventBridge/EventBridgeHandler.php
+++ b/src/Event/EventBridge/EventBridgeHandler.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\EventBridge;
+
+use Bref\Context\Context;
+use Bref\Event\Handler;
+
+/**
+ * Handles EventBridge events.
+ */
+abstract class EventBridgeHandler implements Handler
+{
+    abstract public function handleEventBridge(EventBridgeEvent $event, Context $context): void;
+
+    /** {@inheritDoc} */
+    public function handle($event, Context $context): void
+    {
+        $this->handleEventBridge(new EventBridgeEvent($event), $context);
+    }
+}

--- a/tests/Event/EventBridge/EventBridgeEventTest.php
+++ b/tests/Event/EventBridge/EventBridgeEventTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test\Event\EventBridge;
+
+use Bref\Event\EventBridge\EventBridgeEvent;
+use Bref\Event\InvalidLambdaEvent;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class EventBridgeEventTest extends TestCase
+{
+    public function test canonical case()
+    {
+        $json = json_decode(file_get_contents(__DIR__ . '/eventbridge.json'), true);
+        $event = new EventBridgeEvent($json);
+
+        $this->assertSame('53dc4d37-cffa-4f76-80c9-8b7d4a4d2eaa', $event->getId());
+        $this->assertSame('0', $event->getVersion());
+        $this->assertSame('us-east-1', $event->getAwsRegion());
+        $this->assertSame('123456789012', $event->getAwsAccountId());
+        $this->assertSame('myapp', $event->getSource());
+        $this->assertEquals(new DateTimeImmutable('2015-10-08T16:53:06Z'), $event->getTimestamp());
+        $this->assertSame('Example event', $event->getDetailType());
+        $this->assertSame([
+            'file' => 'streaming/video.mkv',
+        ], $event->getDetail());
+    }
+
+    public function test event with empty details()
+    {
+        $json = json_decode(file_get_contents(__DIR__ . '/eventbridge-details-empty.json'), true);
+        $event = new EventBridgeEvent($json);
+
+        $this->assertSame('53dc4d37-cffa-4f76-80c9-8b7d4a4d2eaa', $event->getId());
+        $this->assertSame('0', $event->getVersion());
+        $this->assertSame('us-east-1', $event->getAwsRegion());
+        $this->assertSame('123456789012', $event->getAwsAccountId());
+        $this->assertSame('aws.events', $event->getSource());
+        $this->assertEquals(new DateTimeImmutable('2015-10-08T16:53:06Z'), $event->getTimestamp());
+        $this->assertSame('Example event', $event->getDetailType());
+        $this->assertSame([], $event->getDetail());
+    }
+
+    public function test invalid event()
+    {
+        $this->expectException(InvalidLambdaEvent::class);
+        $this->expectExceptionMessage('This handler expected to be invoked with a EventBridge event. Instead, the handler was invoked with invalid event data');
+        new EventBridgeEvent([]);
+    }
+}

--- a/tests/Event/EventBridge/eventbridge-details-empty.json
+++ b/tests/Event/EventBridge/eventbridge-details-empty.json
@@ -1,0 +1,13 @@
+{
+    "version": "0",
+    "id": "53dc4d37-cffa-4f76-80c9-8b7d4a4d2eaa",
+    "detail-type": "Example event",
+    "source": "aws.events",
+    "account": "123456789012",
+    "time": "2015-10-08T16:53:06Z",
+    "region": "us-east-1",
+    "resources": [
+        "arn:aws:events:us-east-1:123456789012:rule/my-scheduled-rule"
+    ],
+    "detail": {}
+}

--- a/tests/Event/EventBridge/eventbridge.json
+++ b/tests/Event/EventBridge/eventbridge.json
@@ -1,0 +1,13 @@
+{
+    "version": "0",
+    "id": "53dc4d37-cffa-4f76-80c9-8b7d4a4d2eaa",
+    "detail-type": "Example event",
+    "source": "myapp",
+    "account": "123456789012",
+    "time": "2015-10-08T16:53:06Z",
+    "region": "us-east-1",
+    "resources": [],
+    "detail": {
+        "file": "streaming\/video.mkv"
+    }
+}

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -3,6 +3,8 @@
 namespace Bref\Test\Runtime;
 
 use Bref\Context\Context;
+use Bref\Event\EventBridge\EventBridgeEvent;
+use Bref\Event\EventBridge\EventBridgeHandler;
 use Bref\Event\Handler;
 use Bref\Event\Http\HttpRequestEvent;
 use Bref\Event\S3\S3Event;
@@ -284,6 +286,25 @@ ERROR;
             ],
             'body' => 'Hello world!',
         ]);
+    }
+
+    public function test EventBridge event handler()
+    {
+        $handler = new class() extends EventBridgeHandler {
+            /** @var EventBridgeEvent */
+            public $event;
+            public function handleEventBridge(EventBridgeEvent $event, Context $context): void
+            {
+                $this->event = $event;
+            }
+        };
+
+        $eventData = json_decode(file_get_contents(__DIR__ . '/../Event/EventBridge/eventbridge.json'), true);
+        $this->givenAnEvent($eventData);
+
+        $this->runtime->processNextEvent($handler);
+
+        $this->assertEquals(new EventBridgeEvent($eventData), $handler->event);
     }
 
     public function test invalid handlers are rejected properly()


### PR DESCRIPTION
This PR introduces native support for EventBridge events (by writing a handler for those events). This is similar to what we support with SQS, SNS and S3 events.

Example:

```php
class MyHandler extends EventBridgeHandler
{
    public function handleEventBridge(EventBridgeEvent $event, Context $context): void
    {
        // ...
    }
}

return new MyHandler();
```