### PR TITLE
[docker] Sync fpm-dev and fpm settings

### DIFF
--- a/runtime/layers/fpm-dev/php-fpm.conf
+++ b/runtime/layers/fpm-dev/php-fpm.conf
@@ -6,6 +6,9 @@ pid = /tmp/php-fpm.pid
 ; TODO: report that to the PHP bug tracker
 ;log_level = 'warning'
 
+; New PHP 7.3 option that includes the maximum length when writing to stderr
+log_limit = 8192
+
 [default]
 pm = static
 ; We only need one child because a lambda can process only one request at a time
@@ -17,8 +20,7 @@ clear_env = no
 ; Forward stderr of PHP processes to stderr of PHP-FPM (so that it can be sent to cloudwatch)
 catch_workers_output = yes
 ; New PHP 7.3 option that disables a verbose log prefix
-; Disabled for now until we switch to PHP 7.3
-;decorate_workers_output = no
+decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
 ; See https://github.com/brefphp/bref/issues/275
 rlimit_core = 1


### PR DESCRIPTION
These settings are available in the "fpm" image so they should replicated in the "fpm-dev" image too.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
