### PR TITLE
Send console output to CloudWatch in real time

### DIFF
--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -3,6 +3,7 @@
 
 use Bref\Context\Context;
 use Bref\Runtime\LambdaRuntime;
+use Symfony\Component\Process\Process;
 
 ini_set('display_errors', '1');
 error_reporting(E_ALL);
@@ -43,20 +44,14 @@ while (true) {
             $cliOptions = '';
         }
 
-        // We redirect stderr to stdout so that all the output is collected
-        $command = sprintf(
-            'LAMBDA_INVOCATION_CONTEXT=%s /opt/bin/php %s %s 2>&1',
-            escapeshellarg(json_encode($context)),
-            $handlerFile,
-            $cliOptions
-        );
+        $command = sprintf('/opt/bin/php %s %s 2>&1', $handlerFile, $cliOptions);
+        $process = Process::fromShellCommandline($command, null, ['LAMBDA_INVOCATION_CONTEXT' => json_encode($context)]);
 
-        exec($command, $output, $exitCode);
+        $process->run(function ($type, $buffer) {
+            echo $buffer;
+        });
 
-        $output = implode("\n", $output);
-
-        // Echo the output so that it is written to CloudWatch logs
-        echo $output;
+        $exitCode = $process->getExitCode();
 
         if ($exitCode > 0) {
             throw new Exception('The command exited with a non-zero status code: ' . $exitCode);
@@ -64,7 +59,7 @@ while (true) {
 
         return [
             'exitCode' => $exitCode, // will always be 0
-            'output' => $output,
+            'output' => $process->getOutput(),
         ];
     });
 }


### PR DESCRIPTION
We recently noticed a problem whereby output from our console function (stdout) wasn't appearing in CloudWatch. It turned out to be related to the process reaching our configured Lambda timeout.

Consider the following example:

```php
<?php

echo "Line 1\n";

sleep(10);

echo "Line 2\n";
```

For a function that uses the console layer with a timeout of 10 seconds, the above code produces the following output in CloudWatch (notice no echo):

<img width="1514" alt="Screenshot 2021-03-31 at 15 48 57" src="https://user-images.githubusercontent.com/1046961/113169199-47c9cd00-923d-11eb-81b8-3ab0d94d61b1.png">

With a 15 second timeout we see the following (containing the echo's):

<img width="1514" alt="Screenshot 2021-03-31 at 15 47 49" src="https://user-images.githubusercontent.com/1046961/113170021-14d40900-923e-11eb-900c-3506b39d6f70.png">

This PR changes the way output is handled so it is sent to CloudWatch in real time. With the same example script above, and timeouts of 10 and 15 seconds respectively, we now produce the following outputs in CloudWatch (notice the timestamps, which show the 10 second sleep between each echo):

<img width="1514" alt="Screenshot 2021-03-31 at 15 43 24" src="https://user-images.githubusercontent.com/1046961/113170684-b22f3d00-923e-11eb-8542-2e9b1f3b5469.png">

<img width="1514" alt="Screenshot 2021-03-31 at 15 44 00" src="https://user-images.githubusercontent.com/1046961/113170814-d2f79280-923e-11eb-911c-1cf08a0b073c.png">
