### PR TITLE
Remove redis and mongo extensions

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -107,9 +107,7 @@ Bref strives to include the most common PHP extensions. If a major PHP extension
 
 - **[intl](http://php.net/manual/en/intro.intl.php)** - Internationalization extension (referred as Intl) is a wrapper for ICU library, enabling PHP programmers to perform various locale-aware operations.
 - **[APCu](http://php.net/manual/en/intro.apcu.php)** - APCu is APC stripped of opcode caching.
-- **[phpredis](https://github.com/phpredis/phpredis)** -  The phpredis extension provides an API for communicating with the Redis key-value store.
 - **[PostgreSQL PDO Driver](http://php.net/manual/en/ref.pdo-pgsql.php)** -  PDO_PGSQL is a driver that implements the PHP Data Objects (PDO) interface to enable access from PHP to PostgreSQL databases.
-- **[Mongodb](http://php.net/manual/en/set.mongodb.php)** - Unlike the mongo extension, this extension is developed atop the » libmongoc and » libbson libraries. It provides a minimal API for core driver functionality: commands, queries, writes, connection management, and BSON serialization.
 - **[pthreads](http://php.net/manual/en/book.pthreads.php)** - pthreads is an object-orientated API that provides all of the tools needed for multi-threading in PHP. PHP applications can create, read, write, execute and synchronize with Threads, Workers and Threaded objects.
 - **[imagick](http://php.net/manual/en/book.imagick.php)** - imagick is an image processing library.
 - **[GD](http://php.net/manual/en/book.image.php)** - GD is an image processing library.
@@ -119,9 +117,7 @@ You can enable these extensions by loading them in `php/conf.d/php.ini` (as ment
 ```ini
 extension=intl
 extension=apcu
-extension=redis
 extension=pdo_pgsql
-extension=mongodb
 extension=pthreads
 extension=imagick
 extension=gd

--- a/runtime/base/php-73.Dockerfile
+++ b/runtime/base/php-73.Dockerfile
@@ -94,8 +94,6 @@ RUN ln -s /opt/bref/sbin/* /opt/bin
 
 # Install extensions
 # We can install extensions manually or using `pecl`
-RUN pecl install mongodb
-RUN pecl install redis
 RUN pecl install APCu
 RUN pecl install imagick
 

--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -117,8 +117,6 @@ RUN ln -s /opt/bref/sbin/* /opt/bin
 
 # Install extensions
 # We can install extensions manually or using `pecl`
-RUN pecl install mongodb
-RUN pecl install redis
 RUN pecl install APCu
 RUN pecl install imagick
 

--- a/runtime/base/php-80.Dockerfile
+++ b/runtime/base/php-80.Dockerfile
@@ -117,8 +117,6 @@ RUN ln -s /opt/bref/sbin/* /opt/bin
 
 # Install extensions
 # We can install extensions manually or using `pecl`
-#RUN pecl install mongodb
-#RUN pecl install redis
 RUN pecl install APCu
 #RUN pecl install imagick
 

--- a/runtime/helpers/php/conf.d/php.ini
+++ b/runtime/helpers/php/conf.d/php.ini
@@ -1,5 +1,3 @@
 extension=intl
 extension=apcu
-extension=redis
 extension=pdo_pgsql
-extension=mongodb


### PR DESCRIPTION
As they are now provided as extra extensions, (see https://github.com/brefphp/extra-php-extensions/pull/51 https://github.com/brefphp/extra-php-extensions/pull/60 https://github.com/brefphp/extra-php-extensions/pull/53).


blocked by #748 
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
