### PR TITLE
Local - Parse config tags, prevent from crashing

### DIFF
--- a/src/Console/Command/Local.php
+++ b/src/Console/Command/Local.php
@@ -24,7 +24,6 @@ class Local
         if ($function === null && $handler === null) {
             throw new Exception('Please provide a function name or the --handler= option.');
         }
-        
         if ($function && $data && $handler) {
             throw new Exception('You cannot provide both a funtion name and the --handler= option.');
         }

--- a/src/Console/Command/Local.php
+++ b/src/Console/Command/Local.php
@@ -21,6 +21,10 @@ class Local
 
     public function __invoke(?string $function, ?string $data, ?string $file, ?string $handler, ?string $config, SymfonyStyle $io): int
     {
+        if ($function === null && $handler === null) {
+            throw new Exception('Please provide a function name or the --handler= option.');
+        }
+        
         if ($function && $data && $handler) {
             throw new Exception('You cannot provide both a funtion name and the --handler= option.');
         }
@@ -88,7 +92,7 @@ class Local
             throw new Exception("No `serverless.yml` file was found to resolve function $function.\nIf you do not use serverless.yml, pass the handler via the `--handler` option: vendor/bin/bref local --handler=file.php\nIf your serverless.yml file is stored elsewhere, use the `--config` option: vendor/bin/bref local --config=foo/serverless.yml");
         }
 
-        $serverlessConfig = Yaml::parseFile($file);
+        $serverlessConfig = Yaml::parseFile($file, Yaml::PARSE_CUSTOM_TAGS);
 
         if (! isset($serverlessConfig['functions'][$function])) {
             throw new Exception("There is no function named '$function' in serverless.yml");


### PR DESCRIPTION
- Adds an exception if both function and header are not provided to local invoke.
- Prevents from crashing when config contains tags

Hey guys,
I've just updated to bref 1.0.0 (well done BTW 🎉 ) and tried `vendor/bin/bref local`

First run was obviously wrong, because I didn't pass in a function name, but it ended up with fatal error instead of an exception:
```
vendor/bin/bref local
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Bref\Console\Command\Local::handlerFromServerlessYml()
 must be of the type string, null given, 
called in vendor/bref/bref/src/Console/Command/Local.php on line 36
and defined in vendor/bref/bref/src/Console/Command/Local.php:84
```
Changed to:
<img width="803" alt="Screenshot 2020-11-30 at 13 48 42" src="https://user-images.githubusercontent.com/2435655/100617743-d4599280-3312-11eb-97b2-7916df01df2e.png">

Then, when I got it right, I couldn't run it against my `serverless.yml` config file due to some `CloudFrontDistribution` config containing tags:
```
Origins:
            -   Id: AuthApiGateway
                DomainName: !Join ['.', [!Ref ApiGatewayRestApi, 'execute-api', !Ref AWS::Region, 'amazonaws.com']]
```
adding `Yaml::PARSE_CUSTOM_TAGS` helped. 
