### PR TITLE
Fix Documentation Serverless GetAtt syntax error

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -142,7 +142,7 @@ provider:
         -   Effect: Allow
             Action: s3:*
             Resource:
-                - Fn::GetAtt: Storage.Arn # the storage bucket
+                - Fn::GetAtt: [ Storage, Arn ]  # the storage bucket
                 - Fn::Join: ['', [Fn::GetAtt: Storage.Arn, '/*']] # everything in the storage bucket
 
 resources:


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

The original code in the documentation creates an error when running `serverless deploy`
```
Fn::GetAtt: Storage.Arn # the storage bucket
```

The error that gets created is:
`Serverless: Configuration warning at 'provider.iamRoleStatements[0].Resource[0]['Fn::GetAtt']': should NOT have fewer than 2 items`

Reference:
- https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html

Btw, this is a really cool project. Thanks for the hard work with this one :)