### PR TITLE
Suggest to exclude var directory when deploying Symfony applications

### DIFF
--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -36,6 +36,7 @@ package:
     exclude:
         - node_modules/**
         - tests/**
+        - var/**
 
 functions:
     website:


### PR DESCRIPTION
IMO Symfony's `var` directory (containing mainly cache and log) should not be deployed to AWS and could be excluded by default. Do you agree?

It also avoids potential deploy error when archive is too big due to the cache being included :smile: 