### PR TITLE
Add request_terminate_timeout = 27s

### DIFF
--- a/runtime/layers/fpm/php-fpm.conf
+++ b/runtime/layers/fpm/php-fpm.conf
@@ -25,3 +25,6 @@ decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
 ; See https://github.com/brefphp/bref/issues/275
 rlimit_core = 1
+
+; Make sure no PHP request takes longer than 27s
+request_terminate_timeout = 27s

--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -35,10 +35,10 @@ variables_order="EGPCS"
 ; See https://github.com/brefphp/bref/issues/214
 disable_functions=fastcgi_finish_request
 
-; API Gateway has a timeout of 29 seconds, the default FPM job has a timeout of
-; 28 seconds. Setting this to 27 will give FPM some time to properly finish up
-; its resources and flush logs to CloudWatch.
-max_execution_time=27
+; API Gateway has a timeout of 29 seconds, the default FPM event has a timeout of
+; 28 seconds. A FPM request has a timeout of 27. Setting this to 26 will give FPM
+; some time to properly finish up its resources and flush logs to CloudWatch.
+max_execution_time=26
 
 ; The total upload size limit is 6Mb, we override the defaults to match this limit
 ; API Gateway has a 10Mb limit, but Lambda's is 6Mb


### PR DESCRIPTION
This is a follow up from #700. 

PHP FPM's request_terminate_timeout will always stop the request after 27s seconds. PHP's max_execution_time does not count for `wait` and i/o. 

---------

If we hit `max_execution_time` we get the following notice:

> NOTICE: PHP message: PHP Fatal error:  Maximum execution time of 1 second exceeded in /var/task/public/simple.php on line 7

We will show the output already printed. Ie, you may get half the page. 

We will see all data written on stderr.

------

If we hit `request_terminate_timeout`, we will get an exception from the `hollodotme\\FastCGI`.

> hollodotme\\FastCGI\\Exceptions\\ReadFailedException Stream got blocked, or terminated.",

This leads to an ugly API gatway "internal server error" for the users. 

We will see all data written on stderr.

-------

If the lambda times out we will get a:

> 2020-08-07T10:15:51.137Z 0b5ed35f-1365-46ed-aab9-21914fa662c2 Task timed out after 10.01 seconds

And no other logs (we are in the dark)

------

The FPM config is not configurable by the user. I used this small repo to create an extra layer: https://github.com/Nyholm/bref-overwrite-layer