### PR TITLE
Expose API Gateway path parameters

### DIFF
--- a/docs/function/handlers.md
+++ b/docs/function/handlers.md
@@ -203,6 +203,12 @@ functions:
             - httpApi: 'GET /articles/{id}'
 ```
 
+Note that path parameters (e.g. `{id}` in the example above) are available as request attributes in the PSR-7 request:
+
+```php
+$id = $request->getAttribute('id');
+```
+
 [Full reference of HTTP events in `serverless.yml`](https://www.serverless.com/framework/docs/providers/aws/events/http-api/).
 
 ## Websocket events

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -182,6 +182,14 @@ final class HttpRequestEvent implements LambdaEvent
         return $cookies;
     }
 
+    /**
+     * @return array<string,string>
+     */
+    public function getPathParameters(): array
+    {
+        return $this->event['pathParameters'] ?? [];
+    }
+
     private function rebuildQueryString(): string
     {
         if ($this->payloadVersion === 2.0) {

--- a/src/Event/Http/Psr7Bridge.php
+++ b/src/Event/Http/Psr7Bridge.php
@@ -56,6 +56,10 @@ final class Psr7Bridge
             $server
         );
 
+        foreach ($event->getPathParameters() as $key => $value) {
+            $request = $request->withAttribute($key, $value);
+        }
+
         return $request->withUploadedFiles($files)
             ->withCookieParams($event->getCookies())
             ->withQueryParams($event->getQueryParameters())

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -424,6 +424,18 @@ Year,Make,Model
         $this->assertMethod('OPTIONS');
     }
 
+    /**
+     * @dataProvider provide API Gateway versions
+     */
+    public function test path parameters(int $version)
+    {
+        $this->fromFixture(__DIR__ . "/Fixture/ag-v$version-path-parameters.json");
+        $this->assertPathParameters([
+            'bar' => 'abc',
+            'baz' => 'def',
+        ]);
+    }
+
     abstract protected function fromFixture(string $file): void;
 
     abstract protected function assertBody(string $expected): void;
@@ -468,4 +480,6 @@ Year,Make,Model
         int $size,
         string $content
     ): void;
+
+    abstract protected function assertPathParameters(array $expected): void;
 }

--- a/tests/Event/Http/Fixture/ag-v1-path-parameters.json
+++ b/tests/Event/Http/Fixture/ag-v1-path-parameters.json
@@ -1,0 +1,85 @@
+{
+    "resource": "/foo/{bar}/{baz}",
+    "path": "/foo/abc/def",
+    "httpMethod": "GET",
+    "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Cache-Control": "no-cache",
+        "Host": "example.org",
+        "upgrade-insecure-requests": "1",
+        "User-Agent": "PostmanRuntime/7.20.1",
+        "X-Amzn-Trace-Id": "Root=1-ffffffff-ffffffffffffffffffffffff",
+        "X-Forwarded-For": "1.1.1.1",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "multiValueHeaders": {
+        "Accept": [
+            "*/*"
+        ],
+        "Accept-Encoding": [
+            "gzip, deflate"
+        ],
+        "Host": [
+            "abc.execute-api.us-east-2.amazonaws.com"
+        ],
+        "upgrade-insecure-requests": [
+            "1"
+        ],
+        "User-Agent": [
+            "PostmanRuntime/7.20.1"
+        ],
+        "X-Amzn-Trace-Id": [
+            "Root=1-ffffffff-ffffffffffffffffffffffff"
+        ],
+        "X-Forwarded-For": [
+            "1.1.1.1"
+        ],
+        "X-Forwarded-Port": [
+            "443"
+        ],
+        "X-Forwarded-Proto": [
+            "https"
+        ]
+    },
+    "queryStringParameters": null,
+    "multiValueQueryStringParameters": null,
+    "pathParameters": {
+        "bar": "abc",
+        "baz": "def"
+    },
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "ykuvjw",
+        "resourcePath": "/foo/{bar}/{baz}",
+        "httpMethod": "GET",
+        "extendedRequestId": "Wx6fsEQ4iYcF1Ow=",
+        "requestTime": "29/Nov/2020:17:17:11 +0000",
+        "path": "/dev/foo/abc/def",
+        "accountId": "123400000000",
+        "protocol": "HTTP/1.1",
+        "stage": "dev",
+        "domainPrefix": "dev",
+        "requestTimeEpoch": 1606670231507,
+        "requestId": "dca85d84-6962-4790-95ad-a58f755a59b2",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "1.1.1.1",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "PostmanRuntime/7.20.1",
+            "user": null
+        },
+        "domainName": "example.org",
+        "apiId": "xxxxxxxxxx"
+    },
+    "body": null,
+    "isBase64Encoded": false
+}

--- a/tests/Event/Http/Fixture/ag-v2-path-parameters.json
+++ b/tests/Event/Http/Fixture/ag-v2-path-parameters.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0",
+    "routeKey": "GET /foo/{bar}/{baz}",
+    "rawPath": "/foo/bar/baz",
+    "rawQueryString": "",
+    "headers": {
+        "accept": "*/*",
+        "accept-encoding": "gzip, deflate",
+        "cache-control": "no-cache",
+        "host": "example.org",
+        "upgrade-insecure-requests": "1",
+        "user-agent": "PostmanRuntime/7.20.1",
+        "x-amzn-trace-id": "Root=1-ffffffff-ffffffffffffffffffffffff",
+        "x-forwarded-for": "1.1.1.1",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https"
+    },
+    "requestContext": {
+        "accountId": "123400000000",
+        "apiId": "xxxxxxxxxx",
+        "domainName": "example.org",
+        "domainPrefix": "0000000000",
+        "http": {
+            "method": "GET",
+            "path": "/foo/bar/baz",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "1.1.1.1",
+            "userAgent": "PostmanRuntime/7.20.1"
+        },
+        "requestId": "Wx7DAi1JiYcEPyg=",
+        "routeKey": "GET /foo/{bar}/{baz}",
+        "stage": "$default",
+        "time": "29/Nov/2020:17:20:57 +0000",
+        "timeEpoch": 1606670457514
+    },
+    "pathParameters": {
+        "bar": "abc",
+        "baz": "def"
+    },
+    "isBase64Encoded": false
+}

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -119,4 +119,9 @@ class HttpRequestEventTest extends CommonHttpTest
     ): void {
         // Not applicable here since the class doesn't parse the body
     }
+
+    protected function assertPathParameters(array $expected): void
+    {
+        $this->assertEquals($expected, $this->event->getPathParameters());
+    }
 }

--- a/tests/Event/Http/Psr7BridgeTest.php
+++ b/tests/Event/Http/Psr7BridgeTest.php
@@ -145,4 +145,11 @@ class Psr7BridgeTest extends CommonHttpTest
         $this->assertEquals($size, $uploadedFile->getSize());
         $this->assertEquals($content, $uploadedFile->getStream()->getContents());
     }
+
+    protected function assertPathParameters(array $expected): void
+    {
+        $parameters = $this->request->getAttributes();
+        unset($parameters['lambda-event'], $parameters['lambda-context']);
+        $this->assertEquals($expected, $parameters);
+    }
 }


### PR DESCRIPTION
This makes API Gateway a bit more usable as an application router.

When used with PSR-7 handlers:

```yaml
functions:
    get-article:
        handler: get-article-handler.php
        layers:
            - ${bref:layer.php-74}
        events:
            - httpApi: 'GET /articles/{id}'
```

Path parameters (e.g. `{id}` in the example above) are now available as request attributes in the PSR-7 request:

```php
<?php

require __DIR__ . '/vendor/autoload.php';

use Nyholm\Psr7\Response;
use Psr\Http\Message\ResponseInterface;
use Psr\Http\Message\ServerRequestInterface;
use Psr\Http\Server\RequestHandlerInterface;

class HttpHandler implements RequestHandlerInterface
{
    public function handle(ServerRequestInterface $request): ResponseInterface
    {
        $id = $request->getAttribute('id');

        return new Response(200, [], "Hello $id");
    }
}

return new HttpHandler();
```