### PR TITLE
Migrate to Amazon Linux 2 images

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -147,13 +147,10 @@ To compile the extension, Bref provides the `bref/build-php-*` Docker images. He
 ```dockerfile
 FROM bref/build-php-74
 
-RUN curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/7.3 \
-    && mkdir -p /tmp/blackfire \
-    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
-    && cp /tmp/blackfire/blackfire-*.so /tmp/blackfire.so
+RUN curl -A "Docker" -o /tmp/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/1.42.0/blackfire-php-linux_amd64-php-74.so"
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM lambci/lambda:provided.al2
 
 # Copy things we installed to the final image
 COPY --from=0 /tmp/blackfire.so /opt/bref-extra/blackfire.so

--- a/docs/environment/serverless-yml.md
+++ b/docs/environment/serverless-yml.md
@@ -15,7 +15,7 @@ service: app
 
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
 
 plugins:
     - ./vendor/bref/bref
@@ -68,7 +68,7 @@ The `provider` section also lets us configure global options on all functions:
 provider:
     name: aws
     timeout: 10
-    runtime: provided
+    runtime: provided.al2
 
 functions:
     foo:
@@ -93,13 +93,13 @@ functions:
     foo:
         handler: foo.php
         timeout: 10
-        runtime: provided
+        runtime: provided.al2
         layers:
             - ${bref:layer.php-74}
     bar:
         handler: bar.php
         timeout: 10
-        runtime: provided
+        runtime: provided.al2
         layers:
             - ${bref:layer.php-74}
 
@@ -166,7 +166,7 @@ If your lambda needs to access other AWS services (S3, SQS, SNS…), you will ne
 provider:
     name: aws
     timeout: 10
-    runtime: provided
+    runtime: provided.al2
     iamRoleStatements:
         # Allow to put a file in the `my-bucket` S3 bucket
         -   Effect: Allow

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -24,7 +24,7 @@ service: bref-demo-symfony
 provider:
     name: aws
     region: us-east-1
-    runtime: provided
+    runtime: provided.al2
     environment:
         # Symfony environment variables
         APP_ENV: prod

--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -50,7 +50,7 @@ To use a runtime, import the corresponding layer in `serverless.yml`:
 service: app
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
 plugins:
     - ./vendor/bref/bref
 functions:
@@ -96,7 +96,7 @@ To use them manually you need to use that full name. For example in `serverless.
 service: app
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
 functions:
     hello:
         ...
@@ -114,7 +114,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             ...
-            Runtime: provided
+            Runtime: provided.al2
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-73:7'
 ```

--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -24,7 +24,7 @@ Below is a minimal `serverless.yml`. To create it automatically run `vendor/bin/
 service: app
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
 plugins:
     - ./vendor/bref/bref
 functions:

--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -77,7 +77,7 @@ Below is a minimal `serverless.yml` to deploy a function. To create it automatic
 service: app
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
 plugins:
     - ./vendor/bref/bref
 functions:

--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -26,7 +26,7 @@ Below is a minimal `serverless.yml` to deploy HTTP applications. To create it au
 service: app
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
 plugins:
     - ./vendor/bref/bref
 functions:

--- a/docs/websites.md
+++ b/docs/websites.md
@@ -135,7 +135,7 @@ The `serverless.yml` example below:
 service: app
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
 
 functions:
     website:

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -12,9 +12,8 @@ layers: export/console.zip export/php-73.zip export/php-74.zip export/php-80.zip
 export/php%.zip: docker-images
 	PHP_VERSION=$$(echo $@ | cut -d'/' -f 2 | cut -d'.' -f 1);\
 	rm -f $@;\
-	mkdir export/tmp ; cd export/tmp ;\
-	docker run --entrypoint "tar" bref/$$PHP_VERSION:latest -ch -C /opt .  |tar -x;zip --quiet --recurse-paths ../$$PHP_VERSION.zip . ;
-	rm -rf export/tmp
+	cd export ; \
+	docker run --rm --entrypoint= bref/$$PHP_VERSION:latest sh -c "cd /opt && zip -qq -y -r - {*,.[!.]*} > /tmp/file.zip && cat /tmp/file.zip -" > $$PHP_VERSION.zip ;
 
 # The console runtime
 export/console.zip: layers/console/bootstrap

--- a/runtime/base/clean.sh
+++ b/runtime/base/clean.sh
@@ -9,7 +9,10 @@ set -e
 set -u
 
 # Strip all the unneeded symbols from shared libraries to reduce size.
-find /opt/bref -type f -name "*.so*" -o -name "*.a"  -exec strip --strip-unneeded {} \;
+find /opt/bref -type f -name "*.so*" -exec strip --strip-unneeded {} \;
+find /opt/bref -type f -name "*.a"|xargs rm
+find /opt/bref -type f -name "*.la"|xargs rm
+find /opt/bref -type f -name "*.dist"|xargs rm
 find /opt/bref -type f -executable -exec sh -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; -print|xargs strip --strip-all
 
 # Cleanup all the binaries we don't want.
