### PR TITLE
Updated PDO-Sqlite link to go to the correct page.

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -74,7 +74,7 @@ Bref strives to include the most common PHP extensions. If a major PHP extension
         <li><a href="http://php.net/manual/en/book.pcntl.php">pcntl</a></li>
         <li><a href="http://php.net/manual/en/book.pcre.php">pcre</a></li>
         <li><a href="http://php.net/manual/en/book.pdo.php">PDO</a></li>
-        <li><a href="http://php.net/manual/en/book.pdo-sqlite.php">pdo_sqlite</a></li>
+        <li><a href="http://php.net/manual/en/ref.pdo-sqlite.php">pdo_sqlite</a></li>
         <li><a href="http://php.net/manual/en/ref.pdo-mysql.php">pdo_mysql</a></li>
         <li><a href="http://php.net/manual/en/book.phar.php">Phar</a></li>
         <li><a href="http://php.net/manual/en/book.posix.php">posix</a></li>


### PR DESCRIPTION
On the Bref docs page: https://bref.sh/docs/environment/php.html#extensions-installed-and-enabled
Under `Extensions Installed and enabled`, the pdo_sqlite is throwing a 404, this is because it's a reference in the manual rather than a book page. I've corrected this to point to the correct URL.

