### PR TITLE
use `hello` as the function name

### DIFF
--- a/template/default/serverless.yml
+++ b/template/default/serverless.yml
@@ -9,7 +9,7 @@ plugins:
     - ./vendor/bref/bref
 
 functions:
-    function:
+    hello:
         handler: index.php
         description: ''
         layers:


### PR DESCRIPTION
Use `hello` as the function name in order to avoid any confusion with the `functions` keyword.

By doing that, the template and the example in the documentation remain equals.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
