### PR TITLE
Support multiple cookies with API Gateway v2

### DIFF
--- a/demo/psr7.php
+++ b/demo/psr7.php
@@ -12,6 +12,7 @@ return new class implements RequestHandlerInterface {
     {
         return new Response(200, [
             'Content-Type' => ['text/html'],
+            'Set-Cookie' => ['foo', 'bar'],
         ], 'Hello world!');
     }
 };

--- a/serverless.yml
+++ b/serverless.yml
@@ -47,6 +47,7 @@ functions:
             - ${bref:layer.php-74}
         events:
             -   http: 'ANY /psr7'
+            -   httpApi: 'GET /psr7'
         environment:
             BREF_LOOP_MAX: 100
 

--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -126,7 +126,7 @@ final class FpmHandler extends HttpHandler
             throw new FastCgiCommunicationFailed;
         }
 
-        $responseHeaders = $this->getResponseHeaders($response, $event->hasMultiHeader());
+        $responseHeaders = $this->getResponseHeaders($response);
 
         // Extract the status code
         if (isset($responseHeaders['status'])) {
@@ -134,11 +134,9 @@ final class FpmHandler extends HttpHandler
             unset($responseHeaders['status']);
         }
 
-        $response = new HttpResponse($response->getBody(), $responseHeaders, $status ?? 200);
-
         $this->ensureStillRunning();
 
-        return $response;
+        return new HttpResponse($response->getBody(), $responseHeaders, $status ?? 200);
     }
 
     /**
@@ -280,17 +278,8 @@ final class FpmHandler extends HttpHandler
     /**
      * Return an array of the response headers.
      */
-    private function getResponseHeaders(ProvidesResponseData $response, bool $isMultiHeader): array
+    private function getResponseHeaders(ProvidesResponseData $response): array
     {
-        $responseHeaders = $response->getHeaders();
-        if (! $isMultiHeader) {
-            // If we are not in "multi-header" mode, we must keep the last value only
-            // and cast it to string
-            foreach ($responseHeaders as $key => $value) {
-                $responseHeaders[$key] = end($value);
-            }
-        }
-
-        return array_change_key_case($responseHeaders, CASE_LOWER);
+        return array_change_key_case($response->getHeaders(), CASE_LOWER);
     }
 }

--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -24,6 +24,10 @@ abstract class HttpHandler implements Handler
 
         $response = $this->handleRequest($httpEvent, $context);
 
