### PR TITLE
[FPM] Update comment and max_execution_time

### DIFF
--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -37,10 +37,9 @@ variables_order="EGPCS"
 ; See https://github.com/brefphp/bref/issues/214
 disable_functions=fastcgi_finish_request
 
-; API Gateway has a timeout of 29 seconds, the default Lambda config for FPM has a timeout of
-; 28 seconds. Setting this to 27 will give PHP some time to properly finish up its
-; resources and flush logs to CloudWatch.
-max_execution_time=27
+; API Gateway has a timeout of 29 seconds. Setting this to 28 will give PHP some
+; time to properly finish up its resources and flush logs to CloudWatch.
+max_execution_time=28
 
 ; The total upload size limit is 6Mb, we override the defaults to match this limit
 ; API Gateway has a 10Mb limit, but Lambda's is 6Mb


### PR DESCRIPTION
Just a minor. The FPM setting this comment is referring to was removed in #714