### PR TITLE
Added 25ms delay to ensure concurrent invocation

### DIFF
--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -14,6 +14,8 @@ abstract class HttpHandler implements Handler
     {
         // See https://bref.sh/docs/runtimes/http.html#cold-starts
         if (isset($event['warmer']) && $event['warmer'] === true) {
+            // Delay the response to ensure concurrent invocation
+            usleep(25000);
             return ['Lambda is warm'];
         }
 

--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -14,9 +14,10 @@ abstract class HttpHandler implements Handler
     {
         // See https://bref.sh/docs/runtimes/http.html#cold-starts
         if (isset($event['warmer']) && $event['warmer'] === true) {
-            if ($delay = getenv('WARMUP_DELAY')) {
+            $delay = getenv('WARMUP_DELAY');
+            if (is_numeric($delay)) {
                 // Delay the response to ensure concurrent invocation
-                usleep((int) $delay * 1000);
+                usleep($delay * 1000);
             }
             return ['Lambda is warm'];
         }

--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -17,7 +17,7 @@ abstract class HttpHandler implements Handler
             $delay = getenv('WARMUP_DELAY');
             if (is_numeric($delay)) {
                 // Delay the response to ensure concurrent invocation
-                usleep($delay * 1000);
+                usleep((int) $delay * 1000);
             }
             return ['Lambda is warm'];
         }

--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -14,8 +14,10 @@ abstract class HttpHandler implements Handler
     {
         // See https://bref.sh/docs/runtimes/http.html#cold-starts
         if (isset($event['warmer']) && $event['warmer'] === true) {
-            // Delay the response to ensure concurrent invocation
-            usleep(25000);
+            if ($delay = getenv('WARMUP_DELAY')) {
+                // Delay the response to ensure concurrent invocation
+                usleep((int) $delay * 1000);
+            }
             return ['Lambda is warm'];
         }
 


### PR DESCRIPTION
When trying to warmup a function, it needs to delay a bit the response to ensure concurrent invocations.
When I invoke the function with "{warmer: true}" as input (as described in the [documentation](https://bref.sh/docs/runtimes/http.html#cold-starts)) it takes less than 1ms for the function to end. Without any delay it's very unlikely to get near the desired concurrency. Or even to get any concurrent executions.

For example, by using different warmup plugins or even a simple function that invokes the bref php function, over 5 invocations if you're lucky it will warm 1 more function. Even trying to set a concurrency of 60 you won't get more than 5 warmed up function.

By adding a small delay (25ms), you get more chances to get close to your desired concurrency. Anyway you get billed for a minimum of 100ms, so adding this delay won't impact costs.

Edit:
this is a screenshot of my invocations with {warmer: true}

![image](https://user-images.githubusercontent.com/4161743/92142817-ad271e00-ee14-11ea-9582-256365e8ba7b.png)
