### PR TITLE
Bumped PHP versions to latest for all images

### DIFF
--- a/runtime/base/php-72.Dockerfile
+++ b/runtime/base/php-72.Dockerfile
@@ -13,7 +13,7 @@
 
 FROM bref/tmp/step-1/build-environment as build-environment
 
-ENV VERSION_PHP=7.2.31
+ENV VERSION_PHP=7.2.32
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 RUN set -xe; \

--- a/runtime/base/php-73.Dockerfile
+++ b/runtime/base/php-73.Dockerfile
@@ -13,7 +13,7 @@
 
 FROM bref/tmp/step-1/build-environment as build-environment
 
-ENV VERSION_PHP=7.3.19
+ENV VERSION_PHP=7.3.20
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
 RUN set -xe; \

--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=7.4.7
+ENV VERSION_PHP=7.4.8
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php


### PR DESCRIPTION
I'm back again with an update for docker images. Bref is not concerned by the security update because it's only impacting Windows builds. 

All tests are passing:

```console
➜  runtime $: php layers/tests.php 
...................................
Tests passed
```