### PR TITLE
Update path to cacert.pem

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -119,7 +119,7 @@ RUN set -xe; \
 #   - php
 ENV VERSION_OPENSSL=1.1.1g
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
-ENV CA_BUNDLE_SOURCE="https://curl.haxx.se/ca/cacert.pem"
+ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"
 
 
@@ -148,7 +148,7 @@ RUN set -xe; \
 
 RUN set -xe; \
     make install \
- && curl -k -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
+ && curl -Lk -o ${CA_BUNDLE} ${CA_BUNDLE_SOURCE}
 
 ###############################################################################
 # LIBSSH2 Build


### PR DESCRIPTION
It is good practice to alway use the `--location` (or `-L`) option. That will always follow HTTP redirects. This was the only place we dont use `-L`. 😄 

curl finally got a new domain and this broke our build script. I've updated to the new URL and make sure we dont have this issue in the future. 

```
❯ curl -I https://curl.haxx.se/ca/cacert.pem
HTTP/2 301
server: nginx/1.17.6
content-type: text/html; charset=iso-8859-1
x-frame-options: SAMEORIGIN
location: https://curl.se/ca/cacert.pem
cache-control: max-age=60
expires: Thu, 18 Mar 2021 14:34:46 GMT
strict-transport-security: max-age=31536000
accept-ranges: bytes
date: Thu, 18 Mar 2021 14:34:37 GMT
via: 1.1 varnish
age: 51
x-served-by: cache-bma1646-BMA
x-cache: HIT
x-cache-hits: 2
x-timer: S1616078077.302404,VS0,VE0
content-length: 299
```