### PR TITLE
PHP 8.1 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.1', 8.0', '7.4', '7.3' ]
+                php: [ '8.1', '8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '7.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.1', '8.0', '7.4', '7.3' ]
+                php: [ '8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '7.3'
@@ -37,7 +37,6 @@ jobs:
                     ini-values: expose_php=1
             # See https://github.com/shivammathur/setup-php/issues/280
             -   name: Setup php-fpm
-                if: ${{ matrix.php != '8.0' && matrix.php != '8.1' }}
                 env:
                     version: ${{ matrix.php }}
                 run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.0', '7.4', '7.3' ]
+                php: [ '8.1', 8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '7.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
                     ini-values: expose_php=1
             # See https://github.com/shivammathur/setup-php/issues/280
             -   name: Setup php-fpm
+                if: matrix.php != '8.0' && matrix.php != '8.1'
                 env:
                     version: ${{ matrix.php }}
                 run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
                     ini-values: expose_php=1
             # See https://github.com/shivammathur/setup-php/issues/280
             -   name: Setup php-fpm
-                if: matrix.php != '8.0' && matrix.php != '8.1'
+                if: ${{ matrix.php != '8.0' && matrix.php != '8.1' }}
                 env:
                     version: ${{ matrix.php }}
                 run: |

--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -71,15 +71,17 @@ functions:
 
 The `${...}` notation is the [syntax to use variables](https://serverless.com/framework/docs/providers/aws/guide/variables/) in `serverless.yml`. Bref provides a serverless plugin ("`./vendor/bref/bref`") that provides those variables:
 
+- `${bref:layer.php-81}`
 - `${bref:layer.php-80}`
 - `${bref:layer.php-74}`
 - `${bref:layer.php-73}`
+- `${bref:layer.php-81-fpm}`
 - `${bref:layer.php-80-fpm}`
 - `${bref:layer.php-74-fpm}`
 - `${bref:layer.php-73-fpm}`
 - `${bref:layer.console}`
 
-Bref currently provides runtimes for PHP 7.3, 7.4 and 8.0.
+Bref currently provides runtimes for PHP 7.3, 7.4 and 8.0. It also provides **experimental** runtimes for PHP 8.1.
 
 > `php-80` means PHP 8.0.\*. It is not possible to require a specific "patch" version.
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -62,7 +62,7 @@ docker-images:
 	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev --build-arg PHP_VERSION=73 .
 	cd layers/fpm-dev ; docker build -t bref/php-74-fpm-dev --build-arg PHP_VERSION=74 .
 	cd layers/fpm-dev ; docker build -t bref/php-80-fpm-dev --build-arg PHP_VERSION=80 .
-	cd layers/fpm-dev ; docker build -t bref/php-81-fpm-dev --build-arg PHP_VERSION=81 .
+	#cd layers/fpm-dev ; docker build -t bref/php-81-fpm-dev --build-arg PHP_VERSION=81 . # xdebug not ok
 	cd layers/web; docker build -t bref/fpm-dev-gateway .
 	# Run tests
 	php layers/tests.php

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -6,7 +6,7 @@ publish: layers
 	cd layers ; php publish.php
 
 # Build the layers
-layers: export/console.zip export/php-73.zip export/php-74.zip export/php-80.zip export/php-73-fpm.zip export/php-74-fpm.zip export/php-80-fpm.zip
+layers: export/console.zip export/php-73.zip export/php-74.zip export/php-80.zip export/php-81.zip export/php-73-fpm.zip export/php-74-fpm.zip export/php-80-fpm.zip export/php-81-fpm.zip
 
 # The PHP runtimes
 export/php%.zip: docker-images
@@ -37,26 +37,32 @@ docker-images:
 	cd base ; docker build --file php-73.Dockerfile -t bref/build-php-73 --target build-environment .
 	cd base ; docker build --file php-74.Dockerfile -t bref/build-php-74 --target build-environment .
 	cd base ; docker build --file php-80.Dockerfile -t bref/build-php-80 --target build-environment .
+	cd base ; docker build --file php-81.Dockerfile -t bref/build-php-81 --target build-environment .
 	# Build the whole Dockerfile to generate the cleaned images that will be used in the next step
 	cd base ; docker build --file php-73.Dockerfile -t bref/tmp/cleaned-build-php-73 .
 	cd base ; docker build --file php-74.Dockerfile -t bref/tmp/cleaned-build-php-74 .
 	cd base ; docker build --file php-80.Dockerfile -t bref/tmp/cleaned-build-php-80 .
+	cd base ; docker build --file php-81.Dockerfile -t bref/tmp/cleaned-build-php-81 .
 	# - function
 	cd layers/function ; docker build -t bref/php-73 --build-arg PHP_VERSION=73 .
 	cd layers/function ; docker build -t bref/php-74 --build-arg PHP_VERSION=74 .
 	cd layers/function ; docker build -t bref/php-80 --build-arg PHP_VERSION=80 .
+	cd layers/function ; docker build -t bref/php-81 --build-arg PHP_VERSION=81 .
 	# - fpm
 	cd layers/fpm ; docker build -t bref/php-73-fpm --build-arg PHP_VERSION=73 .
 	cd layers/fpm ; docker build -t bref/php-74-fpm --build-arg PHP_VERSION=74 .
 	cd layers/fpm ; docker build -t bref/php-80-fpm --build-arg PHP_VERSION=80 .
+	cd layers/fpm ; docker build -t bref/php-81-fpm --build-arg PHP_VERSION=81 .
 	# - console
 	cd layers/console ; docker build -t bref/php-73-console --build-arg PHP_VERSION=73 .
 	cd layers/console ; docker build -t bref/php-74-console --build-arg PHP_VERSION=74 .
 	cd layers/console ; docker build -t bref/php-80-console --build-arg PHP_VERSION=80 .
+	cd layers/console ; docker build -t bref/php-81-console --build-arg PHP_VERSION=81 .
 	# Other Docker images
 	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev --build-arg PHP_VERSION=73 .
 	cd layers/fpm-dev ; docker build -t bref/php-74-fpm-dev --build-arg PHP_VERSION=74 .
 	cd layers/fpm-dev ; docker build -t bref/php-80-fpm-dev --build-arg PHP_VERSION=80 .
+	cd layers/fpm-dev ; docker build -t bref/php-81-fpm-dev --build-arg PHP_VERSION=81 .
 	cd layers/web; docker build -t bref/fpm-dev-gateway .
 	# Run tests
 	php layers/tests.php

--- a/runtime/base/php-81.Dockerfile
+++ b/runtime/base/php-81.Dockerfile
@@ -79,7 +79,6 @@ RUN set -xe \
         --disable-cgi \
         --enable-cli \
         --disable-phpdbg \
-        --disable-phpdbg-webhelper \
         --with-sodium \
         --with-readline \
         --with-openssl \

--- a/runtime/base/php-81.Dockerfile
+++ b/runtime/base/php-81.Dockerfile
@@ -46,7 +46,7 @@ RUN set -xe; \
     # --location will follow redirects
     # --silent will hide the progress, but also the errors: we restore error messages with --show-error
     # --fail makes sure that curl returns an error instead of fetching the 404 page
-    curl --location --silent --show-error --fail https://downloads.php.net/~ramsey/php-${VERSION_PHP}.tar.gz/from/this/mirror \
+    curl --location --silent --show-error --fail https://downloads.php.net/~ramsey/php-${VERSION_PHP}.tar.gz \
   | tar xzC ${PHP_BUILD_DIR} --strip-components=1
 # Move into the unpackaged code directory
 WORKDIR  ${PHP_BUILD_DIR}/

--- a/runtime/base/php-81.Dockerfile
+++ b/runtime/base/php-81.Dockerfile
@@ -1,0 +1,140 @@
+# The container we build here contains everything needed to compile PHP + PHP.
+#
+# It can be used as a base to compile extra extensions.
+
+# PHP Build
+# https://github.com/php/php-src/releases
+# Needs:
+#   - zlib
+#   - libxml2
+#   - openssl
+#   - readline
+#   - sodium
+
+FROM bref/tmp/step-1/build-environment as build-environment
+
+
+###############################################################################
+# Oniguruma
+# This library is not packaged in PHP since PHP 7.4.
+# See https://github.com/php/php-src/blob/43dc7da8e3719d3e89bd8ec15ebb13f997bbbaa9/UPGRADING#L578-L581
+# We do not install the system version because I didn't manage to make it work...
+# Ideally we shouldn't compile it ourselves.
+# https://github.com/kkos/oniguruma/releases
+# Needed by:
+#   - php mbstring
+ENV VERSION_ONIG=6.9.6
+ENV ONIG_BUILD_DIR=${BUILD_DIR}/oniguruma
+RUN set -xe; \
+    mkdir -p ${ONIG_BUILD_DIR}; \
+    curl -Ls https://github.com/kkos/oniguruma/releases/download/v${VERSION_ONIG}/onig-${VERSION_ONIG}.tar.gz \
+    | tar xzC ${ONIG_BUILD_DIR} --strip-components=1
+WORKDIR  ${ONIG_BUILD_DIR}/
+RUN set -xe; \
+    ./configure --prefix=${INSTALL_DIR}; \
+    make -j $(nproc); \
+    make install
+
+
+ENV VERSION_PHP=8.1.0beta1
+
+
+ENV PHP_BUILD_DIR=${BUILD_DIR}/php
+RUN set -xe; \
+    mkdir -p ${PHP_BUILD_DIR}; \
+    # Download and upack the source code
+    # --location will follow redirects
+    # --silent will hide the progress, but also the errors: we restore error messages with --show-error
+    # --fail makes sure that curl returns an error instead of fetching the 404 page
+    curl --location --silent --show-error --fail https://downloads.php.net/~ramsey/php-${VERSION_PHP}.tar.gz/from/this/mirror \
+  | tar xzC ${PHP_BUILD_DIR} --strip-components=1
+# Move into the unpackaged code directory
+WORKDIR  ${PHP_BUILD_DIR}/
+
+# Configure the build
+# -fstack-protector-strong : Be paranoid about stack overflows
+# -fpic : Make PHP's main executable position-independent (improves ASLR security mechanism, and has no performance impact on x86_64)
+# -fpie : Support Address Space Layout Randomization (see -fpic)
+# -O3 : Optimize for fastest binaries possible.
+# -I : Add the path to the list of directories to be searched for header files during preprocessing.
+# --enable-option-checking=fatal: make sure invalid --configure-flags are fatal errors instead of just warnings
+# --enable-ftp: because ftp_ssl_connect() needs ftp to be compiled statically (see https://github.com/docker-library/php/issues/236)
+# --enable-mbstring: because otherwise there's no way to get pecl to use it properly (see https://github.com/docker-library/php/issues/195)
+# --with-zlib and --with-zlib-dir: See https://stackoverflow.com/a/42978649/245552
+# --with-pear: necessary for `pecl` to work (to install PHP extensions)
+#
+RUN set -xe \
+ && ./buildconf --force \
+ && CFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+    CPPFLAGS="-fstack-protector-strong -fpic -fpie -O3 -I${INSTALL_DIR}/include -I/usr/include -ffunction-sections -fdata-sections" \
+    LDFLAGS="-L${INSTALL_DIR}/lib64 -L${INSTALL_DIR}/lib -Wl,-O1 -Wl,--strip-all -Wl,--hash-style=both -pie" \
+    ./configure \
+        --build=x86_64-pc-linux-gnu \
+        --prefix=${INSTALL_DIR} \
+        --enable-option-checking=fatal \
+        --enable-sockets \
+        --with-config-file-path=${INSTALL_DIR}/etc/php \
+        --with-config-file-scan-dir=${INSTALL_DIR}/etc/php/conf.d:/var/task/php/conf.d \
+        --enable-fpm \
+        --disable-cgi \
+        --enable-cli \
+        --disable-phpdbg \
+        --disable-phpdbg-webhelper \
+        --with-sodium \
+        --with-readline \
+        --with-openssl \
+        --with-zlib=${INSTALL_DIR} \
+        --with-zlib-dir=${INSTALL_DIR} \
+        --with-curl \
+        --enable-exif \
+        --enable-ftp \
+        --with-gettext \
+        --enable-mbstring \
+        --with-pdo-mysql=shared,mysqlnd \
+        --with-mysqli \
+        --enable-pcntl \
+        --with-zip \
+        --enable-bcmath \
+        --with-pdo-pgsql=shared,${INSTALL_DIR} \
+        --enable-intl=shared \
+        --enable-soap \
+        --with-xsl=${INSTALL_DIR} \
+        --with-pear
+RUN make -j $(nproc)
+# Run `make install` and override PEAR's PHAR URL because pear.php.net is down
+RUN set -xe; \
+ make install PEAR_INSTALLER_URL='https://github.com/pear/pearweb_phars/raw/master/install-pear-nozlib.phar'; \
+ { find ${INSTALL_DIR}/bin ${INSTALL_DIR}/sbin -type f -perm +0111 -exec strip --strip-all '{}' + || true; }; \
+ make clean; \
+ cp php.ini-production ${INSTALL_DIR}/etc/php/php.ini
+
+# Symlink all our binaries into /opt/bin so that Lambda sees them in the path.
+RUN mkdir -p /opt/bin \
+    && cd /opt/bin \
+    && ln -s ../bref/bin/* . \
+    && ln -s ../bref/sbin/* .
+
+# Install extensions
+# We can install extensions manually or using `pecl`
+RUN pecl install APCu
+
+# Run the next step in the previous environment because the `clean.sh` script needs `find`,
+# which isn't installed by default
+FROM build-environment as build-environment-cleaned
+# Remove extra files to make the layers as slim as possible
+COPY clean.sh /tmp/clean.sh
+RUN /tmp/clean.sh && rm /tmp/clean.sh
+
+
+# Now we start back from a clean image.
+# We get rid of everything that is unnecessary (build tools, source code, and anything else
+# that might have created intermediate layers for docker) by copying online the /opt directory.
+FROM public.ecr.aws/lambda/provided:al2
+ENV PATH="/opt/bin:${PATH}" \
+    LD_LIBRARY_PATH="/opt/bref/lib64:/opt/bref/lib"
+
+# Copy everything we built above into the same dir on the base AmazonLinux container.
+COPY --from=build-environment-cleaned /opt /opt
+
+# Set the workdir to the same directory as in AWS Lambda
+WORKDIR /var/task

--- a/runtime/base/php-81.Dockerfile
+++ b/runtime/base/php-81.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=8.1.0beta2
+ENV VERSION_PHP=8.1.0beta3
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php

--- a/runtime/base/php-81.Dockerfile
+++ b/runtime/base/php-81.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=8.1.0beta1
+ENV VERSION_PHP=8.1.0beta2
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php

--- a/runtime/layers/layer-list.php
+++ b/runtime/layers/layer-list.php
@@ -12,6 +12,8 @@ use AsyncAws\Lambda\ValueObject\LayerVersionsListItem;
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 const LAYER_NAMES = [
+    'php-81',
+    'php-81-fpm',
     'php-80',
     'php-80-fpm',
     'php-74',

--- a/runtime/layers/publish.php
+++ b/runtime/layers/publish.php
@@ -9,6 +9,8 @@ use Symfony\Component\Process\Process;
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 $layers = [
+    'php-81' => 'PHP 8.1 for event-driven PHP functions',
+    'php-81-fpm' => 'PHP-FPM 8.1 for web applications',
     'php-80' => 'PHP 8.0 for event-driven PHP functions',
     'php-80-fpm' => 'PHP-FPM 8.0 for web applications',
     'php-74' => 'PHP 7.4 for event-driven PHP functions',

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -65,7 +65,7 @@ $devLayers = [
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
-    'bref/php-81-fpm-dev',
+    // 'bref/php-81-fpm-dev',
 ];
 $devExtensions = [
     'xdebug',

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -18,7 +18,7 @@ $allLayers = [
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
-    'bref/php-81-fpm-dev',
+    // 'bref/php-81-fpm-dev',
 ];
 foreach ($allLayers as $layer) {
     // Working directory

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -32,8 +32,8 @@ foreach ($allLayers as $layer) {
     echo '.';
 
     // Test extensions load correctly
-    // Skip this for PHP 8.0 until all extensions are supported
-    if (strpos($layer, 'php-80') === false) {
+    // Skip this for PHP 8.0 and 8.1 until all extensions are supported
+    if (strpos($layer, 'php-8') === false) {
         exec("docker run --rm -v \${PWD}/helpers:/var/task/ --entrypoint /var/task/extensions-test.sh $layer", $output, $exitCode);
         if ($exitCode !== 0) {
             throw new Exception(implode(PHP_EOL, $output), $exitCode);

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -51,7 +51,7 @@ $fpmLayers = [
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
-    'bref/php-81-fpm-dev',
+    // 'bref/php-81-fpm-dev',
 ];
 foreach ($fpmLayers as $layer) {
     // PHP-FPM is installed

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -10,12 +10,15 @@ $allLayers = [
     'bref/php-73',
     'bref/php-74',
     'bref/php-80',
+    'bref/php-81',
     'bref/php-73-fpm',
     'bref/php-74-fpm',
     'bref/php-80-fpm',
+    'bref/php-81-fpm',
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
+    'bref/php-81-fpm-dev',
 ];
 foreach ($allLayers as $layer) {
     // Working directory
@@ -44,9 +47,11 @@ $fpmLayers = [
     'bref/php-73-fpm',
     'bref/php-74-fpm',
     'bref/php-80-fpm',
+    'bref/php-81-fpm',
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
+    'bref/php-81-fpm-dev',
 ];
 foreach ($fpmLayers as $layer) {
     // PHP-FPM is installed
@@ -60,6 +65,7 @@ $devLayers = [
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
+    'bref/php-81-fpm-dev',
 ];
 $devExtensions = [
     'xdebug',


### PR DESCRIPTION
This pull request adds [PHP 8.1](https://www.php.net/archive/2021.php#2021-08-19-1) runtimes (PHP 8.1.0beta3)
Heavily inspired from #678

### To test it:



Name | Version | Compatible runtimes | Version ARN
-- | -- | -- | --
php-81 | 3 | provided.al2 | arn:aws:lambda:us-east-1:670541007614:layer:php-81:3
php-81-fpm | 3 | provided.al2 | arn:aws:lambda:us-east-1:670541007614:layer:php-81-fpm:3

