### PR TITLE
Added support for multi-value query parameters

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -188,7 +188,7 @@ final class HttpRequestEvent implements LambdaEvent
 
             // re-parse the query-string so it matches the format used when using PHP outside of Lambda
             // this is particularly important when using multi-value params - eg. myvar[]=2&myvar=3 ... = [2, 3]
-            parse_str(join('&', $queryParameterStr), $queryParameters);
+            parse_str(implode('&', $queryParameterStr), $queryParameters);
             return http_build_query($queryParameters);
         }
 

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -90,10 +90,9 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
     {
         $this->fromFixture(__DIR__ . "/Fixture/ag-v$version-query-string-multivalue.json");
 
-        // TODO The feature is not implemented yet
-        $this->assertQueryParameters(['foo' => 'bar']);
-        $this->assertQueryString('foo=bar');
-        $this->assertUri('/path?foo=bar');
+        $this->assertQueryParameters(['foo' => 'bar', 'shapes' => ['circle', 'square']]);
+        $this->assertQueryString('foo=bar&shapes%5B0%5D=circle&shapes%5B1%5D=square');
+        $this->assertUri('/path?foo=bar&shapes%5B0%5D=circle&shapes%5B1%5D=square');
     }
 
     /**

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -17,7 +17,7 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
 
     public function test request with no version fallbacks to v1()
     {
-        $this->fromFixture(__DIR__ . "/Fixture/ag-no-version.json");
+        $this->fromFixture(__DIR__ . '/Fixture/ag-no-version.json');
 
         $this->assertBody('');
         $this->assertContentType(null);
@@ -90,9 +90,15 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
     {
         $this->fromFixture(__DIR__ . "/Fixture/ag-v$version-query-string-multivalue.json");
 
-        $this->assertQueryParameters(['foo' => 'bar', 'shapes' => ['circle', 'square']]);
-        $this->assertQueryString('foo=bar&shapes%5B0%5D=circle&shapes%5B1%5D=square');
-        $this->assertUri('/path?foo=bar&shapes%5B0%5D=circle&shapes%5B1%5D=square');
+        $this->assertQueryParameters([
+            'foo' => ['bar', 'baz'],
+            'cards' => ['birthday'],
+            'colors' => [['red'], ['blue']],
+            'shapes' => ['a' => ['square', 'triangle']],
+            'myvar' => 'abc',
+        ]);
+        $this->assertQueryString('foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc');
+        $this->assertUri('/path?foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc');
     }
 
     /**

--- a/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
@@ -18,8 +18,11 @@
         "foo": "bar"
     },
     "multiValueQueryStringParameters": {
-        "foo": ["bar"],
-        "shapes[]": ["circle", "square"]
+        "foo[]": ["bar", "baz"],
+        "cards[]": ["birthday"],
+        "colors[][]": ["red", "blue"],
+        "shapes[a][]": ["square", "triangle"],
+        "myvar": ["abc"]
     },
     "pathParameters": null,
     "stageVariables": null,

--- a/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
@@ -15,10 +15,11 @@
         "X-Forwarded-Proto": "https"
     },
     "queryStringParameters": {
-        "foo": "baz"
+        "foo": "bar"
     },
     "multiValueQueryStringParameters": {
-        "foo": ["bar", "baz"]
+        "foo": ["bar"],
+        "shapes[]": ["circle", "square"]
     },
     "pathParameters": null,
     "stageVariables": null,

--- a/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "routeKey": "ANY /path",
     "rawPath": "/path",
-    "rawQueryString": "foo=bar&shapes[]=circle&shapes[]=square",
+    "rawQueryString": "foo[]=bar&foo[]=baz&cards[]=birthday&colors[][]=red&colors[][]=blue&shapes[a][]=square&shapes[a][]=triangle&myvar=abc",
     "headers": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",

--- a/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "routeKey": "ANY /path",
     "rawPath": "/path",
-    "rawQueryString": "foo=bar",
+    "rawQueryString": "foo=bar&shapes[]=circle&shapes[]=square",
     "headers": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -129,14 +129,14 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'cards[]' => ['birthday'],
                 'colors[][]' => ['red', 'blue'],
                 'shapes[a][]' => ['square', 'triangle'],
-                'myvar' => ['abc']
+                'myvar' => ['abc'],
             ],
             'queryStringParameters' => [
                 'foo[]' => 'baz', // the 2nd value is preserved only by API Gateway
                 'cards[]' => 'birthday',
                 'colors[][]' => 'red',
                 'shapes[a][]' => 'square',
-                'myvar' => 'abc'
+                'myvar' => 'abc',
             ],
         ];
         $this->assertGlobalVariables($event, [
@@ -145,7 +145,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'cards' => ['birthday'],
                 'colors' => [['red'], ['blue']],
                 'shapes' => ['a' => ['square', 'triangle']],
-                'myvar' => 'abc'
+                'myvar' => 'abc',
             ],
             '$_POST' => [],
             '$_FILES' => [],
@@ -155,7 +155,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'cards' => ['birthday'],
                 'colors' => [['red'], ['blue']],
                 'shapes' => ['a' => ['square', 'triangle']],
-                'myvar' => 'abc'
+                'myvar' => 'abc',
             ],
             '$_SERVER' => [
                 'REQUEST_URI' => '/hello?foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc',

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -125,29 +125,44 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
             'path' => '/hello',
             // See https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/
             'multiValueQueryStringParameters' => [
-                'foo' => ['bar', 'baz'],
+                'foo[]' => ['bar', 'baz'],
+                'cards[]' => ['birthday'],
+                'colors[][]' => ['red', 'blue'],
+                'shapes[a][]' => ['square', 'triangle'],
+                'myvar' => ['abc']
             ],
             'queryStringParameters' => [
-                'foo' => 'baz', // the 2nd value is preserved only by API Gateway
+                'foo[]' => 'baz', // the 2nd value is preserved only by API Gateway
+                'cards[]' => 'birthday',
+                'colors[][]' => 'red',
+                'shapes[a][]' => 'square',
+                'myvar' => 'abc'
             ],
         ];
         $this->assertGlobalVariables($event, [
             '$_GET' => [
-                // TODO The feature is not implemented yet
-                'foo' => 'bar',
+                'foo' => ['bar', 'baz'],
+                'cards' => ['birthday'],
+                'colors' => [['red'], ['blue']],
+                'shapes' => ['a' => ['square', 'triangle']],
+                'myvar' => 'abc'
             ],
             '$_POST' => [],
             '$_FILES' => [],
             '$_COOKIE' => [],
             '$_REQUEST' => [
-                'foo' => 'bar',
+                'foo' => ['bar', 'baz'],
+                'cards' => ['birthday'],
+                'colors' => [['red'], ['blue']],
+                'shapes' => ['a' => ['square', 'triangle']],
+                'myvar' => 'abc'
             ],
             '$_SERVER' => [
-                'REQUEST_URI' => '/hello?foo=bar',
+                'REQUEST_URI' => '/hello?foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc',
                 'PHP_SELF' => '/hello',
                 'PATH_INFO' => '/hello',
                 'REQUEST_METHOD' => 'GET',
-                'QUERY_STRING' => 'foo=bar',
+                'QUERY_STRING' => 'foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
@@ -166,7 +181,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
             'path' => '/hello',
             // See https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/
             'multiValueQueryStringParameters' => [
-                'foo' => ['bar', 'baz'],
+                'foo[]' => ['bar', 'baz'],
             ],
             'queryStringParameters' => [
                 'foo' => 'baz', // the 2nd value is preserved only by API Gateway
@@ -182,21 +197,20 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         ];
         $this->assertGlobalVariables($event, [
             '$_GET' => [
-                // TODO The feature is not implemented yet
-                'foo' => 'bar',
+                'foo' => ['bar', 'baz'],
             ],
             '$_POST' => [],
             '$_FILES' => [],
             '$_COOKIE' => [],
             '$_REQUEST' => [
-                'foo' => 'bar',
+                'foo' => ['bar', 'baz'],
             ],
             '$_SERVER' => [
-                'REQUEST_URI' => '/hello?foo=bar',
+                'REQUEST_URI' => '/hello?foo%5B0%5D=bar&foo%5B1%5D=baz',
                 'PHP_SELF' => '/hello',
                 'PATH_INFO' => '/hello',
                 'REQUEST_METHOD' => 'GET',
-                'QUERY_STRING' => 'foo=bar',
+                'QUERY_STRING' => 'foo%5B0%5D=bar&foo%5B1%5D=baz',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),


### PR DESCRIPTION
This change allows multi-parameter queries to be used when using Version 1 of the API Gateway events (v2 of the API Gateway payloads had already worked);

eg. my-url?shapes[]=square&shapes[]=circle&shapes[]=oval
Resulting in;
$_GET['shapes'] = ['square', 'circle', 'oval']

I've also tested for multi-dimensional arrays;
eg. my-url?shapes[][]=square&shapes[][]=circle
Resulting in;
$_GET['shapes'] = [['square']['circle']]

AND;
eg. my-url?shapes[][a]=square&shapes[][b]=circle
Resulting in;
$_GET['shapes'] = [['a' => 'square']['b' => 'circle']]

AND;
eg. my-url?shapes[a][]=square&shapes[a][]=circle
Resulting in;
$_GET['shapes'] = ['a' => ['square', 'circle']]

The change is especially useful for sending requests of a number of elements (with the same name) via the query-string (eg. a bunch of checkboxes in a form, or when getting a bunch of data by their ID).

I've added a few scenarios in the tests to make sure this works as well as it can, but a few fresh sets of eyes over it all would be welcome. The changes have also been tested on Lambda itself... but again, some extra testing would be nice to confirm all is well :)

Thanks in advance!