### PR TITLE
Allow separation and lazy loading of vendor folder in s3

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -177,3 +177,14 @@ provider:
 ```
 
 The path must start with `/var/task`, which is the directory where projects are installed on AWS Lambda.
+
+## Separate vendor folder
+
+Bref has the ability to shrink the Lambda deployment archive by separating the vendor folder from the applications code and injecting it later on into the Lambda function. This allows Bref to circumvent Lambda file size limitations.
+
+By setting the option `separateVendor` in the `custom` block to `true`, you can enable this feature.
+
+```yaml
+custom:
+    separateVendor: true
+```

--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -182,9 +182,10 @@ The path must start with `/var/task`, which is the directory where projects are 
 
 Bref has the ability to shrink the Lambda deployment archive by separating the vendor folder from the applications code and injecting it later on into the Lambda function. This allows Bref to circumvent Lambda file size limitations.
 
-By setting the option `separateVendor` in the `custom` block to `true`, you can enable this feature.
+By setting the option `separateVendor` in the `custom.bref` block to `true`, you can enable this feature.
 
 ```yaml
 custom:
-    separateVendor: true
+    bref:
+        separateVendor: true
 ```

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class ServerlessPlugin {
     }
 
     async createVendorZip() {
-        if(! this.serverless.service.custom.separateVendor) {
+        if(! this.serverless.service.custom.bref.separateVendor) {
             return;
         }
 

--- a/index.js
+++ b/index.js
@@ -8,19 +8,24 @@
 
 class ServerlessPlugin {
     constructor(serverless, options) {
-        const fs = require("fs");
-        const path = require('path');
-        const filename = path.resolve(__dirname, 'layers.json');
-        const layers = JSON.parse(fs.readFileSync(filename));
+        this.serverless = serverless;
+        this.options = options;
+        this.provider = this.serverless.getProvider('aws');
+        this.chalk = require(process.mainModule.path + '/../node_modules/chalk');
 
-        this.checkCompatibleRuntime(serverless);
+        this.fs = require('fs');
+        this.path = require('path');
+        const filename = this.path.resolve(__dirname, 'layers.json');
+        const layers = JSON.parse(this.fs.readFileSync(filename));
+
+        this.checkCompatibleRuntime();
 
         // Override the variable resolver to declare our own variables
-        const delegate = serverless.variables
-            .getValueFromSource.bind(serverless.variables);
-        serverless.variables.getValueFromSource = (variableString) => {
+        const delegate = this.serverless.variables
+            .getValueFromSource.bind(this.serverless.variables);
+        this.serverless.variables.getValueFromSource = (variableString) => {
             if (variableString.startsWith('bref:layer.')) {
-                const region = serverless.getProvider('aws').getRegion();
+                const region = this.provider.getRegion();
                 const layerName = variableString.substr('bref:layer.'.length);
                 if (! (layerName in layers)) {
                     throw `Unknown Bref layer named "${layerName}"`;
@@ -34,19 +39,210 @@ class ServerlessPlugin {
 
             return delegate(variableString);
         }
+
+        this.hooks = {
+            'package:setupProviderConfiguration': this.createVendorZip.bind(this),
+            'after:aws:deploy:deploy:createStack': this.uploadVendorZip.bind(this),
+            'before:remove:remove': this.removeVendorArchives.bind(this)
+        };
     }
 
-    checkCompatibleRuntime(serverless) {
-        if (serverless.service.provider.runtime === 'provided') {
+    checkCompatibleRuntime() {
+        if (this.serverless.service.provider.runtime === 'provided') {
             throw new Error('Bref 1.0 layers are not compatible with the "provided" runtime. To upgrade to Bref 1.0, you have to switch to "provided.al2" in serverless.yml. More details here: https://bref.sh/docs/news/01-bref-1.0.html#amazon-linux-2');
         }
-        for (const [name, f] of Object.entries(serverless.service.functions)) {
+        for (const [name, f] of Object.entries(this.serverless.service.functions)) {
             if (f.runtime === 'provided') {
                 throw new Error(`Bref 1.0 layers are not compatible with the "provided" runtime. To upgrade to Bref 1.0, you have to switch to "provided.al2" in serverless.yml for the function "${name}". More details here: https://bref.sh/docs/news/01-bref-1.0.html#amazon-linux-2`);
             }
         }
     }
