### PR TITLE
Test build docker images on PRs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,17 @@
+name: Build Docker images
+
+on:
+  pull_request:
+    paths:
+      - runtime/**
+
+jobs:
+  publish:
+    name: Building images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build images
+        run: make docker-images


### PR DESCRIPTION
This build is quite slow, but it is only executed when we make changes to files in `runtime/`. 