### PR TITLE
[LambdaRuntime] Use PHP >7.3 JSON errors

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -267,12 +267,14 @@ final class LambdaRuntime
      */
     private function postJson(string $url, $data): void
     {
-        $jsonData = json_encode($data);
-        if ($jsonData === false) {
-            throw new Exception(sprintf(
-                "The Lambda response cannot be encoded to JSON.\nThis error usually happens when you try to return binary content. If you are writing an HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses\nHere is the original JSON error: '%s'",
-                json_last_error_msg()
-            ));
+        try {
+            $jsonData = json_encode($data, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new Exception(
+                "The Lambda response cannot be encoded to JSON.\nThis error usually happens when you try to return binary content. If you are writing an HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses",
+                0,
+                $e
+            );
         }
 
         if ($this->returnHandler === null) {

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -6,6 +6,7 @@ use Bref\Context\Context;
 use Bref\Context\ContextBuilder;
 use Bref\Event\Handler;
 use Exception;
+use JsonException;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -190,7 +190,7 @@ class LambdaRuntimeTest extends TestCase
 
         $message = <<<ERROR
 The Lambda response cannot be encoded to JSON.
-This error usually happens when you try to return binary content. If you are writing an HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses'
+This error usually happens when you try to return binary content. If you are writing an HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses
 ERROR;
         $this->assertInvocationErrorResult('Exception', $message);
         $this->assertErrorInLogs('Exception', $message);

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -190,8 +190,7 @@ class LambdaRuntimeTest extends TestCase
 
         $message = <<<ERROR
 The Lambda response cannot be encoded to JSON.
-This error usually happens when you try to return binary content. If you are writing an HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses
-Here is the original JSON error: 'Malformed UTF-8 characters, possibly incorrectly encoded'
+This error usually happens when you try to return binary content. If you are writing an HTTP application and you want to return a binary HTTP response (like an image, a PDF, etc.), please read this guide: https://bref.sh/docs/runtimes/http.html#binary-responses'
 ERROR;
         $this->assertInvocationErrorResult('Exception', $message);
         $this->assertErrorInLogs('Exception', $message);


### PR DESCRIPTION
Replace legacy JSON error management with the modern JsonException

Note: I've removed the phrase "Here is the original JSON error: '%s'" in favor of chain exception Exception::$previous