### PR TITLE
Billed duration is now the same as duration when invoking function from `bref local`

### DIFF
--- a/src/Console/Command/Local.php
+++ b/src/Console/Command/Local.php
@@ -117,12 +117,11 @@ class Local
     private function logEnd(float $startTime, SymfonyStyle $io, string $requestId): void
     {
         $duration = ceil((microtime(true) - $startTime) * 1000);
-        $billedDuration = ceil(max($duration / 100, 1)) * 100;
         $memoryUsed = ceil(memory_get_usage() / 1024 / 1024);
 
         $io->writeln([
             "END RequestId: $requestId",
-            "REPORT RequestId: $requestId Duration: $duration ms Billed Duration: $billedDuration ms Memory Size: 1024 MB Max Memory Used: $memoryUsed MB",
+            "REPORT RequestId: $requestId Duration: $duration ms Billed Duration: $duration ms Memory Size: 1024 MB Max Memory Used: $memoryUsed MB",
         ]);
     }
 }


### PR DESCRIPTION
Example when invoking a function with `bref local`:

```console
$ bref local my-function --file sqs.json
START RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95 Version: $LATEST
[...]
END RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95
REPORT RequestId: 8f507cfc-example-4697-b07a-ac58fc914c95 Duration: 3 ms Billed Duration: 100 ms Memory Size: 1024 MB Max Memory Used: 3 MB
```

Now the "Billed Duration" will be the same as "Duration"