### PR TITLE
Added --update-with-dependencies for Laravel installation

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -15,7 +15,7 @@ First, make sure you have followed the [Installation guide](../installation.md) 
 Next, in an existing Laravel project, install Bref and the [Laravel-Bref package](https://github.com/brefphp/laravel-bridge).
 
 ```
-composer require bref/bref bref/laravel-bridge
+composer require bref/bref bref/laravel-bridge --update-with-dependencies
 ```
 
 Then let's create a `serverless.yml` configuration file:


### PR DESCRIPTION
While waiting https://github.com/aws/aws-sdk-php/issues/2264 to be addressed, we have to use the `--update-with-dependencies` option on `composer require` when installing the laravel-bridge package, otherwise we get a composer error on a fresh install.