### PR TITLE
Added expose_php with “Off“ value to disable the X-Powered-By header

### DIFF
--- a/runtime/layers/fpm/php.ini
+++ b/runtime/layers/fpm/php.ini
@@ -48,3 +48,7 @@ upload_max_filesize=6M
 
 ; Enable the PDO MySQL extension
 extension=pdo_mysql
+
+; Disable the header "X-Powered-By" exposing the installed PHP version
+; e.g. X-Powered-By: PHP/8.0.0
+expose_php=Off


### PR DESCRIPTION
Hello 👋

Just got a pentest from one of my client on a project running with Bref. I got only one "vulnerability" on my list which is the "X-Powered-By" header. 

This PR disable it to avoid showing the PHP version currently in use.

I know I can overwrite it on my side, but I think it's better to overwrite it to enable it rather than to disable it. What do you think?