### PR TITLE
Fix missing libs

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -406,6 +406,13 @@ RUN set -xe; cd ${POSTGRES_BUILD_DIR}/src/include && make install
 # sqlite-devel : Since PHP 7.4 this must be installed (https://github.com/php/php-src/blob/99b8e67615159fc600a615e1e97f2d1cf18f14cb/UPGRADING#L616-L619)
 RUN LD_LIBRARY_PATH= yum install -y readline-devel gettext-devel libicu-devel libxslt-devel sqlite-devel
 
+# Copy libcrypt libs and resolve broken libcrypt.so symlink to solve "missing libcrypt.so" error
+RUN cp -a /usr/lib64/libcrypt* ${INSTALL_DIR}/lib64/
+RUN rm ${INSTALL_DIR}/lib64/libcrypt.so && cd ${INSTALL_DIR}/lib64/ && ln -s libcrypt.so.1 libcrypt.so
+
+# Resolve broken libgpg-error.so symlink
+RUN rm ${INSTALL_DIR}/lib64/libgpg-error.so && cd ${INSTALL_DIR}/lib64/ && ln -s libgpg-error.so.0 libgpg-error.so
+
 RUN cp -a /usr/lib64/libgcrypt.so* ${INSTALL_DIR}/lib64/
 
 # Copy readline shared libs that are not present in amazonlinux2


### PR DESCRIPTION
These modifications are intended to address issue #875  whereby compiled PHP layers are missing libraries, despite successful compilation and deployment.
