### PR TITLE
Allow developer to control FPM Timeout via Environment Variable

### DIFF
--- a/runtime/layers/fpm/bootstrap
+++ b/runtime/layers/fpm/bootstrap
@@ -24,7 +24,13 @@ if (! is_file($handlerFile)) {
     $lambdaRuntime->failInitialization("Handler `$handlerFile` doesn't exist");
 }
 
-$phpFpm = new FpmHandler($handlerFile);
+if (getenv('BREF_PHP_FPM_TIMEOUT')) {
+    $timeout = (int) getenv('BREF_PHP_FPM_TIMEOUT') * 1000;
+} else {
+    $timeout = 30000;
+}
+
+$phpFpm = new FpmHandler($handlerFile, $timeout);
 try {
     $phpFpm->start();
 } catch (\Throwable $e) {

--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -44,11 +44,12 @@ final class FpmHandler extends HttpHandler
     /** @var Process|null */
     private $fpm;
     /** @var int */
-    private $socketReadWriteTimeout = 30000;
+    private $socketReadWriteTimeout;
 
-    public function __construct(string $handler, string $configFile = self::CONFIG)
+    public function __construct(string $handler, int $socketReadWriteTimeout, string $configFile = self::CONFIG)
     {
         $this->handler = $handler;
+        $this->socketReadWriteTimeout = $socketReadWriteTimeout;
         $this->configFile = $configFile;
     }
 
@@ -98,17 +99,6 @@ final class FpmHandler extends HttpHandler
     public function __destruct()
     {
         $this->stop();
-    }
-
-    /**
-     * Allow the developer to change the Socket Read Write Timeout to support APIs that take
-     * longer than 30 seconds to run behing ALB.
-     */
-    public function setSocketReadWriteTimeout(int $timeout): self
-    {
-        $this->socketReadWriteTimeout = $timeout;
-
-        return $this;
     }
 
     /**

--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -80,7 +80,7 @@ final class FpmHandler extends HttpHandler
         });
 
         $this->client = new Client;
-        $this->connection = new UnixDomainSocket(self::SOCKET, 1000, 30000);
+        $this->connection = new UnixDomainSocket(self::SOCKET, 1000, $this->socketReadWriteTimeout);
 
         $this->waitUntilReady();
     }

--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -43,6 +43,8 @@ final class FpmHandler extends HttpHandler
     private $configFile;
     /** @var Process|null */
     private $fpm;
+    /** @var int */
+    private $socketReadWriteTimeout = 30000;
 
     public function __construct(string $handler, string $configFile = self::CONFIG)
     {
@@ -96,6 +98,17 @@ final class FpmHandler extends HttpHandler
     public function __destruct()
     {
         $this->stop();
+    }
+
+    /**
+     * Allow the developer to change the Socket Read Write Timeout to support APIs that take
+     * longer than 30 seconds to run behing ALB.
+     */
+    public function setSocketReadWriteTimeout(int $timeout): self
+    {
+        $this->socketReadWriteTimeout = $timeout;
+
+        return $this;
     }
 
     /**

--- a/tests/Handler/FpmHandlerLoadBalancerTest.php
+++ b/tests/Handler/FpmHandlerLoadBalancerTest.php
@@ -151,7 +151,7 @@ final class FpmHandlerLoadBalancerTest extends TestCase
         if ($this->fpm) {
             $this->fpm->stop();
         }
-        $this->fpm = new FpmHandler($handler, __DIR__ . '/PhpFpm/php-fpm.conf');
+        $this->fpm = new FpmHandler($handler, 5000, __DIR__ . '/PhpFpm/php-fpm.conf');
         $this->fpm->start();
     }
 }

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -1085,7 +1085,7 @@ Year,Make,Model
      */
     public function test FPM timeouts are recovered from()
     {
-        $this->fpm = new FpmHandler(__DIR__ . '/PhpFpm/timeout.php', __DIR__ . '/PhpFpm/php-fpm.conf');
+        $this->fpm = new FpmHandler(__DIR__ . '/PhpFpm/timeout.php', 5000, __DIR__ . '/PhpFpm/php-fpm.conf');
         $this->fpm->start();
 
         try {
@@ -1124,7 +1124,7 @@ Year,Make,Model
     {
         // Run `timeout.php` to make sure that the handler is not really executed.
         // If it was, then PHP-FPM would timeout (and error).
-        $this->fpm = new FpmHandler(__DIR__ . '/PhpFpm/timeout.php', __DIR__ . '/PhpFpm/php-fpm.conf');
+        $this->fpm = new FpmHandler(__DIR__ . '/PhpFpm/timeout.php', 5000, __DIR__ . '/PhpFpm/php-fpm.conf');
         $this->fpm->start();
 
         $result = $this->fpm->handle([
@@ -1198,7 +1198,7 @@ Year,Make,Model
         if ($this->fpm) {
             $this->fpm->stop();
         }
-        $this->fpm = new FpmHandler($handler, __DIR__ . '/PhpFpm/php-fpm.conf');
+        $this->fpm = new FpmHandler($handler, 5000, __DIR__ . '/PhpFpm/php-fpm.conf');
         $this->fpm->start();
     }
 }


### PR DESCRIPTION
This is a different approach for #770. The question remains the same: Should bref support APIs that take longer than 30 seconds via ALB?

The environment variable approach has it's downsides of being weird. During Lambda configuration, I'll have to setup my timeout on Lambda Timeout and set it up again on a BREF environment variable. But it seems less error-prone and simpler to document and maintain. [If AWS ever decides to offer an automatic environment variable with the timeout](https://twitter.com/chrismunns/status/1314249684848959489), it's an easy migration path forward.

This approach has no mixing of layers or weird overwrites, but it does come with an environment variable maintenance cost.