### PR TITLE
Remove request_terminate_timeout = 27s

### DIFF
--- a/runtime/layers/fpm/php-fpm.conf
+++ b/runtime/layers/fpm/php-fpm.conf
@@ -25,6 +25,3 @@ decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
 ; See https://github.com/brefphp/bref/issues/275
 rlimit_core = 1
-
-; Make sure no PHP request takes longer than 27s
-request_terminate_timeout = 27s


### PR DESCRIPTION
Im not happy to say that I think we should revert #707. 

See https://github.com/brefphp/bref/issues/713