### PR TITLE
Fix fpm dev gateway

### DIFF
--- a/runtime/layers/web/Dockerfile
+++ b/runtime/layers/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:alpine
 COPY default.conf /etc/nginx/conf.d/default.conf
 
 CMD  if [ -z "$DOCUMENT_ROOT" ];then HANDLER_DR=$HANDLER;else HANDLER_DR=${HANDLER#"$DOCUMENT_ROOT/"};fi;\

--- a/runtime/layers/web/default.conf
+++ b/runtime/layers/web/default.conf
@@ -15,7 +15,6 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php:9001;
         include fastcgi_params;
-        include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME /var/task/##HANDLER##;
         fastcgi_param PATH_INFO $fastcgi_path_info;
         internal;

--- a/runtime/layers/web/default.conf
+++ b/runtime/layers/web/default.conf
@@ -1,6 +1,8 @@
 server {
     server_name php-docker.local;
     root /var/task/##DOCUMENT_ROOT##;
+    fastcgi_buffers 16 16k;
+    fastcgi_buffer_size 32k;
 
     client_max_body_size 6M;
 


### PR DESCRIPTION
- use lightweight (alpine based) docker image :whale:  :leaves: 
- remove duplicate configuration directive :100: 
- add fastcgi buffer configuration to avoid some unexpected local development errors (logging related) :bomb: 

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
