### PR TITLE
add new command to check if we use the last runtime

### DIFF
--- a/bref
+++ b/bref
@@ -452,7 +452,7 @@ $app->command('layer-checker [--region=]', function($region, SymfonyStyle $io) {
 
     $template = Yaml::parseFile('template.yaml', Yaml::PARSE_CUSTOM_TAGS);
     $layers = [];
-    $return = 0;
+    $notUpToDate = false;
     foreach ($template['Resources'] as $resource => $resourceConfig) {
         if (false === array_key_exists('Layers', $resourceConfig['Properties'])) {
             continue;
@@ -473,7 +473,7 @@ $app->command('layer-checker [--region=]', function($region, SymfonyStyle $io) {
                 $runtimeParts = explode(':', $runtime);
                 $runtimePhp = $runtimeParts[6];
                 if ($layerPhp === $runtimePhp) {
-                    $return = 1;
+                    $notUpToDate = true;
                     $layers[] = ['Resources' => $resource, 'current' => $layer, 'isLast' => 'false', 'last' => $runtime];
                     continue;
                 }
@@ -483,11 +483,16 @@ $app->command('layer-checker [--region=]', function($region, SymfonyStyle $io) {
     }
     $io->table(['Resources', 'current', 'isLast', 'last'], $layers);
 
-    if ($return) {
+    if (!$notUpToDate) {
         $io->error('At least one of your layer is not up to date');
+
+        return 1;
     }
 
-    return $return;
+    $io->success('Your layers are up to date');
+
+    return 0;
+
 })->descriptions('Check if your layer version match your bref version');
 
 $app->run();

--- a/bref
+++ b/bref
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
 
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
@@ -434,5 +435,59 @@ $app->command('bref.dev [--profile=] [--stage=]', function (?string $profile, st
 
     return 0;
 })->descriptions('Create a short URL on bref.dev');
+
+$app->command('layer-checker [--region=]', function($region, SymfonyStyle $io) {
+    if (! file_exists('template.yaml')) {
+        $io->error('No `template.yml` file found.');
+
+        return 1;
+    }
+
+    $lock = json_decode(file_get_contents('composer.lock'), true);
+    $brefVersion = $lock['packages'][array_search('bref/bref', array_column($lock['packages'], 'name'), true)]['version'];
+
+    $runtimesBrefPage = file_get_contents('https://runtimes.bref.sh/?region='.$region.'&version='.$brefVersion);
+    $lastRuntimes = [];
+    preg_match_all('/(arn:aws:lambda:'.$region.':209497400698:layer:.*:\d+)/', $runtimesBrefPage, $lastRuntimes);
+
+    $template = Yaml::parseFile('template.yaml', Yaml::PARSE_CUSTOM_TAGS);
+    $layers = [];
+    $return = 0;
+    foreach ($template['Resources'] as $resource => $resourceConfig) {
+        if (false === array_key_exists('Layers', $resourceConfig['Properties'])) {
+            continue;
+        }
+        foreach ($resourceConfig['Properties']['Layers'] as $layer) {
+            if (in_array($layer, $lastRuntimes, true)) {
+                $layers[] = ['Resources' => $resource, 'current' => $layer, 'isLast' => 'true'];
+                continue;
+            }
+            $layerParts = explode(':', $layer);
+            $layerAccount = $layerParts[4];
+            $layerPhp = $layerParts[6];
+            if ('209497400698' !== $layerAccount) {
+                $layers[] = ['Resources' => $resource, 'current' => $layer, 'isLast' => 'N/A'];
+                continue;
+            }
+            foreach ($lastRuntimes[0] as $runtime) {
+                $runtimeParts = explode(':', $runtime);
+                $runtimePhp = $runtimeParts[6];
+                if ($layerPhp === $runtimePhp) {
+                    $return = 1;
+                    $layers[] = ['Resources' => $resource, 'current' => $layer, 'isLast' => 'false', 'last' => $runtime];
+                    continue;
+                }
+            }
+
+        }
+    }
+    $io->table(['Resources', 'current', 'isLast', 'last'], $layers);
+
+    if ($return) {
+        $io->error('At least one of your layer is not up to date');
+    }
+
+    return $return;
+})->descriptions('Check if your layer version match your bref version');
 
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "psr/http-server-handler": "^1.0",
         "async-aws/cloud-formation": "^0.5",
         "async-aws/lambda": "^0.5",
-        "nyholm/psr7": "^1.2"
+        "nyholm/psr7": "^1.2",
+        "symfony/yaml": "^5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5",


### PR DESCRIPTION
When we update bref/bref version we should verify if our current layers set in our template are up to date.
Sometime we can forget to check on https://runtimes.bref.sh the compatible layer with our bref version.
It will be great if we can have a command usable in CI to check this.
So I add a command to check this, so we can now add this command in CI, if all layers are up to date CI will be green, if not Ci will be red.

It's little crappy but the idea is here, I hope it can be usefull and I'm open to discuss.

little screenshot on a current project
![brefRuntimeCheckerCommand](https://user-images.githubusercontent.com/1540419/83928087-cde8c480-a78e-11ea-8c09-0a15eabc5456.png)