### PR TITLE
perf: introduce lightweight layers

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -75,7 +75,6 @@ Bref strives to include the most common PHP extensions. If a major PHP extension
         <li><a href="http://php.net/manual/en/book.pcre.php">pcre</a></li>
         <li><a href="http://php.net/manual/en/book.PDO.php">PDO</a></li>
         <li><a href="http://php.net/manual/en/book.pdo_sqlite.php">pdo_sqlite</a></li>
-        <li><a href="http://php.net/manual/en/ref.pdo-mysql.php">pdo_mysql</a></li>
         <li><a href="http://php.net/manual/en/book.Phar.php">Phar</a></li>
         <li><a href="http://php.net/manual/en/book.posix.php">posix</a></li>
         <li><a href="http://php.net/manual/en/book.readline.php">readline</a></li>
@@ -87,7 +86,6 @@ Bref strives to include the most common PHP extensions. If a major PHP extension
         <ul>
         <li><a href="http://php.net/manual/en/book.SimpleXML.php">SimpleXML</a></li>
         <li><a href="http://php.net/manual/en/book.sodium.php">sodium</a></li>
-        <li><a href="http://php.net/manual/en/book.soap.php">SOAP</a></li>
         <li><a href="http://php.net/manual/en/book.sockets.php">sockets</a></li>
         <li><a href="http://php.net/manual/en/book.SPL.php">SPL</a></li>
         <li><a href="http://php.net/manual/en/book.sqlite3.php">sqlite3</a></li>
@@ -96,7 +94,6 @@ Bref strives to include the most common PHP extensions. If a major PHP extension
         <li><a href="http://php.net/manual/en/book.xml.php">xml</a></li>
         <li><a href="http://php.net/manual/en/book.xmlreader.php">xmlreader</a></li>
         <li><a href="http://php.net/manual/en/book.xmlwriter.php">xmlwriter</a></li>
-        <li><a href="http://php.net/manual/en/book.xsl.php">xsl</a></li>
         <li><a href="http://php.net/manual/en/book.zlib.php">zlib</a></li>
         </ul>
       </td>
