### PR TITLE
Specify max execution time

### DIFF
--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -38,7 +38,7 @@ disable_functions=fastcgi_finish_request
 ; API Gateway has a timeout of 29 seconds, the default FPM job has a timeout of
 ; 28 seconds. Setting this to 27 will give FPM some time to properly finish up
 ; its resources and flush logs to CloudWatch.
-max_execution_time = 27
+max_execution_time=27
 
 ; The total upload size limit is 6Mb, we override the defaults to match this limit
 ; API Gateway has a 10Mb limit, but Lambda's is 6Mb

--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -35,6 +35,11 @@ variables_order="EGPCS"
 ; See https://github.com/brefphp/bref/issues/214
 disable_functions=fastcgi_finish_request
 
+; API Gateway has a timeout of 29 seconds, the default FPM job has a timeout of
+; 28 seconds. Setting this to 27 will give FPM some time to properly finish up
+; its resources and flush logs to CloudWatch.
+max_execution_time = 27
+
 ; The total upload size limit is 6Mb, we override the defaults to match this limit
 ; API Gateway has a 10Mb limit, but Lambda's is 6Mb
 post_max_size=6M


### PR DESCRIPTION
With this change we allow FPM to cleanup its resources and make sure we log things properly. 

The user will no longer see `{"message": "Internal server error"}`. They will see: 

```
❯ curl -I https://foobar.execute-api.eu-central-1.amazonaws.com/dev
HTTP/2 500
content-type: application/json
content-length: 0
date: Mon, 27 Jul 2020 08:13:18 GMT
x-amzn-requestid: 4ba9fbb8-e559-455e-ab50-75b5cb87be22
x-amz-apigw-id: QUroliAFt9A=
x-amzn-trace-id: Root=1-5f1e8c9a-5e00490e;Sampled=0
x-cache: Error from cloudfront
via: 1.1 208ed8b46a4d.cloudfront.net (CloudFront)
x-amz-cf-pop: ARN4-C2
x-amz-cf-id: LvgYYbNbSkYx_lL-eKZqpJZw==
```

![Screenshot 2020-07-27 at 10 15 10](https://user-images.githubusercontent.com/1275206/88519236-133cac00-cff2-11ea-9a03-aacae9de4852.png)

----------

This is a draft PR, I'll see if I can do better. 