### PR TITLE
Add getter for ReceiptHandle in SQSRecord

### DIFF
--- a/src/Event/Sqs/SqsRecord.php
+++ b/src/Event/Sqs/SqsRecord.php
@@ -51,6 +51,14 @@ final class SqsRecord
     }
 
     /**
+     * Returns the receipt handle, the unique identifier for a specific instance of receiving a message.
+     */
+    public function getReceiptHandle(): string
+    {
+        return $this->record['receiptHandle'];
+    }
+
+    /**
      * Returns the record original data as an array.
      *
      * Use this method if you want to access data that is not returned by a method in this class.

--- a/tests/Event/Sqs/SqsEventTest.php
+++ b/tests/Event/Sqs/SqsEventTest.php
@@ -18,12 +18,14 @@ class SqsEventTest extends TestCase
         $this->assertSame('Test message.', $record->getBody());
         $this->assertSame(['foo' => 'bar'], $record->getMessageAttributes());
         $this->assertSame(1, $record->getApproximateReceiveCount());
+        $this->assertSame('AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...', $record->getReceiptHandle());
 
         $record = $event->getRecords()[1];
         $this->assertSame('2e1424d4-f796-459a-8184-9c92662be6da', $record->getMessageId());
         $this->assertSame('Test message.', $record->getBody());
         $this->assertSame([], $record->getMessageAttributes());
         $this->assertSame(4, $record->getApproximateReceiveCount());
+        $this->assertSame('AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...', $record->getReceiptHandle());
     }
 
     public function test invalid event()


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
When executing [DeleteMessage](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_DeleteMessage.html) against SQS (which AFAIK should be done when you successfully process a message), you must provide the ReceiptHandle that SQS provides as input to the Lambda function.

It's both documented [in the Lambda docs](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html), and there is already a ReceiptHandle key in the sample data used in the existing Bref tests. :) 

Because getting this piece of data and using it is a very common operation, I think it deserves its own getter.