### PR TITLE
Fix #118 Document Laravel Queues, along with Symfony Messenger

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ This matrix will be updated as Bref and AWS services evolve over time.
             Jobs, Cron
         </td>
         <td class="p-4 text-center">
-            <span class="maturity-icon shadow bg-orange-400"></span>
+            <span class="maturity-icon shadow bg-green-400"></span>
         </td>
         <td class="p-4 text-center">
             <span class="maturity-icon shadow bg-green-400"></span>
@@ -159,7 +159,7 @@ This matrix will be updated as Bref and AWS services evolve over time.
 
     Jobs, cron tasks and batch processes are very good candidates for FaaS. The scaling model of AWS Lambda can lead to very high throughput in queue processing, and the pay-per-use billing model can sometimes result in drastic costs reduction.
 
-    The main challenge at the moment is the lack of documentation on this topic, as well as the lack of native integration with existing queue libraries like Laravel Queues, Symfony Messenger, Enqueue…
+    Using Bref, it is possible to implement cron jobs and queue workers using PHP. Bref also provides integration with popular queue libraries, like Laravel Queues and Symfony Messenger.
 
 - **API**
 

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -283,6 +283,12 @@ FILESYSTEM_DRIVER=s3
 FILESYSTEM_DRIVER_PUBLIC=s3
 ```
 
+## Laravel Queues
+
+It is possible to run Laravel Queues on AWS Lambda using [Amazon SQS](https://aws.amazon.com/sqs/).
+
+A dedicated Bref package is available for this: [bref/laravel-bridge](https://github.com/brefphp/laravel-bridge).
+
 ## Laravel Passport
 
 Laravel Passport has a `passport:install` command. However, this command cannot be run in Lambda because it needs to write files to the `storage/` directory.

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -132,3 +132,9 @@ provider:
 The secrets (e.g. database passwords) must however not be committed in this file.
 
 To learn more about all this, read the [environment variables documentation](/docs/environment/variables.md).
+
+## Symfony Messenger
+
+It is possible to run Symfony Messenger workers on AWS Lambda.
+
+A dedicated Bref package is available for this: [bref/symfony-messenger](https://github.com/brefphp/symfony-messenger).


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

I have created a separate package for a Laravel Queues integration with Bref: https://github.com/brefphp/laravel-bridge

This PR brings documentation. I have also updated the Symfony documentation for Symfony Messenger, and finally updated the last orange dot in the maturity matrix!