### PR TITLE
Updated PHP version to latest for all images

### DIFF
--- a/runtime/base/php-72.Dockerfile
+++ b/runtime/base/php-72.Dockerfile
@@ -13,7 +13,7 @@
 
 FROM bref/tmp/step-1/build-environment as build-environment
 
-ENV VERSION_PHP=7.2.20
+ENV VERSION_PHP=7.2.31
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 RUN set -xe; \

--- a/runtime/base/php-73.Dockerfile
+++ b/runtime/base/php-73.Dockerfile
@@ -13,7 +13,7 @@
 
 FROM bref/tmp/step-1/build-environment as build-environment
 
-ENV VERSION_PHP=7.3.7
+ENV VERSION_PHP=7.3.19
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 RUN set -xe; \

--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=7.4.4
+ENV VERSION_PHP=7.4.7
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php


### PR DESCRIPTION
This fix the issue #665 

I've bump the version for all 3 PHP docker images. I've build them and run the tests. Everything looks OK:

```console
➜  runtime $: php layers/tests.php 
...................................
Tests passed
```

In the issue discussion, [this tweet](https://twitter.com/nikita_ppv/status/1264857231167807489?s=19) was mentioned. PHP 7.4.7 is used to avoid the yield problem.