### PR TITLE
Fixed the DomainName for s3-website

### DIFF
--- a/docs/websites.md
+++ b/docs/websites.md
@@ -181,7 +181,7 @@ resources:
                             S3OriginConfig: {} # this key is required to tell CloudFront that this is an S3 origin, even though nothing is configured
                             # If you host a static website, like a SPA, use s3-website URLs instead of the config above
                             # See https://stackoverflow.com/questions/15309113/amazon-cloudfront-doesnt-respect-my-s3-website-buckets-index-html-rules#15528757
-                            # DomainName: !Join ['', [!Ref Assets, '.s3-website-', !Ref AWS::Region, '.amazonaws.com']]
+                            # DomainName: !Join ['', [!Ref Assets, '.s3-website.', !Ref AWS::Region, '.amazonaws.com']]
                             # CustomOriginConfig:
                             #     OriginProtocolPolicy: 'http-only' # S3 websites only support HTTP
                             # You'll also need to enable website hosting on your s3 bucket by configuring the WebsiteConfiguration property

--- a/docs/websites.md
+++ b/docs/websites.md
@@ -181,7 +181,7 @@ resources:
                             S3OriginConfig: {} # this key is required to tell CloudFront that this is an S3 origin, even though nothing is configured
                             # If you host a static website, like a SPA, use s3-website URLs instead of the config above
                             # See https://stackoverflow.com/questions/15309113/amazon-cloudfront-doesnt-respect-my-s3-website-buckets-index-html-rules#15528757
-                            # DomainName: !Join ['', [!Ref Assets, '.s3-website.', !Ref AWS::Region, '.amazonaws.com']]
+                            # DomainName: !Select [2, !Split ["/", !GetAtt Assets.WebsiteURL]]
                             # CustomOriginConfig:
                             #     OriginProtocolPolicy: 'http-only' # S3 websites only support HTTP
                             # You'll also need to enable website hosting on your s3 bucket by configuring the WebsiteConfiguration property

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -17,7 +17,7 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
 
     public function test request with no version fallbacks to v1()
     {
-        $this->fromFixture(__DIR__ . "/Fixture/ag-no-version.json");
+        $this->fromFixture(__DIR__ . '/Fixture/ag-no-version.json');
 
         $this->assertBody('');
         $this->assertContentType(null);


### PR DESCRIPTION
Hello,

I copy/pasted the documentation for my latest project and when I deployed it, I got an S3 error from Cloudfront. After further inspection, I found the problem in the DomainName. 

S3 website domain name are written like that: `{bucket_name}.s3-website.eu-west-3.amazonaws.com`. In the documentation, it was like that: `{bucket_name}.s3-website-eu-west-3.amazonaws.com`

Hope it helps.

Edit: I've also fixed the error from PrettyCI 😉 