### PR TITLE
Add a `bref layers` command

### DIFF
--- a/bref
+++ b/bref
@@ -455,6 +455,6 @@ $app->command('layers region', function (string $region, SymfonyStyle $io) {
     ], $array);
 
     return 0;
-})->descriptions('Create a short URL on bref.dev');
+})->descriptions('Displays the versions of the Bref layers');
 
 $app->run();

--- a/bref
+++ b/bref
@@ -435,4 +435,26 @@ $app->command('bref.dev [--profile=] [--stage=]', function (?string $profile, st
     return 0;
 })->descriptions('Create a short URL on bref.dev');
 
+$app->command('layers region', function (string $region, SymfonyStyle $io) {
+    $layers = json_decode(file_get_contents(__DIR__ . '/layers.json'), true);
+    $io->title("Layers for the $region region");
+
+    $array = [];
+    foreach ($layers as $layer => $versions) {
+        $version = $versions[$region];
+        $array[] = [
+            $layer,
+            $version,
+            "arn:aws:lambda:$region:416566615250:layer:$layer:$version",
+        ];
+    }
+    $io->table([
+        'Layer',
+        'Version',
+        'ARN',
+    ], $array);
+
+    return 0;
+})->descriptions('Create a short URL on bref.dev');
+
 $app->run();


### PR DESCRIPTION
Replaces #664

This adds a new `bref layers us-east-1` command that returns the version of the layers to use for the current Bref version.

It will make it easier for people not using `serverless.yml` to keep Bref up to date.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
