### PR TITLE
Default HTTP request event version to 1.0

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -38,7 +38,7 @@ final class HttpRequestEvent implements LambdaEvent
             throw new InvalidLambdaEvent('API Gateway or ALB', $event);
         }
 
-        $this->payloadVersion = (float) $event['version'];
+        $this->payloadVersion = (float) ($event['version'] ?? '1.0');
         $this->event = $event;
         $this->queryString = $this->rebuildQueryString();
         $this->headers = $this->extractHeaders();


### PR DESCRIPTION
The event version does not appear to be defined in some cases, so PHP throws a warning because it's trying to access an undefined property.