### PR TITLE
Homepage Type Updates

### DIFF
--- a/website/template/home.twig
+++ b/website/template/home.twig
@@ -70,7 +70,7 @@
                         Creating and running <strong>modern and scalable PHP applications</strong> can be simple. By using serverless technologies, like AWS Lambda, we can focus on development and worry less about servers.
                     </p>
                     <p>
-                        Bref is an open source project that brings full support for PHP and its frameworks on AWS Lambda.
+                        Bref is an open source project that brings full support for PHP and its frameworks to AWS Lambda.
                     </p>
                 </div>
                 <div class="flex-1 text-center">
@@ -87,7 +87,7 @@
                         for a better view of the cloud.
                     </h2>
                     <p class="mb-3">
-                        Getting started with serverless can be overwhelming. Bref integrates with the open-source <a href="https://serverless.com/">Serverless framework</a> for configuration and deployment.
+                        Getting started with serverless can be overwhelming. Bref integrates with the open-source <a href="https://serverless.com/">Serverless Framework</a> for configuration and deployment.
                         We get the best of both world: <strong>powerful, yet simple</strong>.
                     </p>
                     <p>
@@ -100,7 +100,7 @@
                             <path d="M0 33.9789H9.558L6.59665 42.9153H0V33.9789ZM0 16.9892H15.1875L12.2268 25.9256H0V16.9894V16.9892ZM0 0H20.8178L17.8563 8.9362H0V0ZM30.2377 0H54V8.9362H27.2767L30.2377 0ZM24.608 16.9892H54V25.9258H21.6468L24.608 16.9894V16.9892ZM18.978 33.9789H54V42.9153H16.0171L18.978 33.9789Z" fill="#FD5650"/>
                         </svg>
                     </div>
-                    <h3 class="text-lg md:text-xl font-sans">Simple cloud orchestration <br> via the Serverless framework</h3>
+                    <h3 class="text-lg md:text-xl font-sans">Simple cloud orchestration <br> via the Serverless Framework</h3>
                 </div>
             </div>
 
@@ -116,7 +116,7 @@
     <section class="py-24 lg:pb-32 bg-gray-100 text-center">
         <div class="container mx-auto px-4">
             <h2 class="mb-12 md:mb-16 text-3xl md:text-4xl lg:text-4xl xl:text-5xl font-bref text-gray-800">
-                They sponsors the project
+                They sponsor the project
             </h2>
             <div class="mb-8 flex flex-wrap justify-center justify-around">
                 <a class="block self-center mx-6 mb-6" href="https://null.tc/" title="Serverless consulting company">


### PR DESCRIPTION
Found a typo on the home page:

> They sponsors the project

In this case _sponsors_ should just be _sponsor_.

Went ahead and reviewed all the text and made a few more updates. 

Serverless Framework: In all cases I could find on their sites framework in is capitalized.

Minor change to change "on AWS Lambda" to "to AWS Lambda". This sentence is implying that bref is bringing PHP support _to_ Lambda. 