### PR TITLE
New behaviour for config caches in Laravel 7.x

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -81,7 +81,7 @@ Finally we need to edit `app/Providers/AppServiceProvider.php` because Laravel w
 
 ## Deployment
 
-At the moment deploying Laravel with its caches will break in AWS Lambda (because most file paths are different). This is why it is currently necessary to deploy without the config cache file. Simply run `php artisan config:clear` to make sure that file doesn't exist.
+At the moment deploying Laravel with its caches will break in AWS Lambda (because most file paths are different). This is why it is currently necessary to deploy without the config cache file. However, deploying Laravel without it's packages and services cache will also break in Lambda. The solution is to run `php artisan config:cache` to build all caches (not only config) and then `php artisan config:clear` to make sure that config cache file doesn't exist.
 
 Your application is now ready to be deployed. Follow [the deployment guide](/docs/deploy.md).
 


### PR DESCRIPTION
I'm using Laravel 7.8.1.

If you don't run `artisan config:cache` you will not have `packages.php` and `services.php` inside `bootstrap/cache`.

Without these files Laravel will try to create them and this will cause the error 'The bootstrap/cache directory must be present and writable'.

However, we still need to run `artisan config:clear` to delete `bootstrap/cache/config.php` that contains wrong paths.

<!--
I spent some hours trying to understand why my local deployment is different with the CI version. The reason was in these changes. `php artisan config:clear` is not enough anymore with Laravel 7.x.
-->
