### PR TITLE
Add details about setting SSM entries on Windows

### DIFF
--- a/docs/environment/variables.md
+++ b/docs/environment/variables.md
@@ -43,6 +43,11 @@ To create a parameter you can either do it manually in the [SSM parameter store 
 aws ssm put-parameter --region us-east-1 --name '/my-app/my-parameter' --type String --value 'mysecretvalue'
 ```
 
+For Windows users, the first part of the parth needs to be double slashes and all subsequent forward slashes changed to backslashes:
+```bash
+aws ssm put-parameter --region us-east-1 --name '//my-app\my-parameter' --type String --value 'mysecretvalue'
+```
+
 It is recommended to prefix the parameter name with your application name, for example: `/my-app/my-parameter`.
 
 To import the SSM parameter into an environment variable you can use the [`${ssm:<parameter>}` syntax](https://serverless.com/blog/serverless-secrets-api-keys/):


### PR DESCRIPTION
I found setting the SSM details on a Windows 10 machine using Powershell to be "non-standard" and I hope this small change will save people time in the future.