### PR TITLE
Remove deprecated `bref invoke` command

### DIFF
--- a/bref
+++ b/bref
@@ -128,34 +128,6 @@ $app->command('cli function [--region=] [--profile=] [arguments]*', function (st
     return (int) ($payload['exitCode'] ?? 1);
 });
 
-$app->command('invoke function [--region=] [--profile=] [-e|--event=]', function (string $function, ?string $region, ?string $profile, ?string $event, SymfonyStyle $io) {
-    $io->warning([
-        'The `bref invoke` command is deprecated in favor of the `serverless invoke` command.',
-        'Run `serverless invoke --help` to learn how to use it, or read the documentation here: https://bref.sh/docs/runtimes/function.html#cli',
-    ]);
-
-    $lambda = new SimpleLambdaClient(
-        $region ?: getenv('AWS_DEFAULT_REGION') ?: 'us-east-1',
-        $profile ?: getenv('AWS_PROFILE') ?: 'default'
-    );
-
-    try {
-        $result = $lambda->invoke($function, $event);
-    } catch (InvocationFailed $e) {
-        $io->getErrorStyle()->writeln('<info>' . $e->getInvocationLogs() . '</info>');
-        $io->error($e->getMessage());
-        return 1;
-    }
-
-    $io->getErrorStyle()->writeln('<info>' . $result->getLogs() . '</info>');
-
-    $io->writeln(json_encode($result->getPayload(), JSON_PRETTY_PRINT));
-
-    return 0;
-})->descriptions('Invoke the lambda on the serverless provider', [
-    '--event' => 'Event data as JSON, e.g. `--event \'{"name":"matt"}\'`',
-]);
-
 $app->command('deployment stack-name [--region=] [--profile=]', function (string $stackName, ?string $region, ?string $profile, SymfonyStyle $io) {
     $region = $region ?: getenv('AWS_DEFAULT_REGION') ?: 'us-east-1';
     $profile = $profile ?: getenv('AWS_PROFILE') ?: 'default';


### PR DESCRIPTION
This command was deprecated in favor of `serverless invoke`.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
