### PR TITLE
initialize provider environment variables if there are none

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,6 +111,10 @@ class ServerlessPlugin {
         this.newVendorZipName = vendorZipHash + '.zip';
 
         this.consoleLog('Setting environment variables.');
+        
+        if (! this.serverless.service.provider.environment) {
+            this.serverless.service.provider.environment = [];
+        }
 
         // This environment variable will trigger Bref to download the zip on cold start
         this.serverless.service.provider.environment.BREF_DOWNLOAD_VENDOR = {


### PR DESCRIPTION
fixes bug #847 which causes deployment fail when no environment variables are defined and separateVendor option is used