+
+    async createVendorZip() {
+        if(! this.serverless.service.custom.separateVendor) {
+            return;
+        }
+
+        const vendorZipHash = await this.createZipFile();
+        this.newVendorZipName = vendorZipHash + '.zip';
+
+        let excludes = this.serverless.service.package.exclude;
+        if(excludes.indexOf('vendor/**') === -1) {
+            excludes[excludes.length] = 'vendor/**';
+        }
+
+        //let iamRoleStatements = this.serverless.service.provider.iamRoleStatements;
+        const roleDetails = {
+            'Effect': 'Allow',
+            'Action': [
+                's3:GetObject',
+            ],
+            'Resource': [
+                {
+                    'Fn::Join': [
+                        '',
+                        [
+                            'arn:aws:s3:::',
+                            {
+                                'Ref': 'ServerlessDeploymentBucket'
+                            },
+                            '/',
+                            this.stripSlashes(this.provider.getDeploymentPrefix() + '/vendors/*')
+                        ]
+                    ]
+                }
+            ]
+        };
+
+        let resources = this.serverless.service.provider.coreCloudFormationTemplate.Resources;
+        resources[resources.length] = {
+            'ServerlessDeploymentBucketLambdaAccessPolicy': roleDetails
+        };
+
+        this.consoleLog('Setting environment variables.');
+
+        this.serverless.service.provider.environment.BREF_DOWNLOAD_VENDOR = {
+            'Fn::Join': [
+                '',
+                [
+                    's3://',
+                    {
+                        'Ref': 'ServerlessDeploymentBucket'
+                    },
+                    '/',
+                    this.stripSlashes(this.provider.getDeploymentPrefix() + '/vendors/' + this.newVendorZipName)
+                ]
+            ]
+        };
+    }
+
+    async createZipFile() {
+        this.filePath = '.serverless/vendor.zip';
+
+        return await new Promise((resolve, reject) => {
+            const archiver = require(process.mainModule.path + '/../node_modules/archiver');
+            const output = this.fs.createWriteStream(this.filePath);
+            const archive = archiver('zip', {
+                zlib: { level: 9 } // Sets the compression level.
+            });
+
+            this.consoleLog(`Packaging the Composer vendor directory in ${this.filePath}.`);
+
+            archive.pipe(output);
+            archive.directory('vendor/', false);
+            archive.finalize();
+
+            output.on('close', () => {
+                this.consoleLog(`Created vendor.zip with ${archive.pointer()} total bytes.`);
+                resolve();
+            });
+
+            archive.on('warning', err => {
+                if (err.code === 'ENOENT') {
+                    // log warning
+                    console.warn('Archiver warning', err);
+                } else {
+                    // throw error
+                    console.error('Archiver warning', err);
+                    reject(err);
+                }
+            });
+
+            archive.on('error', err => {
+                console.error('Archiver error', err);
+                reject(err);
+            });
+        })
+            .then(() => {
+                const crypto = require('crypto');
+
+                return new Promise(resolve => {
+                    const hash = crypto.createHash('md5');
+                    this.fs.createReadStream(this.filePath).on('data', data => hash.update(data)).on('end', () => resolve(hash.digest('hex')));
+                });
+            })
+            .catch(err => {
+                throw new Error(`Failed to create zip file vendor.zip: ${err.message}`);
+            });
+    }
+
+    async uploadVendorZip() {
+        await this.uploadZipToS3(this.filePath);
+
+        this.consoleLog('Vendor separation done!');
+    }
+
+    async uploadZipToS3(zipFile) {
+        const bucketName = await this.provider.getServerlessDeploymentBucketName();
+        const deploymentPrefix = await this.provider.getDeploymentPrefix();
+
+        this.consoleLog('Checking vendor file on bucket...');
+
+        try {
+            await this.provider.request('S3', 'headObject', {
+                Bucket: bucketName,
+                Key: this.stripSlashes(deploymentPrefix + '/vendors/' + this.newVendorZipName)
+            });
+
+            this.consoleLog('Vendor file already exists on bucket. Not uploading again.');
+            return;
+        } catch(e) {
+            this.consoleLog('Vendor file not found. Uploading...');
+        }
+
+        const readStream = this.fs.createReadStream(zipFile);
+        const details = {
+            ACL: 'private',
+            Body: readStream,
+            Bucket: bucketName,
+            ContentType: 'application/zip',
+            Key: this.stripSlashes(deploymentPrefix + '/vendors/' + this.newVendorZipName),
+        };
+
+        return await this.provider.request('S3', 'putObject', details);
+    }
+
+    stripSlashes(path) {
+        return path.replace(/^\/+/g, '');
+    }
+
+    async removeVendorArchives() {
+        this.consoleLog('Removing vendor archives from S3 bucket.');
+
+        const bucketName = await this.provider.getServerlessDeploymentBucketName();
+        const deploymentPrefix = await this.provider.getDeploymentPrefix();
+
+        const bucketObjects = await this.provider.request('S3', 'listObjectsV2', {
+            Bucket: bucketName,
+            Prefix: this.stripSlashes(deploymentPrefix + '/vendors/')
+        })
+
+        if(bucketObjects.length === 0) {
+            this.consoleLog('No vendor archives found.');
+            return;
+        }
+
+        let details = {
+            Bucket: bucketName,
+            Delete: {
+                Objects: []
+            }
+        };
+
+        bucketObjects.Contents.forEach(content => {
+            details.Delete.Objects.push({
+                Key: content.Key
+            });
+        });
+
+        this.consoleLog(`Found ${details.Delete.Objects.length} vendor archives. Removing them from Bucket now.`);
+
+        return await this.provider.request('S3', 'deleteObjects', details);
+    }
+
+    consoleLog(message) {
+        console.log(`Bref: ${this.chalk.yellow(message)}`);
+    }
 }
 
 module.exports = ServerlessPlugin;
-

