### PR TITLE
Document S3 assets deployment for Symfony

### DIFF
--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -137,16 +137,7 @@ To learn more about all this, read the [environment variables documentation](/do
 
 To deploy Symfony websites, we need assets to be served by AWS S3. Setting up the S3 bucket is already explained in the [websites documentation](../websites.md#hosting-static-files-with-s3). This section provides additional instructions specific to Symfony assets and Webpack Encore.
 
-First, you can compile assets for production in the `public` directory, then synchronize that directory to a S3 bucket:
-
-```bash
-php bin/console assets:install --env prod
-# if using Webpack Encore, additionally run
-yarn encore production
-aws s3 sync public/ s3://<bucket-name>/ --delete --exclude index.php
-```
-
-Then, you need to [tell Symfony](https://symfony.com/doc/current/reference/configuration/framework.html#base-urls) to use the S3 URL as the assets base URL, instead of your app domain in production.
+First, you need to [tell Symfony](https://symfony.com/doc/current/reference/configuration/framework.html#base-urls) to use the S3 URL as the assets base URL, instead of your app domain in production.
 
 ```yaml
 # config/packages/prod/framework.yaml
@@ -161,6 +152,15 @@ If using Webpack Encore, you also need to add the following config at the end of
 if (Encore.isProduction()) {
     Encore.setPublicPath('https://<bucket-name>.s3.amazonaws.com');
 }
+```
+
+Finally, you can compile assets for production in the `public` directory, then synchronize that directory to a S3 bucket:
+
+```bash
+php bin/console assets:install --env prod
+# if using Webpack Encore, additionally run
+yarn encore production
+aws s3 sync public/ s3://<bucket-name>/ --delete --exclude index.php
 ```
 
 ### Assets in templates

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -150,7 +150,9 @@ If using Webpack Encore, you also need to add the following config at the end of
 
 ```js
 if (Encore.isProduction()) {
-    Encore.setPublicPath('https://<bucket-name>.s3.amazonaws.com');
+    // Note the '/build' at the end of the URL
+    Encore.setPublicPath('https://<bucket-name>.s3.amazonaws.com/build');
+    Encore.setManifestKeyPrefix('build/')
 }
 ```
 

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -155,7 +155,13 @@ framework:
     base_urls: 'https://<bucket-name>.s3.amazonaws.com'
 ```
 
-If using Webpack Encore, you also need to add the following config in `webpack.config.js`
+If using Webpack Encore, you also need to add the following config at the end of `webpack.config.js`
+
+```js
+if (Encore.isProduction()) {
+    Encore.setPublicPath('https://<bucket-name>.s3.amazonaws.com');
+}
+```
 
 ### Assets in templates
 

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -133,6 +133,45 @@ The secrets (e.g. database passwords) must however not be committed in this file
 
 To learn more about all this, read the [environment variables documentation](/docs/environment/variables.md).
 
+## Assets
+
+To deploy Symfony websites, we need assets to be served by AWS S3. Setting up the S3 bucket is already explained in the [websites documentation](../websites.md#hosting-static-files-with-s3). This section provides additional instructions specific to Symfony assets and Webpack Encore.
+
+First, you can compile assets for production in the `public` directory, then synchronize that directory to a S3 bucket:
+
+```bash
+php bin/console assets:install --env prod
+# if using Webpack Encore, additionally run
+yarn encore production
+aws s3 sync public/ s3://<bucket-name>/ --delete --exclude index.php
+```
+
+Then, you need to [tell Symfony](https://symfony.com/doc/current/reference/configuration/framework.html#base-urls) to use the S3 URL as the assets base URL, instead of your app domain in production.
+
+```yaml
+# config/packages/prod/framework.yaml
+framework:
+  assets:
+    base_urls: 'https://<bucket-name>.s3.amazonaws.com'
+```
+
+If using Webpack Encore, you also need to add the following config in `webpack.config.js`
+
+### Assets in templates
+
+For the above configuration to work, assets must be referenced in templates via the `asset()` helper:
+
+```html
+<script src="{{ asset('js/app.js') }}"></script>
+```
+
+If your templates reference some assets via direct path, you should edit them to use the `asset()` helper:
+
+```html
+- <img src="/images/logo.png">
++ <img src="{{ asset('images/logo.png') }}">
+```
+
 ## Symfony Messenger
 
 It is possible to run Symfony Messenger workers on AWS Lambda.


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

This PR is following some discussion we had on Slack regarding the improvement of the Symfony section of Bref docs.

This is mostly pasted from the same part of the [Laravel section](https://bref.sh/docs/frameworks/laravel.html#assets), adapted for Symfony and Webpack Encore.