@@ -19,10 +22,14 @@ find /opt/bin -mindepth 1 -maxdepth 1 ! -name "php" ! -name "php-fpm" -exec rm {
 # Cleanup all the files we don't want either
 # We do not support running pear functions in Lambda
 rm -rf /opt/bref/lib/php/PEAR
-rm -rf /opt/bref/share/doc
-rm -rf /opt/bref/share/man
-rm -rf /opt/bref/share/gtk-doc
+rm -rf /opt/bref/share
 rm -rf /opt/bref/include
+rm -rf /opt/bref/php
+rm -rf /opt/bref/{lib,lib64}/pkgconfig
+rm -rf /opt/bref/{lib,lib64}/cmake
+rm -rf /opt/bref/lib/xml2Conf.sh
+find /opt/bref/lib/php -mindepth 1 -maxdepth 1 -type d -a -not -name extensions |xargs rm -rf
+find /opt/bref/lib/php -mindepth 1 -maxdepth 1 -type f |xargs rm -rf
 rm -rf /opt/bref/lib/php/test
 rm -rf /opt/bref/lib/php/doc
 rm -rf /opt/bref/lib/php/docs
@@ -30,6 +37,7 @@ rm -rf /opt/bref/tests
 rm -rf /opt/bref/doc
 rm -rf /opt/bref/docs
 rm -rf /opt/bref/man
+rm -rf /opt/bref/php/man
 rm -rf /opt/bref/www
 rm -rf /opt/bref/cfg
 rm -rf /opt/bref/libexec

--- a/runtime/base/php-73.Dockerfile
+++ b/runtime/base/php-73.Dockerfile
@@ -85,9 +85,10 @@ RUN set -xe; \
  cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 # Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
-RUN mkdir -p /opt/bin
-RUN ln -s /opt/bref/bin/* /opt/bin
-RUN ln -s /opt/bref/sbin/* /opt/bin
+RUN mkdir -p /opt/bin \
+  && cd /opt/bin \
+  && ln -s ../bref/bin/* . \
+  && ln -s ../bref/sbin/* .
 
 # Install extensions
 # We can install extensions manually or using `pecl`
@@ -104,7 +105,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2018.03
+FROM lambci/lambda:build-provided.al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -109,9 +109,10 @@ RUN set -xe; \
  cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 # Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
-RUN mkdir -p /opt/bin
-RUN ln -s /opt/bref/bin/* /opt/bin
-RUN ln -s /opt/bref/sbin/* /opt/bin
+RUN mkdir -p /opt/bin \
+    && cd /opt/bin \
+    && ln -s ../bref/bin/* . \
+    && ln -s ../bref/sbin/* .
 
 # Install extensions
 # We can install extensions manually or using `pecl`
@@ -128,7 +129,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2018.03
+FROM amazonlinux:2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/base/php-80.Dockerfile
+++ b/runtime/base/php-80.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=8.0.0beta4
+ENV VERSION_PHP=8.0.0rc1
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
@@ -46,7 +46,7 @@ RUN set -xe; \
     # --location will follow redirects
     # --silent will hide the progress, but also the errors: we restore error messages with --show-error
     # --fail makes sure that curl returns an error instead of fetching the 404 page
-    curl --location --silent --show-error --fail https://downloads.php.net/~pollita/php-${VERSION_PHP}.tar.gz \
+    curl --location --silent --show-error --fail https://downloads.php.net/~carusogabriel/php-${VERSION_PHP}.tar.gz \
   | tar xzC ${PHP_BUILD_DIR} --strip-components=1
 # Move into the unpackaged code directory
 WORKDIR  ${PHP_BUILD_DIR}/
@@ -109,9 +109,10 @@ RUN set -xe; \
  cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
 
 # Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
-RUN mkdir -p /opt/bin
-RUN ln -s /opt/bref/bin/* /opt/bin
-RUN ln -s /opt/bref/sbin/* /opt/bin
+RUN mkdir -p /opt/bin \
+    && cd /opt/bin \
+    && ln -s ../bref/bin/* . \
+    && ln -s ../bref/sbin/* .
 
 # Install extensions
 # We can install extensions manually or using `pecl`
@@ -128,7 +129,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2018.03
+FROM lambci/lambda:build-provided.al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -21,12 +21,8 @@ RUN cp $(php -r "echo ini_get('extension_dir');")/xdebug.so /tmp
 
 RUN if [ "$PHP_VERSION" != "80" ] ; \
     then \
-        version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;")-zts \
-        && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
-        && mkdir -p /tmp/blackfire \
-        && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
-        && cp /tmp/blackfire/blackfire-*.so /tmp/blackfire.so \
-        && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz ; \
+        version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/1.42.0/blackfire-php-linux_amd64-php-"$version".so" ; \
     fi
 
 FROM bref/php-${PHP_VERSION}-fpm as build_dev

--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -7,5 +7,5 @@ COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM lambci/lambda:build-provided.al2
 COPY --from=0  /opt /opt

--- a/runtime/layers/function/Dockerfile
+++ b/runtime/layers/function/Dockerfile
@@ -9,5 +9,5 @@ COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 RUN rm /opt/bref/sbin/php-fpm /opt/bin/php-fpm
 
 # Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided
+FROM lambci/lambda:build-provided.al2
 COPY --from=0 /opt /opt

--- a/runtime/layers/publish.php
+++ b/runtime/layers/publish.php
@@ -74,7 +74,7 @@ function publishLayer(string $region, string $layer, string $layerDescription): 
         '--zip-file',
         'fileb://' . $file,
         '--compatible-runtimes',
-        'provided',
+        'provided.al2',
         // Output the version so that we can fetch it and use it
         '--output',
         'text',

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -58,7 +58,8 @@ foreach ($fpmLayers as $layer) {
 // dev layers
 $devLayers = [
     'bref/php-73-fpm-dev',
-    'bref/php-80-fpm-dev',
+    'bref/php-74-fpm-dev',
+    // 'bref/php-80-fpm-dev', // skip until blackfire gets supported for PHP 8.0
 ];
 $devExtensions = [
     'xdebug',
@@ -69,7 +70,9 @@ foreach ($devLayers as $layer) {
     $notLoaded = array_diff($devExtensions, $output);
     // all development extensions are loaded
     if ($exitCode !== 0 || count($notLoaded) > 0) {
-        throw new Exception(implode(PHP_EOL, array_map(function ($extension) { return "Extension $extension is not loaded"; }, $notLoaded)), $exitCode);
+        throw new Exception(implode(PHP_EOL, array_map(function ($extension) {
+            return "Extension $extension is not loaded";
+        }, $notLoaded)), $exitCode);
     }
     echo '.';
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: bref-demo
 
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
     region: us-east-2
     logs:
         restApi: true

--- a/template/console/serverless.yml
+++ b/template/console/serverless.yml
@@ -3,7 +3,7 @@ service: app
 provider:
     name: aws
     region: us-east-1
-    runtime: provided
+    runtime: provided.al2
 
 plugins:
     - ./vendor/bref/bref

--- a/template/default/serverless.yml
+++ b/template/default/serverless.yml
@@ -3,7 +3,7 @@ service: app
 provider:
     name: aws
     region: us-east-1
-    runtime: provided
+    runtime: provided.al2
 
 plugins:
     - ./vendor/bref/bref

--- a/template/http/serverless.yml
+++ b/template/http/serverless.yml
@@ -3,7 +3,7 @@ service: app
 provider:
     name: aws
     region: us-east-1
-    runtime: provided
+    runtime: provided.al2
 
 plugins:
     - ./vendor/bref/bref

--- a/tests/Sam/template.yaml
+++ b/tests/Sam/template.yaml
@@ -8,7 +8,7 @@ Resources:
             FunctionName: 'bref-tests-function'
             CodeUri: ../..
             Handler: tests/Sam/Php/function.php
-            Runtime: provided
+            Runtime: provided.al2
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-74:14'
             Environment:
@@ -21,7 +21,7 @@ Resources:
             FunctionName: 'bref-tests-http'
             CodeUri: ../..
             Handler: tests/Sam/PhpFpm/index.php
-            Runtime: provided
+            Runtime: provided.al2
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-74-fpm:14'
             Events:
@@ -40,7 +40,7 @@ Resources:
             FunctionName: 'bref-tests-http-missing-handler'
             CodeUri: ../..
             Handler: tests/Sam/PhpFpm/UNKNOWN.php
-            Runtime: provided
+            Runtime: provided.al2
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-74-fpm:14'
             Events:
@@ -56,7 +56,7 @@ Resources:
             FunctionName: 'bref-tests-psr7'
             CodeUri: ../..
             Handler: tests/Sam/Php/psr7.php
-            Runtime: provided
+            Runtime: provided.al2
             Layers:
                 - 'arn:aws:lambda:us-east-1:209497400698:layer:php-74:14'
             Events:

--- a/tests/serverless.tests.yml
+++ b/tests/serverless.tests.yml
@@ -2,7 +2,7 @@ service: bref-tests
 
 provider:
     name: aws
-    runtime: provided
+    runtime: provided.al2
     region: eu-west-1
     profile: bref-tests
     apiGateway:


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

[As announced on 12 AUG 2020](https://aws.amazon.com/fr/blogs/compute/migrating-aws-lambda-functions-to-al2/), Amazon Linux 1 EOL (End Of Life) is coming in December 2020.
