### PR TITLE
Simplify the console invocation format (use a simple string)

### DIFF
--- a/bref
+++ b/bref
@@ -105,9 +105,7 @@ $app->command('cli function [--region=] [--profile=] [arguments]*', function (st
     }, $arguments);
 
     try {
-        $result = $lambda->invoke($function, json_encode([
-            'cli' => implode(' ', $arguments),
-        ]));
+        $result = $lambda->invoke($function, json_encode(implode(' ', $arguments)));
     } catch (InvocationFailed $e) {
         $io->getErrorStyle()->writeln('<info>' . $e->getInvocationLogs() . '</info>');
         $io->error($e->getMessage());

--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -26,7 +26,14 @@ if (! is_file($handlerFile)) {
 
 while (true) {
     $lambdaRuntime->processNextEvent(function ($event, Context $context) use ($handlerFile): array {
-        $cliOptions = $event['cli'] ?? '';
+        if (is_array($event)) {
+            // Backward compatibility with the former CLI invocation format
+            $cliOptions = $event['cli'] ?? '';
+        } elseif (is_string($event)) {
+            $cliOptions = $event;
+        } else {
+            $cliOptions = '';
+        }
 
         // We redirect stderr to stdout so that all the output is collected
         $command = sprintf(


### PR DESCRIPTION
From https://github.com/brefphp/bref/issues/339#issuecomment-611445756

The `'{"cli": "doctrine:migrate --force"}'` JSON structure used to exist for Bref 0.2 that used to mix event types for the same handler. Now, we don't really need this anymore.

We could switch the `console` runtime "event" to a simple string. That would make cron much easier to define, for example:

```yaml
        events:
            - schedule:
                rate: rate(1 minute)
                input: 'doctrine:migrate --force'
```

That could even been invokable easily via `serverless invoke`:

```bash
serverless invoke -f console -d 'doctrine:migrate --force'
```

For now I have kept backward compatibility with the current event array format.