### PR TITLE
Remove chalk

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ class ServerlessPlugin {
         this.serverless = serverless;
         this.options = options;
         this.provider = this.serverless.getProvider('aws');
-        this.chalk = require(process.mainModule.path + '/../node_modules/chalk');
 
         this.fs = require('fs');
         this.path = require('path');
@@ -272,7 +271,7 @@ class ServerlessPlugin {
     }
 
     consoleLog(message) {
-        console.log(`Bref: ${this.chalk.yellow(message)}`);
+        console.log(`Bref: ${message}`);
     }
 }
 


### PR DESCRIPTION
When I use a `serverless` binary installedas a project dependency (not global). I get the following error when I try to deploy. 

```
Run SLS_DEBUG=* node_modules/serverless/bin/serverless.js deploy --stage=prod --force

  Error --------------------------------------------------
 
  Error: Cannot find module '/home/runner/work/my-project/my-project/node_modules/serverless/bin/../node_modules/chalk'
  Require stack:
  - /home/runner/work/my-project/my-project/vendor/bref/bref/index.js
  - /home/runner/work/my-project/my-project/node_modules/serverless/lib/classes/PluginManager.js
  - /home/runner/work/my-project/my-project/node_modules/serverless/lib/Serverless.js
  - /home/runner/work/my-project/my-project/node_modules/serverless/scripts/serverless.js
  - /home/runner/work/my-project/my-project/node_modules/serverless/bin/serverless.js
      at Function.Module._resolveFilename (node:internal/modules/cjs/loader:925:15)
      at Function.Module._load (node:internal/modules/cjs/loader:769:27)
      at Module.require (node:internal/modules/cjs/loader:997:19)
      at require (node:internal/modules/cjs/helpers:92:18)
      at new ServerlessPlugin (/home/runner/work/my-project/my-project/vendor/bref/bref/index.js:14:22)
      at PluginManager.addPlugin (/home/runner/work/my-project/my-project/node_modules/serverless/lib/classes/PluginManager.js:95:28)
      at /home/runner/work/my-project/my-project/node_modules/serverless/lib/classes/PluginManager.js:138:33
      at Array.forEach (<anonymous>)
      at PluginManager.loadAllPlugins (/home/runner/work/my-project/my-project/node_modules/serverless/lib/classes/PluginManager.js:138:8)
      at /home/runner/work/my-project/my-project/node_modules/serverless/lib/Serverless.js:91:39
      at /home/runner/work/my-project/my-project/node_modules/serverless/scripts/serverless.js:47:7
 
  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Issues:        forum.serverless.com
 
  Your Environment Information ---------------------------
     Operating System:          linux
     Node Version:              15.6.0
     Framework Version:         2.19.0 (local)
     Plugin Version:            4.4.2
     SDK Version:               2.3.2
     Components Version:        3.4.7
 
Error: Process completed with exit code 1.
```

Chalk can not be loaded properly. I dont see that it brings any great value, so Im happy to remove it. 

Im using bref 1.1.1.

FYI @tomhatzer 