### PR TITLE
add reference to the rds-data api (resolves #596)

### DIFF
--- a/docs/environment/database.md
+++ b/docs/environment/database.md
@@ -6,13 +6,12 @@ introduction: Configure Bref to use a database in your PHP application on AWS La
 
 AWS offers the [RDS](https://aws.amazon.com/rds/) service to run MySQL and PostgreSQL databases.
 
-Here are the database services offered by RDS:
+Here are some of the database services offered by RDS:
 
 - MySQL
 - PostgreSQL
-- [Aurora MySQL](https://aws.amazon.com/rds/aurora/): optimized closed-source fork
-- [Aurora PostgreSQL](https://aws.amazon.com/rds/aurora/): optimized closed-source fork
-- [Aurora Serverless MySQL](https://aws.amazon.com/rds/aurora/serverless/): scales automatically on-demand
+- [Aurora MySQL/PostgreSQL](https://aws.amazon.com/rds/aurora/): closed-source database with MySQL/PostgreSQL compatibility
+- [Aurora Serverless MySQL/PostgreSQL](https://aws.amazon.com/rds/aurora/serverless/): similar to Aurora but scales automatically on-demand
 
 > Aurora Serverless can be configured to scale down to 0 instances when unused (which costs $0), however be careful with this option: the database can take up to 30 seconds to un-pause.
 
@@ -23,7 +22,9 @@ All RDS databases can be setup with Lambda in two ways:
 
 While the first solution is simpler, the second is more secure. Using a VPC also comes with a few limitations that are detailed below.
 
-This page documents how to create databases using VPC (the secure solution). If you want to skip using a VPC you can read the instructions in the "Accessing the database from your machine" section.
+If you use Aurora Serverless, you can also use the [rds-data](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html) api which allows you to use a http api to execute sql statements which is generally considered secure. You probably don't want to use it directly but rather though a library like the [dbal-rds-data](https://github.com/Nemo64/dbal-rds-data) driver which documentents the usage quiet well. Please note that the library and the api itself is quiet new, if you aren't prepared for experimentation you should probably avoid this api altogether.
+
+This page documents how to create databases using VPC (the generally available, reliable and secure solution). If you want to skip using a VPC you can read the instructions in the "Accessing the database from your machine" section.
 
 ## Limitations
 


### PR DESCRIPTION
I added a reference to the aurora rds-data api to the documentation because it is a generally good option to avoid a vpc in your serverless setup.

I also added a reference to my [dbal-rds-data](https://github.com/Nemo64/dbal-rds-data) api which makes the usage fairly seemless because i haven't found another already ready made solution on packagist.

And at last i updated the database list a bit because it was kind of missleading by telling that it is a complete list of services offered by rds. I added a reference that aurora serverless also supports postgresql and made it clear that those are just some of the offered services.