### PR TITLE
Re-remove the API Gateway stage prefix from URLs

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -114,10 +114,21 @@ final class HttpRequestEvent implements LambdaEvent
         }
 
         /**
-         * $event['requestContext']['path'] contains the real URL, including the stage prefix.
-         * $event['path'] contains the URL without the stage prefix.
+         * $event['path'] contains the URL always without the stage prefix.
+         * $event['requestContext']['path'] contains the URL always with the stage prefix.
+         * None of the represents the real URL because:
+         * - the native API Gateway URL has the stage (`/dev`)
+         * - with a custom domain, the URL doesn't have the stage (`/`)
+         * - with CloudFront in front of AG, the URL doesn't have the stage (`/`)
+         * Because it's hard to detect whether CloudFront is used, we will go with the "non-prefixed" URL ($event['path'])
+         * as it's the one most likely used in production (because in production we use custom domains).
+         * Since Bref now recommends HTTP APIs (that don't have a stage prefix), this problem will not be common anyway.
+         * Full history:
+         * - https://github.com/brefphp/bref/issues/67
+         * - https://github.com/brefphp/bref/issues/309
+         * - https://github.com/brefphp/bref/pull/794
          */
-        return $this->event['requestContext']['path'] ?? '/';
+        return $this->event['path'] ?? '/';
     }
 
     public function getUri(): string

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -70,12 +70,12 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
         $this->assertHasMultiHeader(false);
     }
 
-    public function test v1 stage prefix is included in the URL()
+    public function test v1 stage prefix is not included in the URL()
     {
         $this->fromFixture(__DIR__ . '/Fixture/ag-v1-stage-prefix.json');
 
-        $this->assertPath('/dev/path');
-        $this->assertUri('/dev/path');
+        $this->assertPath('/path');
+        $this->assertUri('/path');
     }
 
     /**

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -50,7 +50,6 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
             'httpMethod' => 'GET',
             'path' => '/hello',
             'requestContext' => [
-                'path' => '/hello',
                 'protocol' => 'HTTP/1.1',
             ],
         ];
@@ -69,7 +68,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
-                'LAMBDA_REQUEST_CONTEXT' => '{"path":"\/hello","protocol":"HTTP\/1.1"}',
+                'LAMBDA_REQUEST_CONTEXT' => '{"protocol":"HTTP\/1.1"}',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -84,9 +83,6 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
             'version' => '1.0',
             'httpMethod' => 'GET',
             'path' => '/hello',
-            'requestContext' => [
-                'path' => '/hello',
-            ],
             'queryStringParameters' => [
                 'foo' => 'bar',
                 'bim' => 'baz',
@@ -113,7 +109,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
-                'LAMBDA_REQUEST_CONTEXT' => '{"path":"\/hello"}',
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -128,9 +124,6 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
             'version' => '1.0',
             'httpMethod' => 'GET',
             'path' => '/hello',
-            'requestContext' => [
-                'path' => '/hello',
-            ],
             // See https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/
             'multiValueQueryStringParameters' => [
                 'foo[]' => ['bar', 'baz'],
@@ -174,7 +167,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
-                'LAMBDA_REQUEST_CONTEXT' => '{"path":"\/hello"}',
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
         ]);
@@ -187,7 +180,6 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
             'httpMethod' => 'GET',
             'path' => '/hello',
             'requestContext' => [
-                'path' => '/hello',
                 'foo' => 'baz',
                 'baz' => 'far',
                 'data' => [
@@ -211,7 +203,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
-                'LAMBDA_REQUEST_CONTEXT' => '{"path":"\/hello","foo":"baz","baz":"far","data":{"recurse1":1,"recurse2":2}}',
+                'LAMBDA_REQUEST_CONTEXT' => '{"foo":"baz","baz":"far","data":{"recurse1":1,"recurse2":2}}',
             ],
             'HTTP_RAW_BODY' => '',
         ]);


### PR DESCRIPTION
- `$event['path']` contains the URL **always** without the stage prefix (regardless of the **real** URL)
- `$event['requestContext']['path']` contains the URL **always** with the stage prefix (regardless of the **real** URL)

None of them represents the real URL because:
- the native API Gateway URL has the stage (`/dev`)
- with a custom domain, the URL doesn't have the stage (`/`)
- with CloudFront in front of AG, the URL doesn't have the stage (`/`)

Because it's hard to detect whether CloudFront is used, we will go with the "non-prefixed" URL ($event['path']) as it's the one most likely used in production (because in production we use custom domains).
Since Bref now recommends HTTP APIs (that don't have a stage prefix), this problem will not be common anyway.

Full history:
- https://github.com/brefphp/bref/issues/67
- https://github.com/brefphp/bref/issues/309
- https://github.com/brefphp/bref/pull/794 (attempt at restoring the stage prefix in v1.0)

This PR is merged to fix 1.0.0-beta1. That means that there will be no breaking change when upgrading from 0.5 to 1.0.