### PR TITLE
Expose Lambda invocation context within console runtime

### DIFF
--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -69,3 +69,15 @@ Your database has been migrated.
 $ AWS_DEFAULT_REGION=eu-central-1 AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar vendor/bin/bref cli my-function
 # ...
 ```
+
+## Lambda context
+
+Lambda provides information about the invocation, function, and execution environment via the *lambda context*.
+
+This context is usually available as a parameter (alongside the event), within the defined handler.
+However, within the console runtime we do not have direct access to this parameter.
+To work around that, Bref puts the Lambda context in the `$_SERVER['LAMBDA_INVOCATION_CONTEXT']` variable as a JSON-encoded string.
+
+```php
+$lambdaContext = json_decode($_SERVER['LAMBDA_INVOCATION_CONTEXT'], true);
+```

--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -1,6 +1,7 @@
 #!/opt/bin/php
 <?php declare(strict_types=1);
 
+use Bref\Context\Context;
 use Bref\Runtime\LambdaRuntime;
 
 ini_set('display_errors', '1');
@@ -24,11 +25,16 @@ if (! is_file($handlerFile)) {
 }
 
 while (true) {
-    $lambdaRuntime->processNextEvent(function ($event) use ($handlerFile): array {
+    $lambdaRuntime->processNextEvent(function ($event, Context $context) use ($handlerFile): array {
         $cliOptions = $event['cli'] ?? '';
 
         // We redirect stderr to stdout so that all the output is collected
-        $command = "/opt/bin/php $handlerFile " . $cliOptions . ' 2>&1';
+        $command = sprintf(
+            'LAMBDA_INVOCATION_CONTEXT=%s /opt/bin/php %s %s 2>&1',
+            escapeshellarg(json_encode($context)),
+            $handlerFile,
+            $cliOptions
+        );
 
         exec($command, $output, $exitCode);
 


### PR DESCRIPTION
This allows us to access the Lambda context within console runtime invocations, in a similar fashion to how we can within PHP-FPM usage.

**Note:** This depends on the `JsonSerializable` context changes present in https://github.com/brefphp/bref/pull/623