### PR TITLE
Fix typo in "PHP functions"

### DIFF
--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -53,7 +53,7 @@ There can only be one function returned per PHP file.
 
 ### Context
 
-The function is invoked with the `$event` parameter as well a `$context` parameter. This parameter can be optionally declared if you want to use it:
+The function is invoked with the `$event` parameter as well as a `$context` parameter. This parameter can be optionally declared if you want to use it:
 
 ```php
 <?php


### PR DESCRIPTION
Just one word missing.

- Before:
  - ``The function is invoked with the `$event` parameter as well a `$context` parameter.``
- After:
  - <code>The function is invoked with the \`$event\` parameter as well <strong>as</strong> a \`$context\` parameter.</code>