### PR TITLE
Improve error message when invoking Http Event with invalid payload

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit colors="true"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
-         bootstrap="./vendor/autoload.php">
-
-    <testsuites>
-        <testsuite name="small">
-            <directory>./tests/</directory>
-            <exclude>./tests/Sam</exclude>
-        </testsuite>
-        <testsuite name="runtimes">
-            <directory>./tests/Sam</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./vendor/autoload.php">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="small">
+      <directory>./tests/</directory>
+      <exclude>./tests/Sam</exclude>
+    </testsuite>
+    <testsuite name="runtimes">
+      <directory>./tests/Sam</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -26,7 +26,7 @@ final class HttpRequestEvent implements LambdaEvent
     /** @var float */
     private $payloadVersion;
 
-    public function __construct(array $event)
+    public function __construct($event)
     {
         // version 1.0 of the HTTP payload
         if (isset($event['httpMethod'])) {

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -26,6 +26,7 @@ final class HttpRequestEvent implements LambdaEvent
     /** @var float */
     private $payloadVersion;
 
+    /** @param array $event */
     public function __construct($event)
     {
         // version 1.0 of the HTTP payload

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -26,7 +26,9 @@ final class HttpRequestEvent implements LambdaEvent
     /** @var float */
     private $payloadVersion;
 
-    /** @param array $event */
+    /**
+     * @param mixed $event
+     */
     public function __construct($event)
     {
         // version 1.0 of the HTTP payload

--- a/src/Event/InvalidLambdaEvent.php
+++ b/src/Event/InvalidLambdaEvent.php
@@ -11,7 +11,12 @@ final class InvalidLambdaEvent extends Exception
      */
     public function __construct(string $expectedEventType, $event)
     {
-        $eventData = print_r($event, true);
+        if (! $event) {
+            $eventData = 'null';
+        } else {
+            $eventData = print_r($event, true);
+        }
+
         parent::__construct("This handler expected to be invoked with a $expectedEventType event. Instead, the handler was invoked with invalid event data: $eventData");
     }
 }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -3,6 +3,7 @@
 namespace Bref\Test\Event\Http;
 
 use Bref\Event\Http\HttpRequestEvent;
+use Bref\Event\InvalidLambdaEvent;
 
 class HttpRequestEventTest extends CommonHttpTest
 {
@@ -123,5 +124,15 @@ class HttpRequestEventTest extends CommonHttpTest
     protected function assertPathParameters(array $expected): void
     {
         $this->assertEquals($expected, $this->event->getPathParameters());
+    }
+
+    public function test empty invocation will have friendly error message()
+    {
+        $message = 'This handler expected to be invoked with a API Gateway or ALB event. Instead, the handler was invoked with invalid event data: null';
+
+        $this->expectException(InvalidLambdaEvent::class);
+        $this->expectExceptionMessage($message);
+
+        new HttpRequestEvent(null);
     }
 }


### PR DESCRIPTION
#930 reports an issue when using `bref local hello` with an empty payload and an Http lambda. This PR will make the message a bit clearer and consistent with the other invocation events.

Note that PR #931 mentioned 3 invocation styles (e.g. `vendor/bin/bref local hello '{"name": "Jane"}'` and `vendor/bin/bref local hello --file=event.json`) but those don't have the same issue as they already fall under the appropriate error message.

```

 [ERROR] This handler expected to be invoked with a API Gateway or ALB event. Instead, the handler was invoked with
         invalid event data: Array
         (
             [name] => value
         )
```

ping @sc0ttdav3y