### PR TITLE
Fix missing dependency for PSR-15 handlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "riverline/multipart-parser": "^2.0.6",
         "psr/http-server-handler": "^1.0",
         "async-aws/cloud-formation": "^0.4",
-        "async-aws/lambda": "^0.4"
+        "async-aws/lambda": "^0.4",
+        "nyholm/psr7": "^1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",

--- a/src/Event/Http/Psr7Bridge.php
+++ b/src/Event/Http/Psr7Bridge.php
@@ -4,6 +4,7 @@ namespace Bref\Event\Http;
 
 use Bref\Context\Context;
 use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Stream;
 use Nyholm\Psr7\UploadedFile;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -39,11 +40,18 @@ final class Psr7Bridge
             $server['HTTP_HOST'] = $headers['Host'];
         }
 
+        /**
+         * Nyholm/psr7 does not rewind body streams, we do it manually
+         * so that users can fetch the content of the body directly.
+         */
+        $bodyStream = Stream::create($event->getBody());
+        $bodyStream->rewind();
+
         $request = new ServerRequest(
             $event->getMethod(),
             $event->getUri(),
             $event->getHeaders(),
-            $event->getBody(),
+            $bodyStream,
             $event->getProtocolVersion(),
             $server
         );

--- a/src/Event/Http/Psr7Bridge.php
+++ b/src/Event/Http/Psr7Bridge.php
@@ -3,8 +3,8 @@
 namespace Bref\Event\Http;
 
 use Bref\Context\Context;
-use GuzzleHttp\Psr7\ServerRequest;
-use GuzzleHttp\Psr7\UploadedFile;
+use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\UploadedFile;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Riverline\MultiPartParser\Part;


### PR DESCRIPTION
Since we don't require the AWS SDK anymore, Guzzle is not installed as a transitive dependency. The PSR-15 handler mechanism doesn't work anymore.

The root of the issue was that we did not explicitly require Guzzle's dependency originally, so we missed this. Anyway, I ended up installing @Nyholm's library because it's great (fast, lightweight).

I tried setting up https://github.com/maglnet/ComposerRequireChecker but there are false positives and I gave up after spending some time on it. Anyone is welcome to pick that up :)