### PR TITLE
#409 Add a `bref local` command to invoke functions locally

### DIFF
--- a/bref
+++ b/bref
@@ -6,14 +6,19 @@ use AsyncAws\CloudFormation\CloudFormationClient;
 use AsyncAws\CloudFormation\ValueObject\Output;
 use AsyncAws\CloudFormation\ValueObject\StackEvent;
 use AsyncAws\Core\Exception\Http\HttpException;
+use Bref\Bref;
+use Bref\Console\Command\Local;
 use Bref\Console\LoadingAnimation;
 use Bref\Console\OpenUrl;
+use Bref\Context\Context;
 use Bref\Lambda\InvocationFailed;
 use Bref\Lambda\SimpleLambdaClient;
+use Bref\Runtime\Invoker;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
 
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
@@ -127,6 +132,11 @@ $app->command('cli function [--region=] [--profile=] [arguments]*', function (st
 
     return (int) ($payload['exitCode'] ?? 1);
 });
+
+/**
+ * Invoke a function locally
+ */
+$app->command('local function [event]', new Local);
 
 $app->command('deployment stack-name [--region=] [--profile=]', function (string $stackName, ?string $region, ?string $profile, SymfonyStyle $io) {
     $region = $region ?: getenv('AWS_DEFAULT_REGION') ?: 'us-east-1';

--- a/bref
+++ b/bref
@@ -136,7 +136,7 @@ $app->command('cli function [--region=] [--profile=] [arguments]*', function (st
 /**
  * Invoke a function locally
  */
-$app->command('local function [data] [--file=]', new Local);
+$app->command(Local::SIGNATURE, new Local);
 
 $app->command('deployment stack-name [--region=] [--profile=]', function (string $stackName, ?string $region, ?string $profile, SymfonyStyle $io) {
     $region = $region ?: getenv('AWS_DEFAULT_REGION') ?: 'us-east-1';

--- a/bref
+++ b/bref
@@ -136,7 +136,7 @@ $app->command('cli function [--region=] [--profile=] [arguments]*', function (st
 /**
  * Invoke a function locally
  */
-$app->command('local function [event]', new Local);
+$app->command('local function [data] [--file=]', new Local);
 
 $app->command('deployment stack-name [--region=] [--profile=]', function (string $stackName, ?string $region, ?string $profile, SymfonyStyle $io) {
     $region = $region ?: getenv('AWS_DEFAULT_REGION') ?: 'us-east-1';

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "async-aws/cloud-formation": "^1.0",
         "async-aws/lambda": "^1.0",
         "nyholm/psr7": "^1.2",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "symfony/yaml": "^5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/demo/function.php
+++ b/demo/function.php
@@ -3,5 +3,7 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 return function ($event) {
+    echo 'This is a log line' . PHP_EOL;
+
     return 'Hello ' . ($event['name'] ?? 'world');
 };

--- a/docs/environment/variables.md
+++ b/docs/environment/variables.md
@@ -76,10 +76,15 @@ However Secrets Manager is not free: [pricing details](https://aws.amazon.com/se
 
 ## Local development
 
-When [developing locally using `serverless invoke local`](/docs/local-development.md) you can override environment variables via the `--env` option:
+When [developing locally using `vendor/bin/bref local`](/docs/local-development.md), you can set environment variables using bash:
 
 ```bash
-serverless invoke local -f <Function> --env VAR1=val1 --env VAR2=val2
+VAR1=val1 VAR2=val2 vendor/bin/bref local <funtion>
+
+# Or using `export`:
+export VAR1=val1
+export VAR2=val2
+vendor/bin/bref local <funtion>
 ```
 
 ## Learn more

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -48,6 +48,21 @@ Here is an example, feel free to adjust it to fit your needs:
 docker run --rm -it -v $(PWD):/var/task:ro,delegated bref/php-74 vendor/bin/bref local hello
 ```
 
+If you do not use `serverless.yml` but something else like SAM/CDK/CloudFormation/Terraform, use the `--handler` parameter instead:
+
+```bash
+$ vendor/bin/bref local --handler=my-function.php
+Hello world
+
+# With JSON event data
+$ vendor/bin/bref local '{"name": "Jane"}' --handler=my-function.php
+Hello Jane
+
+# With JSON in a file
+$ vendor/bin/bref local --handler=my-function.php --file=event.json
+Hello Jane
+```
+
 ## HTTP applications
 
 If you want to keep things simple, you can run your PHP application like you did without Bref. For example with your favorite framework:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -3,11 +3,9 @@ title: Local development
 current_menu: local-development
 ---
 
-To run your applications locally with an architecture close to production you can use the `sam` command line tool from AWS.
-
 ## PHP functions
 
-The `serverless invoke local` command invokes your [PHP functions](/docs/runtimes/function.md) locally. You can provide an event if your function expects one.
+The `vendor/bin/bref local` command invokes your [PHP functions](/docs/runtimes/function.md) locally. You can provide an event if your function expects one.
 
 For example, given this function:
 
@@ -21,23 +19,34 @@ return function (array $event) {
 # ...
 
 functions:
-    myFunction:
-        handler: index.php
+    hello:
+        handler: my-function.php
         layers:
             - ${bref:layer.php-74}
 ```
 
 You can invoke it with or without event data:
 
-```sh
-$ serverless invoke local -f myFunction
+```bash
+$ vendor/bin/bref local hello
 Hello world
 
-$ serverless invoke local -f myFunction --data '{"name": "Jane"}'
+# With JSON event data
+$ vendor/bin/bref local hello '{"name": "Jane"}'
+Hello Jane
+
+# With JSON in a file
+$ vendor/bin/bref local hello --file=event.json
 Hello Jane
 ```
 
-> Learn more in the [`serverless invoke local` documentation](https://serverless.com/framework/docs/providers/aws/cli-reference/invoke-local/) or run `serverless invoke local --help`.
+The `bref local` command runs using the local PHP installation. If you prefer to run commands using the same environment as Lambda, you can use Docker.
+
+Here is an example, feel free to adjust it to fit your needs:
+
+```bash
+docker run --rm -it -v $(PWD):/var/task:ro,delegated bref/php-74 vendor/bin/bref local hello
+```
 
 ## HTTP applications
 

--- a/src/Console/Command/Local.php
+++ b/src/Console/Command/Local.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Console\Command;
+
+use Bref\Bref;
+use Bref\Context\Context;
+use Bref\Runtime\Invoker;
+use Exception;
+use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
+
+/**
+ * Local function invocation.
+ */
+class Local
+{
+    public function __invoke(string $function, ?string $event, SymfonyStyle $io)
+    {
+        if (! file_exists('serverless.yml')) {
+            $io->error('No `serverless.yml` file found.');
+            return 1;
+        }
+
+        $handler = $this->resolveHandler($function);
+
+        $event = $event ? json_decode($event, true, 512, JSON_THROW_ON_ERROR) : null;
+
+        // Same configuration as the Bref runtime on Lambda
+        ini_set('display_errors', '1');
+        error_reporting(E_ALL);
+
+        $requestId = '8f507cfc-example-4697-b07a-ac58fc914c95';
+        $startTime = $this->logStart($io, $requestId);
+
+        try {
+            $invoker = new Invoker;
+            $result = $invoker->invoke($handler, $event, new Context($requestId, 0, '', ''));
+        } catch (Throwable $e) {
+            $io->error($e->getMessage());
+            return 1;
+        }
+
+        $this->logEnd($startTime, $io, $requestId);
+        // Show the invocation result
+        $io->block(json_encode($result, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT), null, 'fg=black;bg=green', '', true);
+
+        return 0;
+    }
+
+    /**
+     * @return mixed
+     */
+    private function resolveHandler(string $function)
+    {
+        $serverlessConfig = Yaml::parseFile('serverless.yml');
+
+        if (! isset($serverlessConfig['functions'][$function])) {
+            throw new Exception("There is no function named '$function' in serverless.yml");
+        }
+        if (! isset($serverlessConfig['functions'][$function]['handler'])) {
+            throw new Exception("There is no handler defined on function '$function' in serverless.yml");
+        }
+
+        $handlerName = $serverlessConfig['functions'][$function]['handler'];
+
+        try {
+            return Bref::getContainer()->get($handlerName);
+        } catch (NotFoundExceptionInterface $e) {
+            throw new Exception($e->getMessage() . PHP_EOL . 'Reminder: `bref local` can invoke functions that use the FUNCTION runtime, not the HTTP (or "FPM") runtime. If you are unsure, check out https://bref.sh/docs/local-development.html#http-applications to run HTTP applications locally.');
+        }
+    }
+
+    private function logStart(SymfonyStyle $io, string $requestId): float
+    {
+        $io->writeln("START RequestId: $requestId Version: \$LATEST");
+        return microtime(true);
+    }
+
+    private function logEnd(float $startTime, SymfonyStyle $io, string $requestId): void
+    {
+        $duration = ceil((microtime(true) - $startTime) * 1000);
+        $billedDuration = ceil(max($duration / 100, 1)) * 100;
+        $memoryUsed = ceil(memory_get_usage() / 1024 / 1024);
+
+        $io->writeln([
+            "END RequestId: $requestId",
+            "REPORT RequestId: $requestId Duration: $duration ms Billed Duration: $billedDuration ms Memory Size: 1024 MB Max Memory Used: $memoryUsed MB",
+        ]);
+    }
+}

--- a/src/Console/Command/Local.php
+++ b/src/Console/Command/Local.php
@@ -17,7 +17,7 @@ use Throwable;
  */
 class Local
 {
-    public function __invoke(string $function, ?string $data, ?string $file, SymfonyStyle $io)
+    public function __invoke(string $function, ?string $data, ?string $file, SymfonyStyle $io): int
     {
         if ($data && $file) {
             throw new Exception('You cannot provide both event data and the --file= option.');

--- a/src/Runtime/FileHandlerLocator.php
+++ b/src/Runtime/FileHandlerLocator.php
@@ -21,7 +21,12 @@ class FileHandlerLocator implements ContainerInterface
 
     public function __construct(?string $directory = null)
     {
-        $this->directory = $directory ?: $_SERVER['LAMBDA_TASK_ROOT'];
+        $this->directory = $directory ?: ($_SERVER['LAMBDA_TASK_ROOT'] ?? null);
+
+        // When running locally (`bref local` CLI command) `LAMBDA_TASK_ROOT` is undefined
+        if (! $this->directory) {
+            $this->directory = getcwd();
+        }
     }
 
     /**

--- a/src/Runtime/Invoker.php
+++ b/src/Runtime/Invoker.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Runtime;
+
+use Bref\Event\Handler;
+use Bref\Event\Http\Psr15Handler;
+use Exception;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * @internal
+ */
+final class Invoker
+{
+    /**
+     * @return mixed
+     */
+    public function invoke($handler, $event, $context)
+    {
+        // PSR-15 adapter
+        if ($handler instanceof RequestHandlerInterface) {
+            $handler = new Psr15Handler($handler);
+        }
+
+        if ($handler instanceof Handler) {
+            return $handler->handle($event, $context);
+        }
+
+        if (is_callable($handler)) {
+            // The handler is a callable
+            return $handler($event, $context);
+        }
+
+        throw new Exception('The lambda handler must be a callable or implement handler interfaces');
+    }
+}

--- a/src/Runtime/Invoker.php
+++ b/src/Runtime/Invoker.php
@@ -2,6 +2,7 @@
 
 namespace Bref\Runtime;
 
+use Bref\Context\Context;
 use Bref\Event\Handler;
 use Bref\Event\Http\Psr15Handler;
 use Exception;
@@ -13,9 +14,11 @@ use Psr\Http\Server\RequestHandlerInterface;
 final class Invoker
 {
     /**
+     * @param mixed $handler
+     * @param mixed $event
      * @return mixed
      */
-    public function invoke($handler, $event, $context)
+    public function invoke($handler, $event, Context $context)
     {
         // PSR-15 adapter
         if ($handler instanceof RequestHandlerInterface) {

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -5,7 +5,6 @@ namespace Bref\Runtime;
 use Bref\Context\Context;
 use Bref\Context\ContextBuilder;
 use Bref\Event\Handler;
-use Bref\Event\Http\Psr15Handler;
 use Exception;
 use Psr\Http\Server\RequestHandlerInterface;
 
@@ -40,6 +39,9 @@ final class LambdaRuntime
     /** @var string */
     private $apiUrl;
 
+    /** @var Invoker */
+    private $invoker;
+
     public static function fromEnvironmentVariable(): self
     {
         return new self((string) getenv('AWS_LAMBDA_RUNTIME_API'));
@@ -52,6 +54,7 @@ final class LambdaRuntime
         }
 
         $this->apiUrl = $apiUrl;
+        $this->invoker = new Invoker;
     }
 
     public function __destruct()
@@ -95,22 +98,8 @@ final class LambdaRuntime
 
         $this->ping();
 
-        $result = null;
-
         try {
-            // PSR-15 adapter
-            if ($handler instanceof RequestHandlerInterface) {
-                $handler = new Psr15Handler($handler);
-            }
-
-            if ($handler instanceof Handler) {
-                $result = $handler->handle($event, $context);
-            } elseif (is_callable($handler)) {
-                // The handler is a callable
-                $result = $handler($event, $context);
-            } else {
-                throw new Exception('The lambda handler must be a callable or implement handler interfaces');
-            }
+            $result = $this->invoker->invoke($handler, $event, $context);
 
             $this->sendResponse($context->getAwsRequestId(), $result);
         } catch (\Throwable $e) {


### PR DESCRIPTION
Fixes #409. 

This is an attempt at fixing #409 to simplify running functions locally.

**This is not meant to run HTTP applications**, this is meant to run Lambda functions locally.

**Note: this is planned for v1.0.**

## The problem

Here is a PHP function for Lambda:

```php
<?php
return function ($event) {
    echo 'This is a log line' . PHP_EOL;

    return 'Hello ' . ($event['name'] ?? 'world');
};
```

Here is how it is configured in `serverless.yml`:

```php
functions:
    hello:
        handler: my-hello-function.php
        layers:
            - ${bref:layer.php-74}
```

Here is how we can currently run this function locally:

- `serverless invoke local -f hello`
  - 👍 Runs in Docker (mirrors the prod environment)
  - 👍 `serverless` forwards the local AWS credentials, region and AWS profile automatically
  - 🔴 Downloads the layers (once) & builds a local Docker image everytime : this is very slow
  - 🔴 This is unstable: #409 has multiple reports of people having a broken Docker image, which is a mess

- `docker run --rm -it -v $(PWD):/var/task:ro,delegated bref/php-74 my-hello-function.php '{}'`
  - 👍 Runs in Docker (mirrors the prod environment)
  - 👍 Native Docker command which gives more control than `serverless invoke local`
  - 🔴 Command is long and hard to remember
  - 🔴 Requires to pass the handler file name instead of the function name
  - 🔴 An even more complex command is required to forward AWS credentials and other variables like profile & region

## The solution

This PR introduces a new command:

```bash
$ vendor/bin/bref local hello
START RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95 Version: $LATEST
This is a log line
END RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95
REPORT RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95 Duration: 3 ms Billed Duration: 100 ms Memory Size: 1024 MB Max Memory Used: 4 MB

"Hello world"
```

Output example:

![image](https://user-images.githubusercontent.com/720328/99087788-75cead80-25cb-11eb-973f-78097d86d075.png)

- 👍 The command is simple
- 👍 It uses the same names as in `serverless.yml`
- It runs **without Docker**, using your installed PHP CLI:
  - 👍 It's as fast as possible
  - 👍 AWS credentials & environment variables work as usual
- It can also run **inside Docker** for those who want: `docker run --rm -it -v $(PWD):/var/task:ro,delegated bref/php-74 vendor/bin/bref local hello`
  - 👍 Runs in Docker (mirrors the prod environment)

That way, users can get the best of both worlds!

It is also possible to pass event data as JSON:

```bash
$ vendor/bin/bref local hello '{"name":"Matthieu"}'
START RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95 Version: $LATEST
This is a log line
END RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95
REPORT RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95 Duration: 3 ms Billed Duration: 100 ms Memory Size: 1024 MB Max Memory Used: 4 MB

"Hello Matthieu"
```

If you do not use `serverless.yml` but something else like SAM/CDK/CloudFormation/Terraform, use the `--handler` parameter instead:

```bash
$ vendor/bin/bref local --handler=my-function.php
Hello world

# With JSON event data
$ vendor/bin/bref local '{"name": "Jane"}' --handler=my-function.php
Hello Jane

# With JSON in a file
$ vendor/bin/bref local --handler=my-function.php --file=event.json
Hello Jane
```

## TODO

- [x] More robust code
- [x] Allow to pass event data from a file
- [x] Documentation
- [x] Support SAM/CDK/Terraform/etc.