### PR TITLE
Improve running PHP on Lambda with Docker

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -49,6 +49,10 @@ docker-images:
 	cd layers/fpm ; docker build -t bref/php-73-fpm --build-arg PHP_VERSION=73 .
 	cd layers/fpm ; docker build -t bref/php-74-fpm --build-arg PHP_VERSION=74 .
 	cd layers/fpm ; docker build -t bref/php-80-fpm --build-arg PHP_VERSION=80 .
+	# - console
+	cd layers/console ; docker build -t bref/php-73-console --build-arg PHP_VERSION=73 .
+	cd layers/console ; docker build -t bref/php-74-console --build-arg PHP_VERSION=74 .
+	cd layers/console ; docker build -t bref/php-80-console --build-arg PHP_VERSION=80 .
 	# Other Docker images
 	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev --build-arg PHP_VERSION=73 .
 	cd layers/fpm-dev ; docker build -t bref/php-74-fpm-dev --build-arg PHP_VERSION=74 .

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,36 +1,41 @@
-This directory contains the scripts that create and publish the AWS Lambda runtimes for PHP.
-
-Read the [runtimes documentation](/docs/runtimes/README.md) to learn more.
-
-## How it works
-
-The scripts are written mainly in `Makefile`.
+# Bref runtimes and Docker images
 
 Multiple Docker images are created:
 
 - `bref/tmp/...` images are created locally and not published online
 - `bref/...` images are published on Docker Hub
 
-Workflow:
+Goal for the Docker images:
 
-- 1: Create the `bref/tmp/step-1/build-environment` Docker image.
+- `bref/tmp/step-1/build-environment`
+  
     This image contains everything needed to compile PHP. This image is created standalone because
     it is common for each PHP version. The next step involves a different Dockerfile per PHP version.
 
-- 2: Create the `bref/build-php-XX` images.
+- `bref/build-php-XX`
+  
     There is one image per PHP version. These images contain PHP compiled with all its extensions.
     It is published so that anyone can use it to compile their own extensions.
     It is not the final image because it contains too many things that need to be removed.
 
-- 3: Create the `bref/tmp/cleaned-build-php-XX` images.
+- `bref/tmp/cleaned-build-php-XX`
+  
     There is one image per PHP version. These images contain PHP compiled with all its extensions,
     but with all extra files removed. These images do not contain the bootstrap files and PHP config files.
 
-- 4: Create the `bref/php-XX`, `bref/php-XX-fpm`, `bref/php-XX-fpm-dev` images.
+- `bref/php-XX`, `bref/php-XX-fpm`
+  
     There is one image per PHP version. These images contain exactly what will be in the layers in `/opt`.
 
-- 5: Create the layers zip files in the `export/` directory.
-    We zip the `/opt` directory of each Docker image.
+    These images have 3 goals:
+  
+    - export `/opt` to create layers
+    - run applications locally using Docker: this requires overloading the entrypoint if necessary
+    - deploy applications on Lambda using Docker images: set the handler as `cmd`
 
-- 6: Publish the layers on AWS.
-    We upload and publish the layers in every AWS region using the zip files.
+- `bref/php-XX-fpm-dev`
+
+    Used to run web applications locally.
+
+Layers are created in the `export/` directory (we zip the `/opt` directory of each Docker image).
+We upload and publish the layers in every AWS region using the zip files.

--- a/runtime/layers/console/Dockerfile
+++ b/runtime/layers/console/Dockerfile
@@ -1,0 +1,7 @@
+ARG PHP_VERSION
+FROM bref/php-$PHP_VERSION
+
+# Overwrite the original bootstrap
+COPY bootstrap /opt/bootstrap
+# Copy files to /var/runtime to support deploying as a Docker image
+RUN cp /opt/bootstrap /var/runtime

--- a/runtime/layers/fpm/Dockerfile
+++ b/runtime/layers/fpm/Dockerfile
@@ -9,4 +9,6 @@ COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
 
 # Build the final image from the amazon image that is close to the production environment
 FROM public.ecr.aws/lambda/provided:al2
-COPY --from=0  /opt /opt
+COPY --from=0 /opt /opt
+# Copy files to /var/runtime to support deploying as a Docker image
+RUN cp /opt/bootstrap /var/runtime && cp /opt/breftoolbox.php /var/runtime

--- a/runtime/layers/function/Dockerfile
+++ b/runtime/layers/function/Dockerfile
@@ -12,3 +12,5 @@ RUN rm /opt/bref/sbin/php-fpm /opt/bin/php-fpm
 # Build the final image from the amazon image that is close to the production environment
 FROM public.ecr.aws/lambda/provided:al2
 COPY --from=0 /opt /opt
+# Copy files to /var/runtime to support deploying as a Docker image
+RUN cp /opt/bootstrap /var/runtime


### PR DESCRIPTION
- Improve the existing Docker images for running on Lambda
- Add `php-xx-console` Docker images for running CLI commands on Lambda

Usage example:

```Dockerfile
FROM bref/php-80-fpm

ADD . $LAMBDA_TASK_ROOT

CMD [ "index.php" ]
```

For console commands:

```Dockerfile
FROM bref/php-80-console

ADD . $LAMBDA_TASK_ROOT

CMD [ "bin/console" ]
```