### PR TITLE
Console runtime: Autodetect region and autodetect full function name

### DIFF
--- a/bref
+++ b/bref
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
 
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
@@ -20,6 +21,28 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
 } else {
     /** @noinspection PhpIncludeInspection */
     require_once __DIR__ . '/../../autoload.php';
+}
+
+function getServerlessInfo($stage, $profile, $io): array
+{
+    $serverlessInfo = new Symfony\Component\Process\Process(
+        ['serverless', 'info','--stage', $stage, '--aws-profile', $profile]
+    );
+    $serverlessInfo->start();
+    $animation = new LoadingAnimation($io);
+    do {
+        $animation->tick('Retrieving the stack');
+        usleep(100 * 1000);
+    } while ($serverlessInfo->isRunning());
+    $animation->clear();
+
+    if (!$serverlessInfo->isSuccessful()) {
+        throw new Exception("'The command `serverless info` failed' ".PHP_EOL.$serverlessInfo->getOutput());
+    }
+
+    $serverlessInfoOutput = Yaml::parse( substr($serverlessInfo->getOutput(), strpos($serverlessInfo->getOutput(), "\n") + 1));
+
+    return ($serverlessInfoOutput);
 }
 
 $app = new Silly\Application('Deploy serverless PHP applications');
@@ -91,13 +114,21 @@ $app->command('init', function (SymfonyStyle $io) {
 /**
  * Run a CLI command in the remote environment.
  */
-$app->command('cli function [--region=] [--profile=] [arguments]*', function (string $function, ?string $region, ?string $profile, array $arguments, SymfonyStyle $io) {
+$app->command('cli function [--profile=] [arguments]*', function (string $function, ?string $profile, array $arguments, SymfonyStyle $io) {
+
+    $profile = $profile ?: getenv('AWS_PROFILE') ?: 'default';
+    $serverlessInfo =getServerlessInfo(null, $profile, $io);
+
     $lambda = new SimpleLambdaClient(
-        $region ?: getenv('AWS_DEFAULT_REGION') ?: 'us-east-1',
-        $profile ?: getenv('AWS_PROFILE') ?: 'default',
+        $serverlessInfo['region'],
+        $profile,
         15 * 60 // maximum duration on Lambda
     );
 
+    // Replace short function name (like in serverless.yml) by full qualified name
+    if ($serverlessInfo['functions'][$function]){
+        $function = $serverlessInfo['functions'][$function];
+    }
     // Because arguments may contain spaces, and are going to be executed remotely
     // as a separate process, we need to escape all arguments.
     $arguments = array_map(static function (string $arg): string {
@@ -166,36 +197,25 @@ $app->command('dashboard [--host=] [--port=] [--profile=] [--stage=]', function 
         return 1;
     }
 
-    $serverlessInfo = new Process(['serverless', 'info', '--stage', $stage, '--aws-profile', $profile]);
-    $serverlessInfo->start();
-    $animation = new LoadingAnimation($io);
-    do {
-        $animation->tick('Retrieving the stack');
-        usleep(100*1000);
-    } while ($serverlessInfo->isRunning());
-    $animation->clear();
-
-    if (!$serverlessInfo->isSuccessful()) {
-        $io->error('The command `serverless info` failed' . PHP_EOL . $serverlessInfo->getOutput());
+    try {
+        $serverlessInfo = getServerlessInfo($stage, $profile, $io);
+    }catch (\Exception $e) {
+        $io->error($e->getMessage());
 
         return 1;
     }
 
-    $serverlessInfoOutput = $serverlessInfo->getOutput();
-
-    $region = [];
-    preg_match('/region: ([a-z0-9-]*)/', $serverlessInfoOutput, $region);
-    $region = $region[1];
-
-    $stack = [];
-    preg_match('/stack: ([a-zA-Z0-9-]*)/', $serverlessInfoOutput, $stack);
-    $stack = $stack[1];
+    $region = $serverlessInfo['region'];
+    $stack = $serverlessInfo['stack'];
 
     $io->writeln("Stack: <fg=yellow>$stack ($region)</>");
 
     $dockerPull = new Process(['docker', 'pull', 'bref/dashboard']);
     $dockerPull->setTimeout(null);
     $dockerPull->start();
+
+    $animation = new LoadingAnimation($io);
+
     do {
         $animation->tick('Retrieving the latest version of the dashboard');
         usleep(100*1000);

--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -46,12 +46,12 @@ To run a console command on AWS Lambda, run `bref cli` on your computer:
 vendor/bin/bref cli <function-name> -- <command>
 ```
 
-`<function-name>` is the name of the function that was deployed on AWS. In our example above that would be `hello-dev` because Serverless adds the stage (by default `dev`) as a suffix.
+`<function-name>` is the name of the function that was define in `serverless.yml`. In our example above that would be `hello`.
 
 Pass your command, arguments and options by putting them after `--`. The `--` delimiter separates between options for the `bref cli` command (before `--`) and your command (after `--`).
 
 ```bash
-vendor/bin/bref cli hello-dev <bref options> -- <your command, your options>
+vendor/bin/bref cli hello <bref options> -- <your command, your options>
 ```
 
 For example:
@@ -61,11 +61,11 @@ For example:
 $ vendor/bin/bref cli hello-dev
 # ...
 
-$ vendor/bin/bref cli hello-dev -- doctrine:migrations:migrate
+$ vendor/bin/bref cli hello -- doctrine:migrations:migrate
 Your database will be migrated.
 To execute the SQL queries run the command with the `--force` option.
 
-$ vendor/bin/bref cli hello-dev -- doctrine:migrations:migrate --force
+$ vendor/bin/bref cli hello -- doctrine:migrations:migrate --force
 Your database has been migrated.
 
 # Use environment variables to configure your AWS credentials


### PR DESCRIPTION
Because it's easier to write `bref cli hello` instead of `bref cli app-dev-hello --region=ue-west-3`