### PR TITLE
Support for multiple cookies in http payload version 2.0

### DIFF
--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -287,7 +287,9 @@ final class FpmHandler extends HttpHandler
             // If we are not in "multi-header" mode, we must keep the last value only
             // and cast it to string
             foreach ($responseHeaders as $key => $value) {
-                $responseHeaders[$key] = end($value);
+                if ($key !== 'Set-Cookie') {
+                    $responseHeaders[$key] = end($value);
+                }
             }
         }
 

--- a/tests/Event/Http/HttpResponseTest.php
+++ b/tests/Event/Http/HttpResponseTest.php
@@ -79,4 +79,20 @@ class HttpResponseTest extends TestCase
             'body' => '',
         ], $response->toApiGatewayFormat(true));
     }
+
+    public function test cookie header conversion to API Gateway format version 2()
+    {
+        $response = new HttpResponse('', [
+            'set-cookie' => ['bar', 'baz'],
+            'x-foo-bar' => 'baz',
+        ]);
+
+        self::assertEquals([
+            'isBase64Encoded' => false,
+            'statusCode' => 200,
+            'headers' => ['X-Foo-Bar' => 'baz'],
+            'cookies' => ['bar', 'baz'],
+            'body' => '',
+        ], $response->toApiGatewayFormat());
+    }
 }

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -1018,9 +1018,12 @@ Year,Make,Model
 
     public function test response with cookies()
     {
-        $cookieHeader = $this->get('cookies.php')['headers']['Set-Cookie'];
-
-        self::assertEquals('MyCookie=MyValue; expires=Fri, 12-Jan-2018 08:32:03 GMT; Max-Age=0; path=/hello/; domain=example.com; secure; HttpOnly', $cookieHeader);
+        $cookieHeader = $this->get('cookies.php', [
+            'version' => '1.0',
+            'httpMethod' => 'GET',
+        ])['cookies'];
+        self::assertEquals('MyCookie=FirstValue; expires=Fri, 12-Jan-2018 08:32:03 GMT; Max-Age=0; path=/hello/; domain=example.com; secure; HttpOnly', $cookieHeader[0]);
+        self::assertEquals('MyCookie=MyValue; expires=Fri, 12-Jan-2018 08:32:03 GMT; Max-Age=0; path=/hello/; domain=example.com; secure; HttpOnly', $cookieHeader[1]);
     }
 
     public function test response with multiple cookies with multiheader()


### PR DESCRIPTION
Fix for #818

For http payload version 2.0 there is no `multiValueHeaders` field anymore. But to support multiple cookies, a new `cookies` field was introduced as described here:
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

This PR adds the `cookies` field to the response and removes the `Set-Cookie` header, that is now handled by API-Gateway v2.