+        if ($httpEvent->isFormatV2()) {
+            return $response->toApiGatewayFormatV2();
+        }
+
         return $response->toApiGatewayFormat($httpEvent->hasMultiHeader());
     }
 }

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -70,7 +70,7 @@ final class HttpRequestEvent implements LambdaEvent
 
     public function hasMultiHeader(): bool
     {
-        if ($this->payloadVersion === 2.0) {
+        if ($this->isFormatV2()) {
             return false;
         }
 
@@ -109,7 +109,7 @@ final class HttpRequestEvent implements LambdaEvent
 
     public function getPath(): string
     {
-        if ($this->payloadVersion >= 2) {
+        if ($this->isFormatV2()) {
             return $this->event['rawPath'] ?? '/';
         }
 
@@ -159,20 +159,23 @@ final class HttpRequestEvent implements LambdaEvent
 
     public function getCookies(): array
     {
-        if ($this->payloadVersion === 2.0) {
-            if (! isset($this->event['cookies'])) {
-                return [];
+        if ($this->isFormatV2()) {
+            $cookieParts = $this->event['cookies'] ?? [];
+            $cookies = [];
+            foreach ($cookieParts as $cookiePart) {
+                [$cookieName, $cookieValue] = explode('=', $cookiePart, 2);
+                $cookies[$cookieName] = urldecode($cookieValue);
             }
-            $cookieParts = $this->event['cookies'];
-        } else {
-            if (! isset($this->headers['cookie'])) {
-                return [];
-            }
-            // Multiple "Cookie" headers are not authorized
-            // https://stackoverflow.com/questions/16305814/are-multiple-cookie-headers-allowed-in-an-http-request
-            $cookieHeader = $this->headers['cookie'][0];
-            $cookieParts = explode('; ', $cookieHeader);
+            return $cookies;
         }
+
+        if (! isset($this->headers['cookie'])) {
+            return [];
+        }
+        // Multiple "Cookie" headers are not authorized
+        // https://stackoverflow.com/questions/16305814/are-multiple-cookie-headers-allowed-in-an-http-request
+        $cookieHeader = $this->headers['cookie'][0];
+        $cookieParts = explode('; ', $cookieHeader);
 
         $cookies = [];
         foreach ($cookieParts as $cookiePart) {
@@ -192,7 +195,7 @@ final class HttpRequestEvent implements LambdaEvent
 
     private function rebuildQueryString(): string
     {
-        if ($this->payloadVersion === 2.0) {
+        if ($this->isFormatV2()) {
             $queryString = $this->event['rawQueryString'] ?? '';
             // We re-parse the query string to make sure it is URL-encoded
             // Why? To match the format we get when using PHP outside of Lambda (we get the query string URL-encoded)
@@ -302,11 +305,19 @@ final class HttpRequestEvent implements LambdaEvent
 
         // Cookies are separated from headers in payload v2, we re-add them in there
         // so that we have the full original HTTP request
-        if ($this->payloadVersion === 2.0 && ! empty($this->event['cookies'])) {
+        if (! empty($this->event['cookies']) && $this->isFormatV2()) {
             $cookieHeader = implode('; ', $this->event['cookies']);
             $headers['cookie'] = [$cookieHeader];
         }
 
         return $headers;
+    }
+
+    /**
+     * See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
+     */
+    public function isFormatV2(): bool
+    {
+        return $this->payloadVersion === 2.0;
     }
 }

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -161,21 +161,15 @@ final class HttpRequestEvent implements LambdaEvent
     {
         if ($this->isFormatV2()) {
             $cookieParts = $this->event['cookies'] ?? [];
-            $cookies = [];
-            foreach ($cookieParts as $cookiePart) {
-                [$cookieName, $cookieValue] = explode('=', $cookiePart, 2);
-                $cookies[$cookieName] = urldecode($cookieValue);
+        } else {
+            if (! isset($this->headers['cookie'])) {
+                return [];
             }
-            return $cookies;
+            // Multiple "Cookie" headers are not authorized
+            // https://stackoverflow.com/questions/16305814/are-multiple-cookie-headers-allowed-in-an-http-request
+            $cookieHeader = $this->headers['cookie'][0];
+            $cookieParts = explode('; ', $cookieHeader);
         }
-
-        if (! isset($this->headers['cookie'])) {
-            return [];
-        }
-        // Multiple "Cookie" headers are not authorized
-        // https://stackoverflow.com/questions/16305814/are-multiple-cookie-headers-allowed-in-an-http-request
-        $cookieHeader = $this->headers['cookie'][0];
-        $cookieParts = explode('; ', $cookieHeader);
 
         $cookies = [];
         foreach ($cookieParts as $cookiePart) {

--- a/src/Event/Http/HttpResponse.php
+++ b/src/Event/Http/HttpResponse.php
@@ -16,6 +16,9 @@ final class HttpResponse
     /** @var string */
     private $body;
 
+    /**
+     * @param array<string|string[]> $headers
+     */
     public function __construct(string $body, array $headers = [], int $statusCode = 200)
     {
         $this->body = $body;
@@ -29,11 +32,7 @@ final class HttpResponse
 
         $headers = [];
         foreach ($this->headers as $name => $values) {
-            // Capitalize header keys
-            // See https://github.com/zendframework/zend-diactoros/blob/754a2ceb7ab753aafe6e3a70a1fb0370bde8995c/src/Response/SapiEmitterTrait.php#L96
-            $name = str_replace('-', ' ', $name);
-            $name = ucwords($name);
-            $name = str_replace(' ', '-', $name);
+            $name = $this->capitalizeHeaderName($name);
 
             if ($multiHeaders) {
                 // Make sure the values are always arrays
@@ -59,5 +58,49 @@ final class HttpResponse
             $headersKey => $headers,
             'body' => $base64Encoding ? base64_encode($this->body) : $this->body,
         ];
+    }
+
+    /**
+     * See https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.response
+     */
+    public function toApiGatewayFormatV2(): array
+    {
+        $base64Encoding = (bool) getenv('BREF_BINARY_RESPONSES');
+
+        $headers = [];
+        $cookies = [];
+        foreach ($this->headers as $name => $values) {
+            $name = $this->capitalizeHeaderName($name);
+
+            if ($name === 'Set-Cookie') {
+                $cookies = is_array($values) ? $values : [$values];
+            } else {
+                // Make sure the values are never arrays
+                // because API Gateway v2 does not support multi-value headers
+                $headers[$name] = is_array($values) ? end($values) : $values;
+            }
+        }
+
+        // The headers must be a JSON object. If the PHP array is empty it is
+        // serialized to `[]` (we want `{}`) so we force it to an empty object.
+        $headers = empty($headers) ? new \stdClass : $headers;
+
+        return [
+            'cookies' => $cookies,
+            'isBase64Encoded' => $base64Encoding,
+            'statusCode' => $this->statusCode,
+            'headers' => $headers,
+            'body' => $base64Encoding ? base64_encode($this->body) : $this->body,
+        ];
+    }
+
+    /**
+     * See https://github.com/zendframework/zend-diactoros/blob/754a2ceb7ab753aafe6e3a70a1fb0370bde8995c/src/Response/SapiEmitterTrait.php#L96
+     */
+    private function capitalizeHeaderName(string $name): string
+    {
+        $name = str_replace('-', ' ', $name);
+        $name = ucwords($name);
+        return str_replace(' ', '-', $name);
     }
 }

--- a/tests/Functional/HttpApiTest.php
+++ b/tests/Functional/HttpApiTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test\Functional;
+
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class HttpApiTest extends TestCase
+{
+    use ArraySubsetAsserts;
+
+    /** @var Client */
+    private $http;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->http = new Client([
+            'base_uri' => 'https://3ipdsvypt1.execute-api.eu-west-1.amazonaws.com/',
+            'http_errors' => false,
+        ]);
+    }
+
+    public function test supports multiple cookies with API Gateway format v2()
+    {
+        $response = $this->http->request('GET');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertEquals(['foo', 'bar'], $response->getHeader('Set-Cookie'));
+    }
+}

--- a/tests/Functional/http-api/index.php
+++ b/tests/Functional/http-api/index.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+return new class() implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = new Response(200, [], 'Hello world');
+        $response = $response->withHeader('Set-Cookie', ['foo', 'bar']);
+        return $response;
+    }
+};

--- a/tests/serverless.tests.yml
+++ b/tests/serverless.tests.yml
@@ -33,3 +33,13 @@ functions:
             -   http: 'ANY /'
         environment:
             FOO: bar
+
+    httpApi:
+        handler: tests/Functional/http-api/index.php
+        description: 'Bref HTTP API test'
+        timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
+        reservedConcurrency: 5
+        layers:
+            - ${bref:layer.php-74}
+        events:
+            -   httpApi: 'GET /'


### PR DESCRIPTION
Fixes #818 

Replaces #820 

This PR allows apps to set multiple cookies in HTTP responses when using API Gateway v2.

Previously this wasn't possible because v2 does not support "multi-value headers". But they added a specific `cookies` field which we can use to set multiple cookies.