### PR TITLE
Add Kinesis typed events

### DIFF
--- a/src/Event/Kinesis/KinesisEvent.php
+++ b/src/Event/Kinesis/KinesisEvent.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\Kinesis;
+
+use Bref\Event\InvalidLambdaEvent;
+use Bref\Event\LambdaEvent;
+
+final class KinesisEvent implements LambdaEvent
+{
+    /** @var array */
+    private $event;
+
+    /**
+     * @param mixed $event
+     * @throws InvalidLambdaEvent
+     */
+    public function __construct($event)
+    {
+        if (! is_array($event) || ! isset($event['Records'])) {
+            throw new InvalidLambdaEvent('Kinesis', $event);
+        }
+
+        $this->event = $event;
+    }
+
+    /**
+     * @return KinesisRecord[]
+     */
+    public function getRecords(): array
+    {
+        return array_map(
+            function ($record): KinesisRecord {
+                try {
+                    return new KinesisRecord($record);
+                } catch (\InvalidArgumentException $e) {
+                    throw new InvalidLambdaEvent('Kinesis', $this->event);
+                }
+            },
+            $this->event['Records']
+        );
+    }
+
+    public function toArray(): array
+    {
+        return $this->event;
+    }
+}

--- a/src/Event/Kinesis/KinesisHandler.php
+++ b/src/Event/Kinesis/KinesisHandler.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\Kinesis;
+
+use Bref\Context\Context;
+use Bref\Event\Handler;
+
+abstract class KinesisHandler implements Handler
+{
+    abstract public function handleKinesis(KinesisEvent $event, Context $context): void;
+
+    /** {@inheritDoc} */
+    public function handle($event, Context $context): void
+    {
+        $this->handleKinesis(new KinesisEvent($event), $context);
+    }
+}

--- a/src/Event/Kinesis/KinesisRecord.php
+++ b/src/Event/Kinesis/KinesisRecord.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\Kinesis;
+
+use DateTimeImmutable;
+
+final class KinesisRecord
+{
+    /** @var array */
+    private $record;
+
+    /**
+     * @param mixed $record
+     */
+    public function __construct($record)
+    {
+        if (! is_array($record) || ! isset($record['eventSource']) || $record['eventSource'] !== 'aws:kinesis') {
+            throw new \InvalidArgumentException('Event source must come from Kinesis');
+        }
+
+        $this->record = $record;
+    }
+
+    public function getApproximateArrivalTime(): DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromFormat('U.u', (string) $this->record['kinesis']['approximateArrivalTimestamp']);
+    }
+
+    public function getData(): array
+    {
+        return json_decode(base64_decode($this->getRawData()), true);
+    }
+
+    public function getEventName(): string
+    {
+        return $this->record['eventName'];
+    }
+
+    public function getPartitionKey(): string
+    {
+        return $this->record['kinesis']['partitionKey'];
+    }
+
+    public function getRawData(): string
+    {
+        return $this->record['kinesis']['data'];
+    }
+
+    public function getSequenceNumber(): string
+    {
+        return $this->record['kinesis']['sequenceNumber'];
+    }
+}

--- a/tests/Event/Kinesis/KinesisEventTest.php
+++ b/tests/Event/Kinesis/KinesisEventTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test\Event\Kinesis;
+
+use Bref\Event\Kinesis\KinesisEvent;
+use PHPUnit\Framework\TestCase;
+
+class KinesisEventTest extends TestCase
+{
+    public function test_event()
+    {
+        // Arrange
+        $rawEvent = json_decode(file_get_contents(__DIR__ . '/kinesis.json'), true);
+
+        $data = [
+            'bref' => 1,
+            'data' => 1,
+        ];
+
+        $date = new \DateTime('2020-04-28T05:20:20.453000Z');
+
+        // Act
+        $event = new KinesisEvent($rawEvent);
+        $record = $event->getRecords()[0];
+
+        // Assert
+        $this->assertSame('1', $record->getSequenceNumber());
+        $this->assertSame('bref-1', $record->getPartitionKey());
+        $this->assertSame('eyJicmVmIjoxLCJkYXRhIjoxfQ==', $record->getRawData());
+        $this->assertSame($data, $record->getData());
+        $this->assertEqualsWithDelta($date->getTimestamp(), $record->getApproximateArrivalTime()->getTimestamp(), 0);
+    }
+}

--- a/tests/Event/Kinesis/kinesis.json
+++ b/tests/Event/Kinesis/kinesis.json
@@ -1,0 +1,36 @@
+{
+  "Records": [
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "bref-1",
+        "sequenceNumber": "1",
+        "data": "eyJicmVmIjoxLCJkYXRhIjoxfQ==",
+        "approximateArrivalTimestamp": 1588051220.453
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "1",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::000000000000:role/bref-role",
+      "awsRegion": "ap-southeast-1",
+      "eventSourceARN": "arn:aws:kinesis:ap-southeast-1:000000000000:stream/bref"
+    },
+    {
+      "kinesis": {
+        "kinesisSchemaVersion": "1.0",
+        "partitionKey": "bref-1",
+        "sequenceNumber": "2",
+        "data": "eyJicmVmIjoxLCJkYXRhIjoyfQ==",
+        "approximateArrivalTimestamp": 1588051437.603
+      },
+      "eventSource": "aws:kinesis",
+      "eventVersion": "1.0",
+      "eventID": "2",
+      "eventName": "aws:kinesis:record",
+      "invokeIdentityArn": "arn:aws:iam::000000000000:role/bref-role",
+      "awsRegion": "ap-southeast-1",
+      "eventSourceARN": "arn:aws:kinesis:ap-southeast-1:000000000000:stream/bref"
+    }
+  ]
+}


### PR DESCRIPTION
Added Kinesis typed events.

The data from the Kinesis stream is represented as a Base64 string. The `$record->getData()` decodes this and converted to PHP array. The raw string can also be retrieved using `$record->getRawData()`.