@@ -108,24 +105,16 @@ Bref strives to include the most common PHP extensions. If a major PHP extension
 
 - **[intl](http://php.net/manual/en/intro.intl.php)** - Internationalization extension (referred as Intl) is a wrapper for ICU library, enabling PHP programmers to perform various locale-aware operations.
 - **[APCu](http://php.net/manual/en/intro.apcu.php)** - APCu is APC stripped of opcode caching.
-- **[phpredis](https://github.com/phpredis/phpredis)** -  The phpredis extension provides an API for communicating with the Redis key-value store.
+- **[MySQL PDO Driver](http://php.net/manual/en/ref.pdo-mysql.php)** -  PDO_MYSQL is a driver that implements the PHP Data Objects (PDO) interface to enable access from PHP to MySQL databases.
 - **[PostgreSQL PDO Driver](http://php.net/manual/en/ref.pdo-pgsql.php)** -  PDO_PGSQL is a driver that implements the PHP Data Objects (PDO) interface to enable access from PHP to PostgreSQL databases.
-- **[Mongodb](http://php.net/manual/en/set.mongodb.php)** - Unlike the mongo extension, this extension is developed atop the » libmongoc and » libbson libraries. It provides a minimal API for core driver functionality: commands, queries, writes, connection management, and BSON serialization.
-- **[pthreads](http://php.net/manual/en/book.pthreads.php)** - pthreads is an object-orientated API that provides all of the tools needed for multi-threading in PHP. PHP applications can create, read, write, execute and synchronize with Threads, Workers and Threaded objects.
-- **[imagick](http://php.net/manual/en/book.imagick.php)** - imagick is an image processing library.
-- **[GD](http://php.net/manual/en/book.image.php)** - GD is an image processing library.
 
 You can enable these extensions by loading them in `php/conf.d/php.ini` (as mentioned in [the section above](#phpini)), for example:
 
 ```ini
 extension=intl
 extension=apcu
-extension=redis
+extension=pdo_mysql
 extension=pdo_pgsql
-extension=mongodb
-extension=pthreads
-extension=imagick
-extension=gd
 ```
 
 ### Extra extensions
@@ -164,7 +153,7 @@ RUN curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire
     && cp /tmp/blackfire/blackfire-*.so /tmp/blackfire.so
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM lambci/lambda:provided.al2
 
 # Copy things we installed to the final image
 COPY --from=0 /tmp/blackfire.so /opt/bref-extra/blackfire.so

--- a/runtime/base/clean.sh
+++ b/runtime/base/clean.sh
@@ -9,7 +9,8 @@ set -e
 set -u
 
 # Strip all the unneeded symbols from shared libraries to reduce size.
-find /opt/bref -type f -name "*.so*" -o -name "*.a"  -exec strip --strip-unneeded {} \;
+find /opt/bref -type f -name "*.so*" -exec strip --strip-unneeded {} \;
+find /opt/bref -type f -name "*.a"|xargs rm
 find /opt/bref -type f -executable -exec sh -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; -print|xargs strip --strip-all
 
 # Cleanup all the binaries we don't want.
@@ -23,6 +24,11 @@ rm -rf /opt/bref/share/doc
 rm -rf /opt/bref/share/man
 rm -rf /opt/bref/share/gtk-doc
 rm -rf /opt/bref/include
+rm -rf /opt/bref/{lib,lib64}/pkgconfig
+rm -rf /opt/bref/{lib,lib64}/cmake
+rm -rf /opt/bref/lib/xml2Conf.sh
+find /opt/bref/lib/php -mindepth 1 -maxdepth 1 -type d -a -not -name extensions | xargs rm -rf
+find /opt/bref/lib/php -mindepth 1 -maxdepth 1 -type f | xargs rm -rf
 rm -rf /opt/bref/lib/php/test
 rm -rf /opt/bref/lib/php/doc
 rm -rf /opt/bref/lib/php/docs
@@ -30,6 +36,7 @@ rm -rf /opt/bref/tests
 rm -rf /opt/bref/doc
 rm -rf /opt/bref/docs
 rm -rf /opt/bref/man
+rm -rf /opt/bref/php/man
 rm -rf /opt/bref/www
 rm -rf /opt/bref/cfg
 rm -rf /opt/bref/libexec

--- a/runtime/base/php-72.Dockerfile
+++ b/runtime/base/php-72.Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe; \
     # --silent will hide the progress, but also the errors: we restore error messages with --show-error
     # --fail makes sure that curl returns an error instead of fetching the 404 page
     curl --location --silent --show-error --fail https://github.com/php/php-src/archive/php-${VERSION_PHP}.tar.gz \
-  | tar xzC ${PHP_BUILD_DIR} --strip-components=1
+    | tar xzC ${PHP_BUILD_DIR} --strip-components=1
 # Move into the unpackaged code directory
 WORKDIR  ${PHP_BUILD_DIR}/
 
@@ -36,58 +36,51 @@ WORKDIR  ${PHP_BUILD_DIR}/
 # --enable-option-checking=fatal: make sure invalid --configure-flags are fatal errors instead of just warnings
 # --enable-ftp: because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 # --enable-mbstring: because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
-# --enable-maintainer-zts: build PHP as ZTS (Zend Thread Safe) to be able to use pthreads
 # --with-zlib and --with-zlib-dir: See https://stackoverflow.com/a/42978649/245552
 # --enable-opcache-file: allows to use the `opcache.file_cache` option
 #
 RUN set -xe \
- && ./buildconf --force \
- && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+    && ./buildconf --force \
+    && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     CPPFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-O1 -Wl,--strip-all -Wl,--hash-style=both -pie" \
     ./configure \
-        --build=x86_64-pc-linux-gnu \
-        --prefix=${INSTALL_DIR} \
-        --enable-option-checking=fatal \
-        --enable-maintainer-zts \
-        --enable-sockets \
-        --with-config-file-path=${INSTALL_DIR}/etc/php \
-        --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
-        --enable-fpm \
-        --disable-cgi \
-        --enable-cli \
-        --disable-phpdbg \
-        --disable-phpdbg-webhelper \
-        --with-sodium \
-        --with-readline \
-        --with-openssl \
-        --with-zlib=${INSTALL_DIR} \
-        --with-zlib-dir=${INSTALL_DIR} \
-        --with-curl \
-        --enable-exif \
-        --enable-ftp \
-        --with-gettext \
-        --enable-mbstring \
-        --with-pdo-mysql=shared,mysqlnd \
-        --with-mysqli \
-        --enable-pcntl \
-        --enable-zip \
-        --enable-bcmath \
-        --with-pdo-pgsql=shared,${INSTALL_DIR} \
-        --enable-intl=shared \
-        --enable-opcache-file \
-        --enable-soap \
-        --with-xsl=${INSTALL_DIR} \
-        --with-gd \
-        --with-png-dir=${INSTALL_DIR} \
-        --with-jpeg-dir=${INSTALL_DIR}
+    --build=x86_64-pc-linux-gnu \
+    --prefix=${INSTALL_DIR} \
+    --enable-option-checking=fatal \
+    --enable-sockets \
+    --with-config-file-path=${INSTALL_DIR}/etc/php \
+    --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
+    --enable-fpm \
+    --disable-cgi \
+    --enable-cli \
+    --disable-phpdbg \
+    --disable-phpdbg-webhelper \
+    --with-sodium \
+    --with-readline \
+    --with-openssl \
+    --with-zlib=${INSTALL_DIR} \
+    --with-zlib-dir=${INSTALL_DIR} \
+    --with-curl \
+    --enable-exif \
+    --enable-ftp \
+    --with-gettext \
+    --enable-mbstring \
+    --with-pdo-mysql=shared,mysqlnd \
+    --with-mysqli \
+    --enable-pcntl \
+    --enable-zip \
+    --enable-bcmath \
+    --with-pdo-pgsql=shared,${INSTALL_DIR} \
+    --enable-intl=shared \
+    --enable-opcache-file
 RUN make -j $(nproc)
 # Run `make install` and override PEAR's PHAR URL because pear.php.net is down
 RUN set -xe; \
- make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
- { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
- make clean; \
- cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
+    make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
+    { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
+    make clean; \
+    cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 
 # Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
@@ -97,24 +90,7 @@ RUN ln -s /opt/bref/sbin/* /opt/bin
 
 # Install extensions
 # We can install extensions manually or using `pecl`
-RUN pecl install mongodb
-RUN pecl install redis
 RUN pecl install APCu
-RUN pecl install imagick
-
-# pthreads
-ENV PTHREADS_BUILD_DIR=${BUILD_DIR}/pthreads
-# Build from master because there are no pthreads release compatible with PHP 7.3
-RUN set -xe; \
-    mkdir -p ${PTHREADS_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/krakjoe/pthreads/archive/master.tar.gz \
-    | tar xzC ${PTHREADS_BUILD_DIR} --strip-components=1
-WORKDIR  ${PTHREADS_BUILD_DIR}/
-RUN set -xe; \
-    phpize \
- && ./configure \
- && make \
- && make install
 
 
 # Run the next step in the previous environment because the `clean.sh` script needs `find`,
@@ -128,7 +104,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2018.03
+FROM lambci/lambda:build-provided.al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/base/php-73.Dockerfile
+++ b/runtime/base/php-73.Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe; \
     # --silent will hide the progress, but also the errors: we restore error messages with --show-error
     # --fail makes sure that curl returns an error instead of fetching the 404 page
     curl --location --silent --show-error --fail https://github.com/php/php-src/archive/php-${VERSION_PHP}.tar.gz \
-  | tar xzC ${PHP_BUILD_DIR} --strip-components=1
+    | tar xzC ${PHP_BUILD_DIR} --strip-components=1
 # Move into the unpackaged code directory
 WORKDIR  ${PHP_BUILD_DIR}/
 
@@ -36,58 +36,51 @@ WORKDIR  ${PHP_BUILD_DIR}/
 # --enable-option-checking=fatal: make sure invalid --configure-flags are fatal errors instead of just warnings
 # --enable-ftp: because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 # --enable-mbstring: because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
-# --enable-maintainer-zts: build PHP as ZTS (Zend Thread Safe) to be able to use pthreads
 # --with-zlib and --with-zlib-dir: See https://stackoverflow.com/a/42978649/245552
 # --enable-opcache-file: allows to use the `opcache.file_cache` option
 #
 RUN set -xe \
- && ./buildconf --force \
- && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+    && ./buildconf --force \
+    && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     CPPFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-O1 -Wl,--strip-all -Wl,--hash-style=both -pie" \
     ./configure \
-        --build=x86_64-pc-linux-gnu \
-        --prefix=${INSTALL_DIR} \
-        --enable-option-checking=fatal \
-        --enable-maintainer-zts \
-        --enable-sockets \
-        --with-config-file-path=${INSTALL_DIR}/etc/php \
-        --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
-        --enable-fpm \
-        --disable-cgi \
-        --enable-cli \
-        --disable-phpdbg \
-        --disable-phpdbg-webhelper \
-        --with-sodium \
-        --with-readline \
-        --with-openssl \
-        --with-zlib=${INSTALL_DIR} \
-        --with-zlib-dir=${INSTALL_DIR} \
-        --with-curl \
-        --enable-exif \
-        --enable-ftp \
-        --with-gettext \
-        --enable-mbstring \
-        --with-pdo-mysql=shared,mysqlnd \
-        --with-mysqli \
-        --enable-pcntl \
-        --enable-zip \
-        --enable-bcmath \
-        --with-pdo-pgsql=shared,${INSTALL_DIR} \
-        --enable-intl=shared \
-        --enable-opcache-file \
-        --enable-soap \
-        --with-xsl=${INSTALL_DIR} \
-        --with-gd \
-        --with-png-dir=${INSTALL_DIR} \
-        --with-jpeg-dir=${INSTALL_DIR}
+    --build=x86_64-pc-linux-gnu \
+    --prefix=${INSTALL_DIR} \
+    --enable-option-checking=fatal \
+    --enable-sockets \
+    --with-config-file-path=${INSTALL_DIR}/etc/php \
+    --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
+    --enable-fpm \
+    --disable-cgi \
+    --enable-cli \
+    --disable-phpdbg \
+    --disable-phpdbg-webhelper \
+    --with-sodium \
+    --with-readline \
+    --with-openssl \
+    --with-zlib=${INSTALL_DIR} \
+    --with-zlib-dir=${INSTALL_DIR} \
+    --with-curl \
+    --enable-exif \
+    --enable-ftp \
+    --with-gettext \
+    --enable-mbstring \
+    --with-pdo-mysql=shared,mysqlnd \
+    --with-mysqli \
+    --enable-pcntl \
+    --enable-zip \
+    --enable-bcmath \
+    --with-pdo-pgsql=shared,${INSTALL_DIR} \
+    --enable-intl=shared \
+    --enable-opcache-file
 RUN make -j $(nproc)
 # Run `make install` and override PEAR's PHAR URL because pear.php.net is down
 RUN set -xe; \
- make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
- { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
- make clean; \
- cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
+    make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
+    { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
+    make clean; \
+    cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 # Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
 RUN mkdir -p /opt/bin
@@ -96,24 +89,7 @@ RUN ln -s /opt/bref/sbin/* /opt/bin
 
 # Install extensions
 # We can install extensions manually or using `pecl`
-RUN pecl install mongodb
-RUN pecl install redis
 RUN pecl install APCu
-RUN pecl install imagick
-
-# pthreads
-ENV PTHREADS_BUILD_DIR=${BUILD_DIR}/pthreads
-# Build from master because there are no pthreads release compatible with PHP 7.3
-RUN set -xe; \
-    mkdir -p ${PTHREADS_BUILD_DIR}/bin; \
-    curl -Ls https://github.com/krakjoe/pthreads/archive/master.tar.gz \
-    | tar xzC ${PTHREADS_BUILD_DIR} --strip-components=1
-WORKDIR  ${PTHREADS_BUILD_DIR}/
-RUN set -xe; \
-    phpize \
- && ./configure \
- && make \
- && make install
 
 
 # Run the next step in the previous environment because the `clean.sh` script needs `find`,
@@ -127,7 +103,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2018.03
+FROM lambci/lambda:build-provided.al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -23,7 +23,7 @@ FROM bref/tmp/step-1/build-environment as build-environment
 # https://github.com/kkos/oniguruma/releases
 # Needed by:
 #   - php mbstring
-ENV VERSION_ONIG=6.9.3
+ENV VERSION_ONIG=6.9.5
 ENV ONIG_BUILD_DIR=${BUILD_DIR}/oniguruma
 RUN set -xe; \
     mkdir -p ${ONIG_BUILD_DIR}; \
@@ -47,7 +47,7 @@ RUN set -xe; \
     # --silent will hide the progress, but also the errors: we restore error messages with --show-error
     # --fail makes sure that curl returns an error instead of fetching the 404 page
     curl --location --silent --show-error --fail https://www.php.net/get/php-${VERSION_PHP}.tar.gz/from/this/mirror \
-  | tar xzC ${PHP_BUILD_DIR} --strip-components=1
+    | tar xzC ${PHP_BUILD_DIR} --strip-components=1
 # Move into the unpackaged code directory
 WORKDIR  ${PHP_BUILD_DIR}/
 
@@ -60,57 +60,51 @@ WORKDIR  ${PHP_BUILD_DIR}/
 # --enable-option-checking=fatal: make sure invalid --configure-flags are fatal errors instead of just warnings
 # --enable-ftp: because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 # --enable-mbstring: because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
-# --enable-maintainer-zts: build PHP as ZTS (Zend Thread Safe) to be able to use pthreads
 # --with-zlib and --with-zlib-dir: See https://stackoverflow.com/a/42978649/245552
 # --with-pear: necessary for `pecl` to work (to install PHP extensions)
 #
 RUN set -xe \
- && ./buildconf --force \
- && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+    && ./buildconf --force \
+    && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     CPPFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-O1 -Wl,--strip-all -Wl,--hash-style=both -pie" \
     ./configure \
-        --build=x86_64-pc-linux-gnu \
-        --prefix=${INSTALL_DIR} \
-        --enable-option-checking=fatal \
-        --enable-maintainer-zts \
-        --enable-sockets \
-        --with-config-file-path=${INSTALL_DIR}/etc/php \
-        --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
-        --enable-fpm \
-        --disable-cgi \
-        --enable-cli \
-        --disable-phpdbg \
-        --disable-phpdbg-webhelper \
-        --with-sodium \
-        --with-readline \
-        --with-openssl \
-        --with-zlib=${INSTALL_DIR} \
-        --with-zlib-dir=${INSTALL_DIR} \
-        --with-curl \
-        --enable-exif \
-        --enable-ftp \
-        --with-gettext \
-        --enable-mbstring \
-        --with-pdo-mysql=shared,mysqlnd \
-        --with-mysqli \
-        --enable-pcntl \
-        --with-zip \
-        --enable-bcmath \
-        --with-pdo-pgsql=shared,${INSTALL_DIR} \
-        --enable-intl=shared \
-        --enable-soap \
-        --with-xsl=${INSTALL_DIR} \
-        --enable-gd \
-        --with-jpeg=${INSTALL_DIR} \
-        --with-pear
+    --build=x86_64-pc-linux-gnu \
+    --prefix=${INSTALL_DIR} \
+    --enable-option-checking=fatal \
+    --enable-sockets \
+    --with-config-file-path=${INSTALL_DIR}/etc/php \
+    --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
+    --enable-fpm \
+    --disable-cgi \
+    --enable-cli \
+    --disable-phpdbg \
+    --disable-phpdbg-webhelper \
+    --with-sodium \
+    --with-readline \
+    --with-openssl \
+    --with-zlib=${INSTALL_DIR} \
+    --with-zlib-dir=${INSTALL_DIR} \
+    --with-curl \
+    --enable-exif \
+    --enable-ftp \
+    --with-gettext \
+    --enable-mbstring \
+    --with-pdo-mysql=shared,mysqlnd \
+    --with-mysqli \
+    --enable-pcntl \
+    --with-zip \
+    --enable-bcmath \
+    --with-pdo-pgsql=shared,${INSTALL_DIR} \
+    --enable-intl=shared \
+    --with-pear
 RUN make -j $(nproc)
 # Run `make install` and override PEAR's PHAR URL because pear.php.net is down
 RUN set -xe; \
- make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
- { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
- make clean; \
- cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
+    make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
+    { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
+    make clean; \
+    cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 # Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
 RUN mkdir -p /opt/bin
@@ -119,11 +113,7 @@ RUN ln -s /opt/bref/sbin/* /opt/bin
 
 # Install extensions
 # We can install extensions manually or using `pecl`
-RUN pecl install mongodb
-RUN pecl install redis
 RUN pecl install APCu
-RUN pecl install imagick
-
 
 # Run the next step in the previous environment because the `clean.sh` script needs `find`,
 # which isn't installed by default
@@ -136,7 +126,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2018.03
+FROM amazonlinux:2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/base/php-80.Dockerfile
+++ b/runtime/base/php-80.Dockerfile
@@ -23,7 +23,7 @@ FROM bref/tmp/step-1/build-environment as build-environment
 # https://github.com/kkos/oniguruma/releases
 # Needed by:
 #   - php mbstring
-ENV VERSION_ONIG=6.9.3
+ENV VERSION_ONIG=6.9.5
 ENV ONIG_BUILD_DIR=${BUILD_DIR}/oniguruma
 RUN set -xe; \
     mkdir -p ${ONIG_BUILD_DIR}; \
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=8.0.0beta1
+ENV VERSION_PHP=8.0.0beta2
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
@@ -46,8 +46,8 @@ RUN set -xe; \
     # --location will follow redirects
     # --silent will hide the progress, but also the errors: we restore error messages with --show-error
     # --fail makes sure that curl returns an error instead of fetching the 404 page
-    curl --location --silent --show-error --fail https://downloads.php.net/~carusogabriel/php-${VERSION_PHP}.tar.gz \
-  | tar xzC ${PHP_BUILD_DIR} --strip-components=1
+    curl --location --silent --show-error --fail https://downloads.php.net/~pollita/php-${VERSION_PHP}.tar.gz \
+    | tar xzC ${PHP_BUILD_DIR} --strip-components=1
 # Move into the unpackaged code directory
 WORKDIR  ${PHP_BUILD_DIR}/
 
@@ -60,56 +60,51 @@ WORKDIR  ${PHP_BUILD_DIR}/
 # --enable-option-checking=fatal: make sure invalid --configure-flags are fatal errors instead of just warnings
 # --enable-ftp: because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
 # --enable-mbstring: because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
-# --enable-maintainer-zts: build PHP as ZTS (Zend Thread Safe) to be able to use pthreads
 # --with-zlib and --with-zlib-dir: See https://stackoverflow.com/a/42978649/245552
 # --with-pear: necessary for `pecl` to work (to install PHP extensions)
 #
 RUN set -xe \
- && ./buildconf --force \
- && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+    && ./buildconf --force \
+    && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     CPPFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-O1 -Wl,--strip-all -Wl,--hash-style=both -pie" \
     ./configure \
-        --build=x86_64-pc-linux-gnu \
-        --prefix=${INSTALL_DIR} \
-        --enable-option-checking=fatal \
-        --enable-sockets \
-        --with-config-file-path=${INSTALL_DIR}/etc/php \
-        --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
-        --enable-fpm \
-        --disable-cgi \
-        --enable-cli \
-        --disable-phpdbg \
-        --disable-phpdbg-webhelper \
-        --with-sodium \
-        --with-readline \
-        --with-openssl \
-        --with-zlib=${INSTALL_DIR} \
-        --with-zlib-dir=${INSTALL_DIR} \
-        --with-curl \
-        --enable-exif \
-        --enable-ftp \
-        --with-gettext \
-        --enable-mbstring \
-        --with-pdo-mysql=shared,mysqlnd \
-        --with-mysqli \
-        --enable-pcntl \
-        --with-zip \
-        --enable-bcmath \
-        --with-pdo-pgsql=shared,${INSTALL_DIR} \
-        --enable-intl=shared \
-        --enable-soap \
-        --with-xsl=${INSTALL_DIR} \
-        --enable-gd \
-        --with-jpeg=${INSTALL_DIR} \
-        --with-pear
+    --build=x86_64-pc-linux-gnu \
+    --prefix=${INSTALL_DIR} \
+    --enable-option-checking=fatal \
+    --enable-sockets \
+    --with-config-file-path=${INSTALL_DIR}/etc/php \
+    --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
+    --enable-fpm \
+    --disable-cgi \
+    --enable-cli \
+    --disable-phpdbg \
+    --disable-phpdbg-webhelper \
+    --with-sodium \
+    --with-readline \
+    --with-openssl \
+    --with-zlib=${INSTALL_DIR} \
+    --with-zlib-dir=${INSTALL_DIR} \
+    --with-curl \
+    --enable-exif \
+    --enable-ftp \
+    --with-gettext \
+    --enable-mbstring \
+    --with-pdo-mysql=shared,mysqlnd \
+    --with-mysqli \
+    --enable-pcntl \
+    --with-zip \
+    --enable-bcmath \
+    --with-pdo-pgsql=shared,${INSTALL_DIR} \
+    --enable-intl=shared \
+    --with-pear
 RUN make -j $(nproc)
 # Run `make install` and override PEAR's PHAR URL because pear.php.net is down
 RUN set -xe; \
- make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
- { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
- make clean; \
- cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
+    make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
+    { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
+    make clean; \
+    cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 # Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
 RUN mkdir -p /opt/bin
@@ -118,10 +113,7 @@ RUN ln -s /opt/bref/sbin/* /opt/bin
 
 # Install extensions
 # We can install extensions manually or using `pecl`
-#RUN pecl install mongodb
-#RUN pecl install redis
 RUN pecl install APCu
-#RUN pecl install imagick
 
 
 # Run the next step in the previous environment because the `clean.sh` script needs `find`,
@@ -135,7 +127,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2018.03
+FROM lambci/lambda:build-provided.al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/helpers/php/conf.d/php.ini
+++ b/runtime/helpers/php/conf.d/php.ini
@@ -1,5 +1,2 @@
 extension=intl
 extension=apcu
-extension=redis
-extension=pdo_pgsql
-extension=mongodb

--- a/runtime/helpers/php/conf.dev.d/php.ini
+++ b/runtime/helpers/php/conf.dev.d/php.ini
@@ -1,2 +1,2 @@
-extension=blackfire
+; extension=blackfire
 zend_extension=xdebug

--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -10,5 +10,5 @@ RUN if [ "$PHP_VERSION" = "72" ]; then cd /opt/bref/etc/ && sed -i '/decorate_wo
 RUN if [ "$PHP_VERSION" = "72" ]; then cd /opt/bref/etc/ && sed -i '/log_limit/d' php-fpm.conf; fi;
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM lambci/lambda:build-provided.al2
 COPY --from=0  /opt /opt

--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -45,5 +45,3 @@ max_execution_time=27
 post_max_size=6M
 upload_max_filesize=6M
 
-; Enable the PDO MySQL extension
-extension=pdo_mysql

--- a/runtime/layers/function/Dockerfile
+++ b/runtime/layers/function/Dockerfile
@@ -9,5 +9,5 @@ COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 RUN rm /opt/bref/sbin/php-fpm /opt/bin/php-fpm
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM lambci/lambda:build-provided.al2
 COPY --from=0 /opt /opt

--- a/runtime/layers/function/php.ini
+++ b/runtime/layers/function/php.ini
@@ -37,6 +37,3 @@ zend_extension=opcache.so
 ; We explicitly populate all variables else ENV is not populated by default.
 ; See https://github.com/brefphp/bref/pull/291
 variables_order="EGPCS"
-
-; Enable the PDO MySQL extension
-extension=pdo_mysql

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -64,18 +64,21 @@ foreach ($fpmLayers as $layer) {
 $devLayers = [
     'bref/php-72-fpm-dev',
     'bref/php-73-fpm-dev',
+    'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
 ];
 $devExtensions = [
     'xdebug',
-    'blackfire',
+    // 'blackfire',
 ];
 foreach ($devLayers as $layer) {
     exec("docker run --rm -v \${PWD}/helpers:/var/task/ --entrypoint php $layer -m", $output, $exitCode);
     $notLoaded = array_diff($devExtensions, $output);
     // all development extensions are loaded
     if ($exitCode !== 0 || count($notLoaded) > 0) {
-        throw new Exception(implode(PHP_EOL, array_map(function ($extension) { return "Extension $extension is not loaded"; }, $notLoaded)), $exitCode);
+        throw new Exception(implode(PHP_EOL, array_map(function ($extension) {
+            return "Extension $extension is not loaded";
+        }, $notLoaded)), $exitCode);
     }
     echo '.';
 }


### PR DESCRIPTION
Fixes #722 

## Why?

1. Because light layers reduce execution time (especially cold starts), between 5 to 15% depending of the kind of app and lambda allocated memory.
2. Because with extra extensions it seem useless to have as many extensions provided by default in the base layer.

## What

- Better clean process
- Removal of following extensions: mongodb, redis, imagick. From now use extras instead
- Removal of: soap, xsl, gd, pthread (and zts)
- Adoption of new GA [Amazon Linux 2 images that will become mandatory at the end of this year](https://aws.amazon.com/fr/blogs/compute/migrating-aws-lambda-functions-to-al2/).

## Notes:
1. Supersedes #702 
2. Find redis & mongob extra exts in https://github.com/brefphp/extra-php-extensions/pull/51

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
