### PR TITLE
Fix regression introduced in #903 relating to process timeouts

### DIFF
--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -44,8 +44,9 @@ while (true) {
             $cliOptions = '';
         }
 
+        $timeout = max(1, $context->getRemainingTimeInMillis() / 1000 - 1);
         $command = sprintf('/opt/bin/php %s %s 2>&1', $handlerFile, $cliOptions);
-        $process = Process::fromShellCommandline($command, null, ['LAMBDA_INVOCATION_CONTEXT' => json_encode($context)]);
+        $process = Process::fromShellCommandline($command, null, ['LAMBDA_INVOCATION_CONTEXT' => json_encode($context)], null, $timeout);
 
         $process->run(function ($type, $buffer) {
             echo $buffer;


### PR DESCRIPTION
In #903 we started using the Symfony Process component to execute the handler in the console context. This fixed an issue whereby output from the sub-process wouldn't get flushed to CloudWatch if the Lambda timeout was exceeded. However, as [pointed out](https://github.com/brefphp/bref/pull/903#issuecomment-830712762) by @dhrrgn, this introduced another problem whereby if the sub-process doesn't finish before the default timeout in Symfony Process (60s), it would be terminated, even if the Lambda timeout hasn't been reached.

As suggested in the linked comment above, this change updates the way we invoke the Process component to specify a timeout of 1 second less than the Lambda timeout. Aligning the timeouts in this way means the sub-process will always either complete gracefully (i.e. before the timeout) or the Process component will terminate it and we'll see a thrown exception, rather than the Lambda timing out and terminating for us.

To demo the problem, here's the CloudWatch output for a Lambda with a 65s timeout and a PHP handler that sleeps for 61s:

<img width="1496" alt="Screenshot 2021-05-02 at 09 40 03" src="https://user-images.githubusercontent.com/1046961/116807309-610ab580-ab2a-11eb-844e-221589ac9a14.png">

As we can see, even though the Lambda timeout is greater than the sleep, the Process component terminates at 60s.

With the fix in place, here's the output for the exact same scenario:

<img width="1507" alt="Screenshot 2021-05-02 at 09 20 10" src="https://user-images.githubusercontent.com/1046961/116806838-9bbf1e80-ab27-11eb-8def-a789e259d30b.png">

Here's the output for a Lambda with a 10s timeout and an 11s sleep (exception thrown 1s before the Lambda timeout):

<img width="1496" alt="Screenshot 2021-05-02 at 09 26 47" src="https://user-images.githubusercontent.com/1046961/116806987-88f91980-ab28-11eb-9cd8-6a608fa0cd7f.png">

And just for completeness, this is from a Lambda with a 10s timeout and a 5s sleep:

<img width="1496" alt="Screenshot 2021-05-02 at 09 32 33" src="https://user-images.githubusercontent.com/1046961/116807134-54399200-ab29-11eb-9794-e684d09de84d.png">