### PR TITLE
try to make the cdn configuration simpler

### DIFF
--- a/docs/websites.md
+++ b/docs/websites.md
@@ -182,8 +182,6 @@ resources:
                         -   Id: Assets
                             DomainName: !GetAtt Assets.RegionalDomainName
                             S3OriginConfig: {} # this key is required to tell CloudFront that this is an S3 origin, even though nothing is configured
-                            # you can also use a CustomOrigin but the S3Origin creates correct 404 error and has other optimizations as well
-                            # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/DownloadDistS3AndCustomOrigins.html#concept_S3Origin
                     # The default behavior is to send everything to AWS Lambda
                     DefaultCacheBehavior:
                         AllowedMethods: [GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE]

--- a/docs/websites.md
+++ b/docs/websites.md
@@ -153,10 +153,7 @@ resources:
     Resources:
         # The S3 bucket that stores the assets
         Assets:
-            Type: AWS::S3::Bucket
-            Properties:
-                BucketName: <bucket-name>
-                AccessControl: PublicRead # needed for the cdn to read the directory structure
+            # [...] see the previous section for details 
         AssetsBucketPolicy:
             # [...] see the previous section for details 
     

--- a/docs/websites.md
+++ b/docs/websites.md
@@ -179,6 +179,13 @@ resources:
                         -   Id: Assets
                             DomainName: !GetAtt Assets.RegionalDomainName
                             S3OriginConfig: {} # this key is required to tell CloudFront that this is an S3 origin, even though nothing is configured
+                            # If you host a static website, like a SPA, use s3-website URLs instead of the config above
+                            # See https://stackoverflow.com/questions/15309113/amazon-cloudfront-doesnt-respect-my-s3-website-buckets-index-html-rules#15528757
+                            # DomainName: !Join ['', [!Ref Assets, '.s3-website-', !Ref AWS::Region, '.amazonaws.com']]
+                            # CustomOriginConfig:
+                            #     OriginProtocolPolicy: 'http-only' # S3 websites only support HTTP
+                            # You'll also need to enable website hosting on your s3 bucket by configuring the WebsiteConfiguration property
+                            # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html#cfn-s3-bucket-websiteconfiguration
                     # The default behavior is to send everything to AWS Lambda
                     DefaultCacheBehavior:
                         AllowedMethods: [GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE]


### PR DESCRIPTION
The serverless-pseudo-parameters plugin is not really needed and the trade of of a slightly less readable syntax is definitely worth the 1 fewer dependency and not needing to having npm.
This was annoying when I started experimenting with bref and aws a few months ago since I already had webpack and frontend dependencies in my `package.json`. It wasn't sensible to completely avoid plugins for me but the initial setup is much simpler like this.

Then I also removed the slightly inconsistent definition of the assets target. It talked and configured the source partially for an s3 website source but didn't use an s3 website endpoint in the end. It now is just a plain s3origin with a reference to the manual. There are a few advantages to an s3origin like correctly sending 404 error when something isn't there.
