### PR TITLE
Add Cape Town Region

### DIFF
--- a/runtime/layers/regions.json
+++ b/runtime/layers/regions.json
@@ -14,5 +14,6 @@
     "ap-northeast-1",
     "ap-northeast-2",
     "ap-southeast-1",
-    "ap-southeast-2"
+    "ap-southeast-2",
+    "af-south-1"
 ]


### PR DESCRIPTION
AWS recently added the af-south-1 region in South Africa and we would like to use Bref in our local region.

I have created a PR for the runtimes page as well: brefphp/runtimes.bref.sh#4