--- a/index.js
+++ b/index.js
@@ -76,12 +76,14 @@ class ServerlessPlugin {
 
         // This defines the access rights for Lambda, so it can download the
         // vendor archive file from the vendors subfolder.
-        const roleDetails = {
-            'Effect': 'Allow',
-            'Action': [
+        this.serverless.service.provider.iamRoleStatements = this.serverless.service.provider.iamRoleStatements ? this.serverless.service.provider.iamRoleStatements : [];
+
+        this.serverless.service.provider.iamRoleStatements.push({
+            Effect: 'Allow',
+            Action: [
                 's3:GetObject',
             ],
-            'Resource': [
+            Resource: [
                 {
                     'Fn::Join': [
                         '',
@@ -96,12 +98,7 @@ class ServerlessPlugin {
                     ]
                 }
             ]
-        };
-
-        let resources = this.serverless.service.provider.coreCloudFormationTemplate.Resources;
-        resources[resources.length] = {
-            'ServerlessDeploymentBucketLambdaAccessPolicy': roleDetails
-        };
+        });
 
         this.consoleLog('Setting environment variables.');
 

--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -9,7 +9,15 @@ error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
-if (getenv('BREF_AUTOLOAD_PATH')) {
+if (getenv('BREF_DOWNLOAD_VENDOR')) {
+    if(! file_exists('/tmp/vendor') || ! file_exists('/tmp/vendor/autoload.php')) {
+        require_once __DIR__ . '/breftoolbox.php';
+
+        \Bref\ToolBox\BrefToolBox::downloadAndConfigureVendor();
+    }
+
+    require '/tmp/vendor/autoload.php';
+} elseif (getenv('BREF_AUTOLOAD_PATH')) {
     /** @noinspection PhpIncludeInspection */
     require getenv('BREF_AUTOLOAD_PATH');
 } else {

--- a/runtime/layers/console/breftoolbox.php
+++ b/runtime/layers/console/breftoolbox.php
@@ -32,7 +32,11 @@ use const CURLOPT_FILE;
 use const CURLOPT_FOLLOWLOCATION;
 use const CURLOPT_HEADER;
 
-class BrefToolBox {
+/**
+ * @internal
+ */
+class BrefToolBox
+{
     /**
      * Path to autoload_static.php file from composer
      */
@@ -61,7 +65,7 @@ class BrefToolBox {
             self::EXTRACTION_PATH
         );
 
-        if(! $unzipped) {
+        if (!$unzipped) {
             throw new Exception('Unable to unzip vendor archive.');
         }
 
@@ -72,10 +76,6 @@ class BrefToolBox {
 
     /**
      * Download vendor archive from s3 bucket
-     *
-     * @param string $s3String
-     * @param string $downloadPath
-     * @return void
      */
     private static function downloadVendorArchive(string $s3String, string $downloadPath): void
     {
@@ -93,7 +93,7 @@ class BrefToolBox {
             $filePath
         );
 
-        if(file_exists($downloadPath)) {
+        if (file_exists($downloadPath)) {
             unlink($downloadPath);
         }
 
@@ -115,38 +115,28 @@ class BrefToolBox {
     /**
      * Create S3 signed url to download vendor archive from
      * From https://gist.github.com/anthonyeden/4448695ad531016ec12bcdacc9d91cb8
-     *
-     * @param $AWSAccessKeyId
-     * @param $AWSSecretAccessKey
-     * @param $AWSSessionToken
-     * @param $BucketName
-     * @param $AWSRegion
-     * @param $canonical_uri
-     * @param int $expires
-     * @return string
      */
     private static function AWS_S3_PresignDownload(
-        $AWSAccessKeyId,
-        $AWSSecretAccessKey,
-        $AWSSessionToken,
-        $BucketName,
-        $AWSRegion,
-        $canonical_uri,
-        $expires = 86400
-    ): string
-    {
+        string $AWSAccessKeyId,
+        string $AWSSecretAccessKey,
+        string $AWSSessionToken,
+        string $BucketName,
+        string $AWSRegion,
+        string $canonical_uri,
+        int $expires = 86400
+    ): string {
         // Creates a signed download link for an AWS S3 file
         // Based on https://gist.github.com/kelvinmo/d78be66c4f36415a6b80
 
         $encoded_uri = str_replace('%2F', '/', rawurlencode($canonical_uri));
 
         // Specify the hostname for the S3 endpoint
-        if($AWSRegion == 'us-east-1') {
-            $hostname = trim($BucketName .".s3.amazonaws.com");
+        if ($AWSRegion == 'us-east-1') {
+            $hostname = trim($BucketName . ".s3.amazonaws.com");
             $header_string = "host:" . $hostname . "\n";
             $signed_headers_string = "host";
         } else {
-            $hostname =  trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
+            $hostname = trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
             $header_string = "host:" . $hostname . "\n";
             $signed_headers_string = "host";
         }
@@ -178,7 +168,8 @@ class BrefToolBox {
         $query_string = substr($query_string, 0, -1);
 
         $canonical_request = "GET\n" . $encoded_uri . "\n" . $query_string . "\n" . $header_string . "\n" . $signed_headers_string . "\nUNSIGNED-PAYLOAD";
-        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request, false);
+        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request,
+                false);
         $signing_key = hash_hmac('sha256', 'aws4_request',
             hash_hmac('sha256', 's3',
                 hash_hmac('sha256', $AWSRegion,
@@ -194,17 +185,13 @@ class BrefToolBox {
 
     /**
      * Unzip vendor archive into temporary path
-     *
-     * @param string $filePath
-     * @param string $unzipPath
-     * @return bool
      */
     private static function unzipVendorArchive(string $filePath, string $unzipPath): bool
     {
         $zip = new ZipArchive();
         $resource = $zip->open($filePath);
 
-        if(! file_exists($unzipPath)) {
+        if (!file_exists($unzipPath)) {
             mkdir($unzipPath, 0755, true);
         }
 
@@ -220,8 +207,6 @@ class BrefToolBox {
 
     /**
      * Update composer autoload_static.php file with correct path for Lambda task root
-     *
-     * @return void
      */
     private static function updateComposerAutoloading(): void
     {

--- a/runtime/layers/console/breftoolbox.php
+++ b/runtime/layers/console/breftoolbox.php
@@ -1,0 +1,236 @@
+<?php declare(strict_types=1);
+
+namespace Bref\ToolBox;
+
+use Exception;
+use ZipArchive;
+use function curl_close;
+use function curl_exec;
+use function curl_init;
+use function curl_setopt_array;
+use function fclose;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function fopen;
+use function getenv;
+use function gmdate;
+use function hash;
+use function hash_hmac;
+use function ksort;
+use function mkdir;
+use function preg_match;
+use function rawurlencode;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function substr;
+use function time;
+use function trim;
+use function unlink;
+use const CURLOPT_FILE;
+use const CURLOPT_FOLLOWLOCATION;
+use const CURLOPT_HEADER;
+
+class BrefToolBox {
+    /**
+     * Path to autoload_static.php file from composer
+     */
+    const AUTOLOAD_STATIC_PATH = '/tmp/vendor/composer/autoload_static.php';
+    /**
+     * Path where the vendor archive will be stored
+     */
+    const DOWNLOAD_FILE_PATH = '/tmp/vendor.zip';
+    /**
+     * Path where the extracted vendor archives contents will be stored
+     */
+    const EXTRACTION_PATH = '/tmp/vendor/';
+
+    /**
+     * @throws Exception
+     */
+    public static function downloadAndConfigureVendor()
+    {
+        self::downloadVendorArchive(
+            getenv('BREF_DOWNLOAD_VENDOR'),
+            self::DOWNLOAD_FILE_PATH
+        );
+
+        $unzipped = self::unzipVendorArchive(
+            self::DOWNLOAD_FILE_PATH,
+            self::EXTRACTION_PATH
+        );
+
+        if(! $unzipped) {
+            throw new Exception('Unable to unzip vendor archive.');
+        }
+
+        unlink(self::DOWNLOAD_FILE_PATH);
+
+        self::updateComposerAutoloading();
+    }
+
+    /**
+     * Download vendor archive from s3 bucket
+     *
+     * @param string $s3String
+     * @param string $downloadPath
+     * @return void
+     */
+    private static function downloadVendorArchive(string $s3String, string $downloadPath): void
+    {
+        preg_match('~s3\:\/\/([^\/]+)\/(.*)~', $s3String, $matches);
+        $bucket = $matches[1];
+        $filePath = '/' . $matches[2];
+        $region = getenv('AWS_REGION');
+
+        $url = self::AWS_S3_PresignDownload(
+            getenv('AWS_ACCESS_KEY_ID'),
+            getenv('AWS_SECRET_ACCESS_KEY'),
+            getenv('AWS_SESSION_TOKEN'),
+            $bucket,
+            $region,
+            $filePath
+        );
+
+        if(file_exists($downloadPath)) {
+            unlink($downloadPath);
+        }
+
+        $fp = fopen($downloadPath, 'w');
+
+        $options = [
+            CURLOPT_HEADER => 0,
+            CURLOPT_FOLLOWLOCATION => 1,
+            CURLOPT_FILE => $fp,
+        ];
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, $options);
+        curl_exec($ch);
+        curl_close($ch);
+        fclose($fp);
+    }
+
+    /**
+     * Create S3 signed url to download vendor archive from
+     * From https://gist.github.com/anthonyeden/4448695ad531016ec12bcdacc9d91cb8
+     *
+     * @param $AWSAccessKeyId
+     * @param $AWSSecretAccessKey
+     * @param $AWSSessionToken
+     * @param $BucketName
+     * @param $AWSRegion
+     * @param $canonical_uri
+     * @param int $expires
+     * @return string
+     */
+    private static function AWS_S3_PresignDownload(
+        $AWSAccessKeyId,
+        $AWSSecretAccessKey,
+        $AWSSessionToken,
+        $BucketName,
+        $AWSRegion,
+        $canonical_uri,
+        $expires = 86400
+    ): string
+    {
+        // Creates a signed download link for an AWS S3 file
+        // Based on https://gist.github.com/kelvinmo/d78be66c4f36415a6b80
+
+        $encoded_uri = str_replace('%2F', '/', rawurlencode($canonical_uri));
+
+        // Specify the hostname for the S3 endpoint
+        if($AWSRegion == 'us-east-1') {
+            $hostname = trim($BucketName .".s3.amazonaws.com");
+            $header_string = "host:" . $hostname . "\n";
+            $signed_headers_string = "host";
+        } else {
+            $hostname =  trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
+            $header_string = "host:" . $hostname . "\n";
+            $signed_headers_string = "host";
+        }
+
+        $date_text = gmdate('Ymd', time());
+        $time_text = $date_text . 'T000000Z';
+        $algorithm = 'AWS4-HMAC-SHA256';
+        $scope = $date_text . "/" . $AWSRegion . "/s3/aws4_request";
+
+        $x_amz_params = array(
+            'X-Amz-Algorithm' => $algorithm,
+            'X-Amz-Credential' => $AWSAccessKeyId . '/' . $scope,
+            'X-Amz-Date' => $time_text,
+            'X-Amz-SignedHeaders' => $signed_headers_string,
+            'X-Amz-Security-Token' => $AWSSessionToken,
+        );
+
+        if ($expires > 0) {
+            // 'Expires' is the number of seconds until the request becomes invalid
+            $x_amz_params['X-Amz-Expires'] = (string)$expires;
+        }
+
+        ksort($x_amz_params);
+
+        $query_string = "";
+        foreach ($x_amz_params as $key => $value) {
+            $query_string .= rawurlencode($key) . '=' . rawurlencode($value) . "&";
+        }
+        $query_string = substr($query_string, 0, -1);
+
+        $canonical_request = "GET\n" . $encoded_uri . "\n" . $query_string . "\n" . $header_string . "\n" . $signed_headers_string . "\nUNSIGNED-PAYLOAD";
+        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request, false);
+        $signing_key = hash_hmac('sha256', 'aws4_request',
+            hash_hmac('sha256', 's3',
+                hash_hmac('sha256', $AWSRegion,
+                    hash_hmac('sha256', $date_text, 'AWS4' . $AWSSecretAccessKey, true),
+                    true),
+                true),
+            true
+        );
+        $signature = hash_hmac('sha256', $string_to_sign, $signing_key);
+
+        return 'https://' . $hostname . $encoded_uri . '?' . $query_string . '&X-Amz-Signature=' . $signature;
+    }
+
+    /**
+     * Unzip vendor archive into temporary path
+     *
+     * @param string $filePath
+     * @param string $unzipPath
+     * @return bool
+     */
+    private static function unzipVendorArchive(string $filePath, string $unzipPath): bool
+    {
+        $zip = new ZipArchive();
+        $resource = $zip->open($filePath);
+
+        if(! file_exists($unzipPath)) {
+            mkdir($unzipPath, 0755, true);
+        }
+
+        if ($resource !== true) {
+            return false;
+        }
+
+        $zip->extractTo($unzipPath);
+        $zip->close();
+
+        return true;
+    }
+
+    /**
+     * Update composer autoload_static.php file with correct path for Lambda task root
+     *
+     * @return void
+     */
+    private static function updateComposerAutoloading(): void
+    {
+        $updatedStaticLoader = str_replace(
+            "__DIR__ . '/../..'",
+            sprintf("'%s'", rtrim(getenv('LAMBDA_TASK_ROOT'), '/')),
+            file_get_contents(self::AUTOLOAD_STATIC_PATH)
+        );
+
+        file_put_contents(self::AUTOLOAD_STATIC_PATH, $updatedStaticLoader);
+    }
+}

--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -3,6 +3,7 @@ FROM bref/tmp/cleaned-build-php-$PHP_VERSION
 ARG PHP_VERSION
 
 COPY bootstrap /opt/bootstrap
+COPY breftoolbox.php /opt/breftoolbox.php
 COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
 

--- a/runtime/layers/fpm/bootstrap
+++ b/runtime/layers/fpm/bootstrap
@@ -9,7 +9,15 @@ error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
-if (getenv('BREF_AUTOLOAD_PATH')) {
+if (getenv('BREF_DOWNLOAD_VENDOR')) {
+    if(! file_exists('/tmp/vendor') || ! file_exists('/tmp/vendor/autoload.php')) {
+        require_once __DIR__ . '/breftoolbox.php';
+
+        \Bref\ToolBox\BrefToolBox::downloadAndConfigureVendor();
+    }
+
+    require '/tmp/vendor/autoload.php';
+} elseif (getenv('BREF_AUTOLOAD_PATH')) {
     /** @noinspection PhpIncludeInspection */
     require getenv('BREF_AUTOLOAD_PATH');
 } else {

--- a/runtime/layers/fpm/breftoolbox.php
+++ b/runtime/layers/fpm/breftoolbox.php
@@ -32,7 +32,11 @@ use const CURLOPT_FILE;
 use const CURLOPT_FOLLOWLOCATION;
 use const CURLOPT_HEADER;
 
-class BrefToolBox {
+/**
+ * @internal
+ */
+class BrefToolBox
+{
     /**
      * Path to autoload_static.php file from composer
      */
@@ -61,7 +65,7 @@ class BrefToolBox {
             self::EXTRACTION_PATH
         );
 
-        if(! $unzipped) {
+        if (!$unzipped) {
             throw new Exception('Unable to unzip vendor archive.');
         }
 
@@ -72,10 +76,6 @@ class BrefToolBox {
 
     /**
      * Download vendor archive from s3 bucket
-     *
-     * @param string $s3String
-     * @param string $downloadPath
-     * @return void
      */
     private static function downloadVendorArchive(string $s3String, string $downloadPath): void
     {
@@ -93,7 +93,7 @@ class BrefToolBox {
             $filePath
         );
 
-        if(file_exists($downloadPath)) {
+        if (file_exists($downloadPath)) {
             unlink($downloadPath);
         }
 
@@ -115,38 +115,28 @@ class BrefToolBox {
     /**
      * Create S3 signed url to download vendor archive from
      * From https://gist.github.com/anthonyeden/4448695ad531016ec12bcdacc9d91cb8
-     *
-     * @param $AWSAccessKeyId
-     * @param $AWSSecretAccessKey
-     * @param $AWSSessionToken
-     * @param $BucketName
-     * @param $AWSRegion
-     * @param $canonical_uri
-     * @param int $expires
-     * @return string
      */
     private static function AWS_S3_PresignDownload(
-        $AWSAccessKeyId,
-        $AWSSecretAccessKey,
-        $AWSSessionToken,
-        $BucketName,
-        $AWSRegion,
-        $canonical_uri,
-        $expires = 86400
-    ): string
-    {
+        string $AWSAccessKeyId,
+        string $AWSSecretAccessKey,
+        string $AWSSessionToken,
+        string $BucketName,
+        string $AWSRegion,
+        string $canonical_uri,
+        int $expires = 86400
+    ): string {
         // Creates a signed download link for an AWS S3 file
         // Based on https://gist.github.com/kelvinmo/d78be66c4f36415a6b80
 
         $encoded_uri = str_replace('%2F', '/', rawurlencode($canonical_uri));
 
         // Specify the hostname for the S3 endpoint
-        if($AWSRegion == 'us-east-1') {
-            $hostname = trim($BucketName .".s3.amazonaws.com");
+        if ($AWSRegion == 'us-east-1') {
+            $hostname = trim($BucketName . ".s3.amazonaws.com");
             $header_string = "host:" . $hostname . "\n";
             $signed_headers_string = "host";
         } else {
-            $hostname =  trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
+            $hostname = trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
             $header_string = "host:" . $hostname . "\n";
             $signed_headers_string = "host";
         }
@@ -178,7 +168,8 @@ class BrefToolBox {
         $query_string = substr($query_string, 0, -1);
 
         $canonical_request = "GET\n" . $encoded_uri . "\n" . $query_string . "\n" . $header_string . "\n" . $signed_headers_string . "\nUNSIGNED-PAYLOAD";
-        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request, false);
+        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request,
+                false);
         $signing_key = hash_hmac('sha256', 'aws4_request',
             hash_hmac('sha256', 's3',
                 hash_hmac('sha256', $AWSRegion,
@@ -194,17 +185,13 @@ class BrefToolBox {
 
     /**
      * Unzip vendor archive into temporary path
-     *
-     * @param string $filePath
-     * @param string $unzipPath
-     * @return bool
      */
     private static function unzipVendorArchive(string $filePath, string $unzipPath): bool
     {
         $zip = new ZipArchive();
         $resource = $zip->open($filePath);
 
-        if(! file_exists($unzipPath)) {
+        if (!file_exists($unzipPath)) {
             mkdir($unzipPath, 0755, true);
         }
 
@@ -220,8 +207,6 @@ class BrefToolBox {
 
     /**
      * Update composer autoload_static.php file with correct path for Lambda task root
-     *
-     * @return void
      */
     private static function updateComposerAutoloading(): void
     {

--- a/runtime/layers/fpm/breftoolbox.php
+++ b/runtime/layers/fpm/breftoolbox.php
@@ -1,0 +1,236 @@
+<?php declare(strict_types=1);
+
+namespace Bref\ToolBox;
+
+use Exception;
+use ZipArchive;
+use function curl_close;
+use function curl_exec;
+use function curl_init;
+use function curl_setopt_array;
+use function fclose;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function fopen;
+use function getenv;
+use function gmdate;
+use function hash;
+use function hash_hmac;
+use function ksort;
+use function mkdir;
+use function preg_match;
+use function rawurlencode;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function substr;
+use function time;
+use function trim;
+use function unlink;
+use const CURLOPT_FILE;
+use const CURLOPT_FOLLOWLOCATION;
+use const CURLOPT_HEADER;
+
+class BrefToolBox {
+    /**
+     * Path to autoload_static.php file from composer
+     */
+    const AUTOLOAD_STATIC_PATH = '/tmp/vendor/composer/autoload_static.php';
+    /**
+     * Path where the vendor archive will be stored
+     */
+    const DOWNLOAD_FILE_PATH = '/tmp/vendor.zip';
+    /**
+     * Path where the extracted vendor archives contents will be stored
+     */
+    const EXTRACTION_PATH = '/tmp/vendor/';
+
+    /**
+     * @throws Exception
+     */
+    public static function downloadAndConfigureVendor()
+    {
+        self::downloadVendorArchive(
+            getenv('BREF_DOWNLOAD_VENDOR'),
+            self::DOWNLOAD_FILE_PATH
+        );
+
+        $unzipped = self::unzipVendorArchive(
+            self::DOWNLOAD_FILE_PATH,
+            self::EXTRACTION_PATH
+        );
+
+        if(! $unzipped) {
+            throw new Exception('Unable to unzip vendor archive.');
+        }
+
+        unlink(self::DOWNLOAD_FILE_PATH);
+
+        self::updateComposerAutoloading();
+    }
+
+    /**
+     * Download vendor archive from s3 bucket
+     *
+     * @param string $s3String
+     * @param string $downloadPath
+     * @return void
+     */
+    private static function downloadVendorArchive(string $s3String, string $downloadPath): void
+    {
+        preg_match('~s3\:\/\/([^\/]+)\/(.*)~', $s3String, $matches);
+        $bucket = $matches[1];
+        $filePath = '/' . $matches[2];
+        $region = getenv('AWS_REGION');
+
+        $url = self::AWS_S3_PresignDownload(
+            getenv('AWS_ACCESS_KEY_ID'),
+            getenv('AWS_SECRET_ACCESS_KEY'),
+            getenv('AWS_SESSION_TOKEN'),
+            $bucket,
+            $region,
+            $filePath
+        );
+
+        if(file_exists($downloadPath)) {
+            unlink($downloadPath);
+        }
+
+        $fp = fopen($downloadPath, 'w');
+
+        $options = [
+            CURLOPT_HEADER => 0,
+            CURLOPT_FOLLOWLOCATION => 1,
+            CURLOPT_FILE => $fp,
+        ];
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, $options);
+        curl_exec($ch);
+        curl_close($ch);
+        fclose($fp);
+    }
+
+    /**
+     * Create S3 signed url to download vendor archive from
+     * From https://gist.github.com/anthonyeden/4448695ad531016ec12bcdacc9d91cb8
+     *
+     * @param $AWSAccessKeyId
+     * @param $AWSSecretAccessKey
+     * @param $AWSSessionToken
+     * @param $BucketName
+     * @param $AWSRegion
+     * @param $canonical_uri
+     * @param int $expires
+     * @return string
+     */
+    private static function AWS_S3_PresignDownload(
+        $AWSAccessKeyId,
+        $AWSSecretAccessKey,
+        $AWSSessionToken,
+        $BucketName,
+        $AWSRegion,
+        $canonical_uri,
+        $expires = 86400
+    ): string
+    {
+        // Creates a signed download link for an AWS S3 file
+        // Based on https://gist.github.com/kelvinmo/d78be66c4f36415a6b80
+
+        $encoded_uri = str_replace('%2F', '/', rawurlencode($canonical_uri));
+
+        // Specify the hostname for the S3 endpoint
+        if($AWSRegion == 'us-east-1') {
+            $hostname = trim($BucketName .".s3.amazonaws.com");
+            $header_string = "host:" . $hostname . "\n";
+            $signed_headers_string = "host";
+        } else {
+            $hostname =  trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
+            $header_string = "host:" . $hostname . "\n";
+            $signed_headers_string = "host";
+        }
+
+        $date_text = gmdate('Ymd', time());
+        $time_text = $date_text . 'T000000Z';
+        $algorithm = 'AWS4-HMAC-SHA256';
+        $scope = $date_text . "/" . $AWSRegion . "/s3/aws4_request";
+
+        $x_amz_params = array(
+            'X-Amz-Algorithm' => $algorithm,
+            'X-Amz-Credential' => $AWSAccessKeyId . '/' . $scope,
+            'X-Amz-Date' => $time_text,
+            'X-Amz-SignedHeaders' => $signed_headers_string,
+            'X-Amz-Security-Token' => $AWSSessionToken,
+        );
+
+        if ($expires > 0) {
+            // 'Expires' is the number of seconds until the request becomes invalid
+            $x_amz_params['X-Amz-Expires'] = (string)$expires;
+        }
+
+        ksort($x_amz_params);
+
+        $query_string = "";
+        foreach ($x_amz_params as $key => $value) {
+            $query_string .= rawurlencode($key) . '=' . rawurlencode($value) . "&";
+        }
+        $query_string = substr($query_string, 0, -1);
+
+        $canonical_request = "GET\n" . $encoded_uri . "\n" . $query_string . "\n" . $header_string . "\n" . $signed_headers_string . "\nUNSIGNED-PAYLOAD";
+        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request, false);
+        $signing_key = hash_hmac('sha256', 'aws4_request',
+            hash_hmac('sha256', 's3',
+                hash_hmac('sha256', $AWSRegion,
+                    hash_hmac('sha256', $date_text, 'AWS4' . $AWSSecretAccessKey, true),
+                    true),
+                true),
+            true
+        );
+        $signature = hash_hmac('sha256', $string_to_sign, $signing_key);
+
+        return 'https://' . $hostname . $encoded_uri . '?' . $query_string . '&X-Amz-Signature=' . $signature;
+    }
+
+    /**
+     * Unzip vendor archive into temporary path
+     *
+     * @param string $filePath
+     * @param string $unzipPath
+     * @return bool
+     */
+    private static function unzipVendorArchive(string $filePath, string $unzipPath): bool
+    {
+        $zip = new ZipArchive();
+        $resource = $zip->open($filePath);
+
+        if(! file_exists($unzipPath)) {
+            mkdir($unzipPath, 0755, true);
+        }
+
+        if ($resource !== true) {
+            return false;
+        }
+
+        $zip->extractTo($unzipPath);
+        $zip->close();
+
+        return true;
+    }
+
+    /**
+     * Update composer autoload_static.php file with correct path for Lambda task root
+     *
+     * @return void
+     */
+    private static function updateComposerAutoloading(): void
+    {
+        $updatedStaticLoader = str_replace(
+            "__DIR__ . '/../..'",
+            sprintf("'%s'", rtrim(getenv('LAMBDA_TASK_ROOT'), '/')),
+            file_get_contents(self::AUTOLOAD_STATIC_PATH)
+        );
+
+        file_put_contents(self::AUTOLOAD_STATIC_PATH, $updatedStaticLoader);
+    }
+}

--- a/runtime/layers/function/Dockerfile
+++ b/runtime/layers/function/Dockerfile
@@ -3,6 +3,7 @@ FROM bref/tmp/cleaned-build-php-$PHP_VERSION
 
 COPY bootstrap /opt/bootstrap
 COPY bootstrap.php /opt/bref/bootstrap.php
+COPY breftoolbox.php /opt/bref/breftoolbox.php
 COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 
 # Remove PHP-FPM

--- a/runtime/layers/function/bootstrap.php
+++ b/runtime/layers/function/bootstrap.php
@@ -8,7 +8,15 @@ error_reporting(E_ALL);
 
 $appRoot = getenv('LAMBDA_TASK_ROOT');
 
-if (getenv('BREF_AUTOLOAD_PATH')) {
+if (getenv('BREF_DOWNLOAD_VENDOR')) {
+    if(! file_exists('/tmp/vendor') || ! file_exists('/tmp/vendor/autoload.php')) {
+        require_once '/opt/bref/breftoolbox.php';
+
+        \Bref\ToolBox\BrefToolBox::downloadAndConfigureVendor();
+    }
+
+    require '/tmp/vendor/autoload.php';
+} elseif (getenv('BREF_AUTOLOAD_PATH')) {
     /** @noinspection PhpIncludeInspection */
     require getenv('BREF_AUTOLOAD_PATH');
 } else {

--- a/runtime/layers/function/breftoolbox.php
+++ b/runtime/layers/function/breftoolbox.php
@@ -32,7 +32,11 @@ use const CURLOPT_FILE;
 use const CURLOPT_FOLLOWLOCATION;
 use const CURLOPT_HEADER;
 
-class BrefToolBox {
+/**
+ * @internal
+ */
+class BrefToolBox
+{
     /**
      * Path to autoload_static.php file from composer
      */
@@ -61,7 +65,7 @@ class BrefToolBox {
             self::EXTRACTION_PATH
         );
 
-        if(! $unzipped) {
+        if (!$unzipped) {
             throw new Exception('Unable to unzip vendor archive.');
         }
 
@@ -72,10 +76,6 @@ class BrefToolBox {
 
     /**
      * Download vendor archive from s3 bucket
-     *
-     * @param string $s3String
-     * @param string $downloadPath
-     * @return void
      */
     private static function downloadVendorArchive(string $s3String, string $downloadPath): void
     {
@@ -93,7 +93,7 @@ class BrefToolBox {
             $filePath
         );
 
-        if(file_exists($downloadPath)) {
+        if (file_exists($downloadPath)) {
             unlink($downloadPath);
         }
 
@@ -115,38 +115,28 @@ class BrefToolBox {
     /**
      * Create S3 signed url to download vendor archive from
      * From https://gist.github.com/anthonyeden/4448695ad531016ec12bcdacc9d91cb8
-     *
-     * @param $AWSAccessKeyId
-     * @param $AWSSecretAccessKey
-     * @param $AWSSessionToken
-     * @param $BucketName
-     * @param $AWSRegion
-     * @param $canonical_uri
-     * @param int $expires
-     * @return string
      */
     private static function AWS_S3_PresignDownload(
-        $AWSAccessKeyId,
-        $AWSSecretAccessKey,
-        $AWSSessionToken,
-        $BucketName,
-        $AWSRegion,
-        $canonical_uri,
-        $expires = 86400
-    ): string
-    {
+        string $AWSAccessKeyId,
+        string $AWSSecretAccessKey,
+        string $AWSSessionToken,
+        string $BucketName,
+        string $AWSRegion,
+        string $canonical_uri,
+        int $expires = 86400
+    ): string {
         // Creates a signed download link for an AWS S3 file
         // Based on https://gist.github.com/kelvinmo/d78be66c4f36415a6b80
 
         $encoded_uri = str_replace('%2F', '/', rawurlencode($canonical_uri));
 
         // Specify the hostname for the S3 endpoint
-        if($AWSRegion == 'us-east-1') {
-            $hostname = trim($BucketName .".s3.amazonaws.com");
+        if ($AWSRegion == 'us-east-1') {
+            $hostname = trim($BucketName . ".s3.amazonaws.com");
             $header_string = "host:" . $hostname . "\n";
             $signed_headers_string = "host";
         } else {
-            $hostname =  trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
+            $hostname = trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
             $header_string = "host:" . $hostname . "\n";
             $signed_headers_string = "host";
         }
@@ -178,7 +168,8 @@ class BrefToolBox {
         $query_string = substr($query_string, 0, -1);
 
         $canonical_request = "GET\n" . $encoded_uri . "\n" . $query_string . "\n" . $header_string . "\n" . $signed_headers_string . "\nUNSIGNED-PAYLOAD";
-        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request, false);
+        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request,
+                false);
         $signing_key = hash_hmac('sha256', 'aws4_request',
             hash_hmac('sha256', 's3',
                 hash_hmac('sha256', $AWSRegion,
@@ -194,17 +185,13 @@ class BrefToolBox {
 
     /**
      * Unzip vendor archive into temporary path
-     *
-     * @param string $filePath
-     * @param string $unzipPath
-     * @return bool
      */
     private static function unzipVendorArchive(string $filePath, string $unzipPath): bool
     {
         $zip = new ZipArchive();
         $resource = $zip->open($filePath);
 
-        if(! file_exists($unzipPath)) {
+        if (!file_exists($unzipPath)) {
             mkdir($unzipPath, 0755, true);
         }
 
@@ -220,8 +207,6 @@ class BrefToolBox {
 
     /**
      * Update composer autoload_static.php file with correct path for Lambda task root
-     *
-     * @return void
      */
     private static function updateComposerAutoloading(): void
     {

--- a/runtime/layers/function/breftoolbox.php
+++ b/runtime/layers/function/breftoolbox.php
@@ -1,0 +1,236 @@
+<?php declare(strict_types=1);
+
+namespace Bref\ToolBox;
+
+use Exception;
+use ZipArchive;
+use function curl_close;
+use function curl_exec;
+use function curl_init;
+use function curl_setopt_array;
+use function fclose;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function fopen;
+use function getenv;
+use function gmdate;
+use function hash;
+use function hash_hmac;
+use function ksort;
+use function mkdir;
+use function preg_match;
+use function rawurlencode;
+use function rtrim;
+use function sprintf;
+use function str_replace;
+use function substr;
+use function time;
+use function trim;
+use function unlink;
+use const CURLOPT_FILE;
+use const CURLOPT_FOLLOWLOCATION;
+use const CURLOPT_HEADER;
+
+class BrefToolBox {
+    /**
+     * Path to autoload_static.php file from composer
+     */
+    const AUTOLOAD_STATIC_PATH = '/tmp/vendor/composer/autoload_static.php';
+    /**
+     * Path where the vendor archive will be stored
+     */
+    const DOWNLOAD_FILE_PATH = '/tmp/vendor.zip';
+    /**
+     * Path where the extracted vendor archives contents will be stored
+     */
+    const EXTRACTION_PATH = '/tmp/vendor/';
+
+    /**
+     * @throws Exception
+     */
+    public static function downloadAndConfigureVendor()
+    {
+        self::downloadVendorArchive(
+            getenv('BREF_DOWNLOAD_VENDOR'),
+            self::DOWNLOAD_FILE_PATH
+        );
+
+        $unzipped = self::unzipVendorArchive(
+            self::DOWNLOAD_FILE_PATH,
+            self::EXTRACTION_PATH
+        );
+
+        if(! $unzipped) {
+            throw new Exception('Unable to unzip vendor archive.');
+        }
+
+        unlink(self::DOWNLOAD_FILE_PATH);
+
+        self::updateComposerAutoloading();
+    }
+
+    /**
+     * Download vendor archive from s3 bucket
+     *
+     * @param string $s3String
+     * @param string $downloadPath
+     * @return void
+     */
+    private static function downloadVendorArchive(string $s3String, string $downloadPath): void
+    {
+        preg_match('~s3\:\/\/([^\/]+)\/(.*)~', $s3String, $matches);
+        $bucket = $matches[1];
+        $filePath = '/' . $matches[2];
+        $region = getenv('AWS_REGION');
+
+        $url = self::AWS_S3_PresignDownload(
+            getenv('AWS_ACCESS_KEY_ID'),
+            getenv('AWS_SECRET_ACCESS_KEY'),
+            getenv('AWS_SESSION_TOKEN'),
+            $bucket,
+            $region,
+            $filePath
+        );
+
+        if(file_exists($downloadPath)) {
+            unlink($downloadPath);
+        }
+
+        $fp = fopen($downloadPath, 'w');
+
+        $options = [
+            CURLOPT_HEADER => 0,
+            CURLOPT_FOLLOWLOCATION => 1,
+            CURLOPT_FILE => $fp,
+        ];
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, $options);
+        curl_exec($ch);
+        curl_close($ch);
+        fclose($fp);
+    }
+
+    /**
+     * Create S3 signed url to download vendor archive from
+     * From https://gist.github.com/anthonyeden/4448695ad531016ec12bcdacc9d91cb8
+     *
+     * @param $AWSAccessKeyId
+     * @param $AWSSecretAccessKey
+     * @param $AWSSessionToken
+     * @param $BucketName
+     * @param $AWSRegion
+     * @param $canonical_uri
+     * @param int $expires
+     * @return string
+     */
+    private static function AWS_S3_PresignDownload(
+        $AWSAccessKeyId,
+        $AWSSecretAccessKey,
+        $AWSSessionToken,
+        $BucketName,
+        $AWSRegion,
+        $canonical_uri,
+        $expires = 86400
+    ): string
+    {
+        // Creates a signed download link for an AWS S3 file
+        // Based on https://gist.github.com/kelvinmo/d78be66c4f36415a6b80
+
+        $encoded_uri = str_replace('%2F', '/', rawurlencode($canonical_uri));
+
+        // Specify the hostname for the S3 endpoint
+        if($AWSRegion == 'us-east-1') {
+            $hostname = trim($BucketName .".s3.amazonaws.com");
+            $header_string = "host:" . $hostname . "\n";
+            $signed_headers_string = "host";
+        } else {
+            $hostname =  trim($BucketName . ".s3-" . $AWSRegion . ".amazonaws.com");
+            $header_string = "host:" . $hostname . "\n";
+            $signed_headers_string = "host";
+        }
+
+        $date_text = gmdate('Ymd', time());
+        $time_text = $date_text . 'T000000Z';
+        $algorithm = 'AWS4-HMAC-SHA256';
+        $scope = $date_text . "/" . $AWSRegion . "/s3/aws4_request";
+
+        $x_amz_params = array(
+            'X-Amz-Algorithm' => $algorithm,
+            'X-Amz-Credential' => $AWSAccessKeyId . '/' . $scope,
+            'X-Amz-Date' => $time_text,
+            'X-Amz-SignedHeaders' => $signed_headers_string,
+            'X-Amz-Security-Token' => $AWSSessionToken,
+        );
+
+        if ($expires > 0) {
+            // 'Expires' is the number of seconds until the request becomes invalid
+            $x_amz_params['X-Amz-Expires'] = (string)$expires;
+        }
+
+        ksort($x_amz_params);
+
+        $query_string = "";
+        foreach ($x_amz_params as $key => $value) {
+            $query_string .= rawurlencode($key) . '=' . rawurlencode($value) . "&";
+        }
+        $query_string = substr($query_string, 0, -1);
+
+        $canonical_request = "GET\n" . $encoded_uri . "\n" . $query_string . "\n" . $header_string . "\n" . $signed_headers_string . "\nUNSIGNED-PAYLOAD";
+        $string_to_sign = $algorithm . "\n" . $time_text . "\n" . $scope . "\n" . hash('sha256', $canonical_request, false);
+        $signing_key = hash_hmac('sha256', 'aws4_request',
+            hash_hmac('sha256', 's3',
+                hash_hmac('sha256', $AWSRegion,
+                    hash_hmac('sha256', $date_text, 'AWS4' . $AWSSecretAccessKey, true),
+                    true),
+                true),
+            true
+        );
+        $signature = hash_hmac('sha256', $string_to_sign, $signing_key);
+
+        return 'https://' . $hostname . $encoded_uri . '?' . $query_string . '&X-Amz-Signature=' . $signature;
+    }
+
+    /**
+     * Unzip vendor archive into temporary path
+     *
+     * @param string $filePath
+     * @param string $unzipPath
+     * @return bool
+     */
+    private static function unzipVendorArchive(string $filePath, string $unzipPath): bool
+    {
+        $zip = new ZipArchive();
+        $resource = $zip->open($filePath);
+
+        if(! file_exists($unzipPath)) {
+            mkdir($unzipPath, 0755, true);
+        }
+
+        if ($resource !== true) {
+            return false;
+        }
+
+        $zip->extractTo($unzipPath);
+        $zip->close();
+
+        return true;
+    }
+
+    /**
+     * Update composer autoload_static.php file with correct path for Lambda task root
+     *
+     * @return void
+     */
+    private static function updateComposerAutoloading(): void
+    {
+        $updatedStaticLoader = str_replace(
+            "__DIR__ . '/../..'",
+            sprintf("'%s'", rtrim(getenv('LAMBDA_TASK_ROOT'), '/')),
+            file_get_contents(self::AUTOLOAD_STATIC_PATH)
+        );
+
+        file_put_contents(self::AUTOLOAD_STATIC_PATH, $updatedStaticLoader);
+    }
+}


### PR DESCRIPTION
Dear Bref team,

this is my first big contribution to this project and I hope this one will become a small part of this great project.

**WHY**
I'm currently trying out a few bigger opensource eCommerce/CMS/PIM scripts based on Symfony in my spare time and was curious if I could get them deployed on Lambda. The Lambda .zip archive went up to 80 megabytes and more due to the amount of packages in the vendor directory and immediately reached the limits of AWS Lambda.

Together with @mnapoli, who was a great helper, I've created this modification that allows bref users to store the vendor folder archive in s3 and then lazy load it into the Lambda temporary directory. There are also modifications in place for composer to load the correct source files.

Based on the input from @mnapoli we did not extend the layers with additional binaries and instead used PHP code to do the s3 downloading and ext-zip to do the unpacking of the vendor archive.

I'm looking forward to your comments and ideas on this.

Thank you very much and have a great day!

Best wishes
Tom