### PR TITLE
Fix: running locally using HttpRequestEvent fails with TypeError

### DIFF
--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -20,6 +20,11 @@ abstract class HttpHandler implements Handler
             return ['Lambda is warm'];
         }
 
+        // $event must be an array for HttpRequestEvent but might come in as null
+        if (!is_array($event)) {
+            $event = [];
+        }
+
         $httpEvent = new HttpRequestEvent($event);
 
         $response = $this->handleRequest($httpEvent, $context);

--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -25,7 +25,7 @@ abstract class HttpHandler implements Handler
             $event = [
                 'requestContext' => [
                     'http' => [
-                        'method' => 'GET'
+                        'method' => 'GET',
                     ],
                 ],
             ];

--- a/src/Event/Http/HttpHandler.php
+++ b/src/Event/Http/HttpHandler.php
@@ -20,9 +20,15 @@ abstract class HttpHandler implements Handler
             return ['Lambda is warm'];
         }
 
-        // $event must be an array for HttpRequestEvent but might come in as null
-        if (!is_array($event)) {
-            $event = [];
+        // If $event is null, set it up as a GET default
+        if ($event === null) {
+            $event = [
+                'requestContext' => [
+                    'http' => [
+                        'method' => 'GET'
+                    ],
+                ],
+            ];
         }
 
         $httpEvent = new HttpRequestEvent($event);


### PR DESCRIPTION
This PR fixes the issue described in https://github.com/brefphp/bref/issues/930.

The README docs [here](https://bref.sh/docs/function/local-development.html) describe local development, and provide the following command examples:

```
$ vendor/bin/bref local hello
$ vendor/bin/bref local hello '{"name": "Jane"}'
$ vendor/bin/bref local hello --file=event.json
```

The problem is that these don't work if the handlers use `HttpRequestEvent` (i.e. implementing `RequestHandlerInterface`). Currently Bref crashes with a TypeError because `$event` is null but is expected to be an array in `HtpRequestEvent`'s constructor. 

So to ensure the local development docs are honoured for these events, I've implemented a basic GET request in the case where `$event` is `null`. 

An alternative strategy would be to throw an exception in this place to avoid the TypeError. If this is preferred, some documentation on what's expected for running these types of handlers should be also written (and I'm out of my depth here).

Thanks, Scott.