### PR TITLE
SSM parameter SecureString recommendation

### DIFF
--- a/docs/environment/variables.md
+++ b/docs/environment/variables.md
@@ -40,23 +40,23 @@ Instead you can use the [SSM parameter store](https://docs.aws.amazon.com/system
 To create a parameter you can either do it manually in the [SSM parameter store console](https://console.aws.amazon.com/systems-manager/parameters) or use the following command:
 
 ```bash
-aws ssm put-parameter --region us-east-1 --name '/my-app/my-parameter' --type String --value 'mysecretvalue'
+aws ssm put-parameter --region us-east-1 --name '/my-app/my-parameter' --type SecureString --value 'mysecretvalue'
 ```
 
 For Windows users, the first part of the path needs to be double slashes and all subsequent forward slashes changed to backslashes:
 ```bash
-aws ssm put-parameter --region us-east-1 --name '//my-app\my-parameter' --type String --value 'mysecretvalue'
+aws ssm put-parameter --region us-east-1 --name '//my-app\my-parameter' --type SecureString --value 'mysecretvalue'
 ```
 
 It is recommended to prefix the parameter name with your application name, for example: `/my-app/my-parameter`.
 
-To import the SSM parameter into an environment variable you can use the [`${ssm:<parameter>}` syntax](https://serverless.com/blog/serverless-secrets-api-keys/):
+To import the SSM parameter into an environment variable you can use the [`${ssm:<parameter>~true}` syntax](https://www.serverless.com/framework/docs/providers/aws/guide/variables/#reference-variables-using-the-ssm-parameter-store):
 
 ```yaml
 provider:
     # ...
     environment:
-        MY_PARAMETER: ${ssm:/my-app/my-parameter}
+        MY_PARAMETER: ${ssm:/my-app/my-parameter~true}
 ```
 
 ### An alternative: AWS Secrets Manager


### PR DESCRIPTION
I followed the documentation provided by Bref explaining SSM parameter String usage for secrets.

But that is not following AWS recommendation _(linked in Bref's documentation)_
![image](https://user-images.githubusercontent.com/5444185/91543386-cc0e4780-e91e-11ea-8c21-59a3b7d81a4c.png)

I found that Bref can follow this recommendation with 
![image](https://user-images.githubusercontent.com/5444185/91543851-1e4f6880-e91f-11ea-8eea-b0ce30d697a5.png)

I suggest this documentation's update for others AWS and serverless framework rookies like me.
