### PR TITLE
Make sure one can access user's IP easily

### DIFF
--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -182,6 +182,11 @@ final class FpmHandler extends HttpHandler
         $request->setCustomVar('LAMBDA_INVOCATION_CONTEXT', json_encode($context));
         $request->setCustomVar('LAMBDA_REQUEST_CONTEXT', json_encode($event->getRequestContext()));
 
+        if (isset($event->toArray()['identity']['sourceIp'])) {
+            // Add user's IP as an easy to access variable
+            $request->setCustomVar('LAMBDA_IDENTITY_SOURCE_IP', $event->toArray()['identity']['sourceIp']);
+        }
+
         /** @deprecated The LAMBDA_CONTEXT has been renamed to LAMBDA_REQUEST_CONTEXT for clarity */
         $request->setCustomVar('LAMBDA_CONTEXT', json_encode($event->getRequestContext()));
 


### PR DESCRIPTION
To access the users IP currently, one need to: 

```
if (isset($_SERVER['LAMBDA_REQUEST_CONTEXT'])) {
    $context = json_decode($_SERVER['LAMBDA_REQUEST_CONTEXT'], true);
    $userIp = $context['identity']['sourceIp'] ?? '';
}
```

To avoid decoding a json string to an array, I suggest to put the user IP in a separate variable. 

Pros: 
- It is way simpler
- The user IP is a common value that I would like to have in my logs. 

Cons: 
- We take up "space" in the global `$_SERVER`. But it is just a small string. So I guess it is fine. 
