### PR TITLE
use new amazon container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ changelog:
 
 # http://amazon-linux-2-packages.bref.sh/
 amazonlinux-package-list:
-	docker run --rm -it amazonlinux:2 yum list --quiet --color=never > index.html
+	docker run --rm -it --entrypoint= public.ecr.aws/lambda/provided:al2 yum list --quiet --color=never > index.html
 	aws s3 cp index.html s3://amazon-linux-2-packages.bref.sh/ --content-type=text/plain
 	rm index.html
 

--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -149,15 +149,15 @@ FROM bref/build-php-74
 
 RUN curl -A "Docker" -o /tmp/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/1.42.0/blackfire-php-linux_amd64-php-74.so"
 
-# Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:provided.al2
+# Build the final image from the amazon image that is close to the production environment
+FROM public.ecr.aws/lambda/provided:al2
 
 # Copy things we installed to the final image
 COPY --from=0 /tmp/blackfire.so /opt/bref-extra/blackfire.so
 ```
 
 The `.so` extension file can then be retrieved in `/opt/bref-extra/blackfire.so`.
-If you installed system libraries, you may also need to copy them to the `lambci/lambda`
+If you installed system libraries, you may also need to copy them to the `public.ecr.aws/lambda/provided:al2`
 image.
 
 See [brefphp/extra-php-extensions](https://github.com/brefphp/extra-php-extensions)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -13,7 +13,15 @@ export/php%.zip: docker-images
 	PHP_VERSION=$$(echo $@ | cut -d'/' -f 2 | cut -d'.' -f 1);\
 	rm -f $@;\
 	cd export ; \
-	docker run --rm --entrypoint= bref/$$PHP_VERSION:latest sh -c "cd /opt && zip -qq -y -r - {*,.[!.]*} > /tmp/file.zip && cat /tmp/file.zip -" > $$PHP_VERSION.zip ;
+	set -e ; \
+	rm -rf opt ; \
+	CID=$$(docker create --entrypoint=scratch bref/$$PHP_VERSION:latest) ; \
+	docker cp $${CID}:/opt . ; \
+	docker rm $${CID} ; \
+	cd opt ; \
+	zip -qq -y -r - {*,.[!.]*} > ../$$PHP_VERSION.zip
+	cd ../ ; \
+	rm -rf opt ;
 
 # The console runtime
 export/console.zip: layers/console/bootstrap

--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -6,7 +6,7 @@
 # https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html
 # AWS provides it a Docker image that we use here:
 # https://github.com/amazonlinux/container-images/tree/amzn2
-FROM amazonlinux:2
+FROM public.ecr.aws/lambda/provided:al2
 
 
 # Move to /tmp to compile everything in there.
@@ -28,7 +28,7 @@ RUN set -xe \
 # our libraries, and at least one library requires a version of cmake greater than that.
 #
 # Needed to build:
-# - libzip: minimum required CMAKE version 3.0.2
+# - libzip: minimum required CMAKE version 3.0.
 RUN LD_LIBRARY_PATH= yum install -y cmake3
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 

--- a/runtime/base/php-73.Dockerfile
+++ b/runtime/base/php-73.Dockerfile
@@ -105,7 +105,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM lambci/lambda:build-provided.al2
+FROM public.ecr.aws/lambda/provided:al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -129,7 +129,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM amazonlinux:2
+FROM public.ecr.aws/lambda/provided:al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/base/php-80.Dockerfile
+++ b/runtime/base/php-80.Dockerfile
@@ -129,7 +129,7 @@ RUN /tmp/clean.sh && rm /tmp/clean.sh
 # Now we start back from a clean image.
 # We get rid of everything that is unnecessary (build tools, source code, and anything else
 # that might have created intermediate layers for docker) by copying online the /opt directory.
-FROM lambci/lambda:build-provided.al2
+FROM public.ecr.aws/lambda/provided:al2
 ENV PATH="/opt/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
 

--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -6,6 +6,6 @@ COPY bootstrap /opt/bootstrap
 COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
 
-# Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:build-provided.al2
+# Build the final image from the amazon image that is close to the production environment
+FROM public.ecr.aws/lambda/provided:al2
 COPY --from=0  /opt /opt

--- a/runtime/layers/function/Dockerfile
+++ b/runtime/layers/function/Dockerfile
@@ -8,6 +8,6 @@ COPY php.ini /opt/bref/etc/php/conf.d/bref.ini
 # Remove PHP-FPM
 RUN rm /opt/bref/sbin/php-fpm /opt/bin/php-fpm
 
-# Build the final image from the lambci image that is close to the production environment
-FROM lambci/lambda:build-provided.al2
+# Build the final image from the amazon image that is close to the production environment
+FROM public.ecr.aws/lambda/provided:al2
 COPY --from=0 /opt /opt


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

During 2020 re:Invent, Amazon has anounced support of docker images for lambdas. They've also [published new base container images](https://gallery.ecr.aws/lambda/provided). This pull request suggests to use corresponding images to build bref images.

I've tested on some apps and it's ok. The only thing is that in the new images the user is root and there's no more filesystem protection (previous images had only /var/task and /tmp as read/write paths, others were read-only).

Big advantage by the way is that resulting docker images are lightweight compared to currently produced ones.