### PR TITLE
Document using buildDir in Kernel.php

### DIFF
--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -38,7 +38,7 @@ package:
         - tests/**
         - var/**
     include:
-        - var/cache/prod # allows to deploy a pre-warmed container
+        - var/cache/prod/** # allows to deploy a pre-warmed container
 
 functions:
     website:


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
Symfony 5.2 introduced `Kernel::getBuildDir()` for read-only cache that can be prewarmed (like the container).

This is my attempt to document its usage with Bref.

I think it could also replace the `prepareCacheDir` of the [symfony-bridge](https://github.com/brefphp/symfony-bridge/blob/master/src/BrefKernel.php#L64) but I might be missing something. Hope you can give me some more information about it. 

Just to give you an insight on the performance boost for cold starts, here are my benchmark on a `symfony/skeleton` app (using `ab -c 20 -n 20`).

Using the currently documented approach
```
Percentage of the requests served within a certain time (ms)
  50%   1549
  66%   1641
  75%   1732
  80%   1771
  90%   1853
  95%   1860
  98%   1860
  99%   1860
 100%   1860
```

Using the config added by this PR
```
Percentage of the requests served within a certain time (ms)
  50%    960
  66%    972
  75%    984
  80%    986
  90%    998
  95%   1147
  98%   1147
  99%   1147
 100%   1147
```

Let me know what you think :slightly_smiling_face: 