### PR TITLE
Updated tests

### DIFF
--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -23,7 +23,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         $this->fakeContext = new Context('abc', time(), 'abc', 'abc');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->fpm->stop();
         ob_end_clean();

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -31,14 +31,14 @@ class LambdaRuntimeTest extends TestCase
     /** @var LambdaRuntime */
     private $runtime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         ob_start();
         Server::start();
         $this->runtime = new LambdaRuntime('localhost:8126');
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         Server::stop();
         ob_end_clean();

--- a/tests/Sam/PhpFpmRuntimeTest.php
+++ b/tests/Sam/PhpFpmRuntimeTest.php
@@ -17,7 +17,7 @@ class PhpFpmRuntimeTest extends TestCase
     /** @var string */
     private $logs;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->logs = '';

--- a/tests/Sam/Psr7Test.php
+++ b/tests/Sam/Psr7Test.php
@@ -12,7 +12,7 @@ class Psr7Test extends TestCase
     /** @var string */
     private $logs;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->logs = '';


### PR DESCRIPTION
This is more of a helper to assist with future updates which are going to be needed when you update to a later version of PHPUnit (the latest version has changed the base-classes, so the signatures on some of the methods need to be updated)

I'd needed to update them anyway when running the PHPUnit tests locally (before realising the vendor/bin/phpunit exec was the correct command!)