### PR TITLE
fix: remove twice added include fastcgi_params

### DIFF
--- a/runtime/layers/web/default.conf
+++ b/runtime/layers/web/default.conf
@@ -13,7 +13,6 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php:9001;
         include fastcgi_params;
-        include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /var/task/##HANDLER##;
         fastcgi_param PATH_INFO $fastcgi_path_info;
         internal;


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
because it's useless