### PR TITLE
fix: shell typo in nghttp2 build script

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -219,7 +219,7 @@ RUN set -xe; \
 WORKDIR  ${NGHTTP2_BUILD_DIR}/
 
 RUN set -xe; \
-    && CFLAGS="" \
+    CFLAGS="" \
     CPPFLAGS="-I${INSTALL_DIR}/include  -I/usr/include" \
     LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib" \
     ./configure \


### PR DESCRIPTION
Build was broken because of this typo
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
