### PR TITLE
Re-enable opcache.validate_timestamps

### DIFF
--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -15,7 +15,9 @@ opcache.enable=1
 opcache.validate_permission=0
 
 ; The code is readonly on lambdas so it never changes
-opcache.validate_timestamps=0
+; This setting is now disabled: code could be written to /tmp which is read/write
+; (e.g. a compiled container) Such a performance optimization can be done by users.
+;opcache.validate_timestamps=0
 
 ; Set sane values, modern PHP applications have higher needs than opcache's defaults
 ; See https://tideways.com/profiler/blog/fine-tune-your-opcache-configuration-to-avoid-caching-suprises

--- a/runtime/layers/function/php.ini
+++ b/runtime/layers/function/php.ini
@@ -22,7 +22,9 @@ opcache.file_cache_only=1
 opcache.validate_permission=0
 
 ; The code is readonly on lambdas so it never changes
-opcache.validate_timestamps=0
+; This setting is now disabled: code could be written to /tmp which is read/write
+; (e.g. a compiled container) Such a performance optimization can be done by users.
+;opcache.validate_timestamps=0
 
 ; Set sane values, modern PHP applications have higher needs than opcache's defaults
 ; See https://tideways.com/profiler/blog/fine-tune-your-opcache-configuration-to-avoid-caching-suprises


### PR DESCRIPTION
This change disables a non-standard optimization that was applied automatically by Bref. The main reason it was applied was that the code source is read-only on Lambda.

However, that is not 100% true: code written to `/tmp` is read/write (for example when using `/tmp` as a cache directory, or for a compiled container, etc.). The `opcache.validate_timestamps=0` would cause bugs very hard to debug.

Additionally, switching to `opcache.validate_timestamps=1` will allow code in development to be reloaded when changed without having to restart containers.

This could cause a very small performance regression, but I consider that less important than fixing an actual bug.

Users are welcome to re-enable that option in `php.ini`:

```
opcache.validate_timestamps=0
```