### PR TITLE
feature: Deal with nested exception

### DIFF
--- a/docs/news/01-bref-1.0.md
+++ b/docs/news/01-bref-1.0.md
@@ -17,7 +17,9 @@ Needless to say, **Bref is stable** and has been for a long time.
     Indeed, Bref runs more than 1 billion requests and jobs every month!
 </div>
 
-And to celebrate, we're finally releasing **Bref 1.0**!
+"Serverless PHP" is no longer a niche, and running scalable PHP applications has never been simpler.
+
+To celebrate, we're finally releasing **Bref 1.0**!
 
 ## 1 billion executions per month
 


### PR DESCRIPTION
Currently, we display only first level of nested exception. 

If a previous exception exists, it would be nice to dump its trace also to cloudwatch

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
