### PR TITLE
Dont use guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,7 @@
         "phpunit/phpunit": "^9.0",
         "dms/phpunit-arraysubset-asserts": "^0.2.0",
         "doctrine/coding-standard": "^8.0",
-        "phpstan/phpstan": "^0.12",
-        "guzzlehttp/guzzle": "^6.3"
+        "phpstan/phpstan": "^0.12"
     },
     "scripts": {
         "test": [

--- a/demo/psr7.php
+++ b/demo/psr7.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-use GuzzleHttp\Psr7\Response;
+use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;


### PR DESCRIPTION
We download `guzzlehttp/guzzle` because we need a PSR7 implementation. We already have a PSR7 implementation and a HTTP client installed. We dont need to install a legacy version of Guzzle. 

-----

I know it looks like Im super bias and just want to push to promote `nyholm/psr7`. But I am also maintainer of `guzzlehttp/guzzle` and `guzzlehttp/psr7`.