### PR TITLE
Custom extra bootstrap step

### DIFF
--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -26,6 +26,12 @@ if (getenv('BREF_DOWNLOAD_VENDOR')) {
     require $appRoot . '/vendor/autoload.php';
 }
 
+$customBootstrap = $appRoot . '/lambda_bootstrap.php';
+if (file_exists($customBootstrap)) {
+    /** @noinspection PhpIncludeInspection */
+    require_once $customBootstrap;
+}
+
 $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 
 $handlerFile = $appRoot . '/' . getenv('_HANDLER');

--- a/runtime/layers/fpm/bootstrap
+++ b/runtime/layers/fpm/bootstrap
@@ -25,6 +25,12 @@ if (getenv('BREF_DOWNLOAD_VENDOR')) {
     require $appRoot . '/vendor/autoload.php';
 }
 
+$customBootstrap = $appRoot . '/lambda_bootstrap.php';
+if (file_exists($customBootstrap)) {
+    /** @noinspection PhpIncludeInspection */
+    require_once $customBootstrap;
+}
+
 $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 
 $handlerFile = $appRoot . '/' . getenv('_HANDLER');

--- a/runtime/layers/function/bootstrap.php
+++ b/runtime/layers/function/bootstrap.php
@@ -24,6 +24,12 @@ if (getenv('BREF_DOWNLOAD_VENDOR')) {
     require $appRoot . '/vendor/autoload.php';
 }
 
+$customBootstrap = $appRoot . '/lambda_bootstrap.php';
+if (file_exists($customBootstrap)) {
+    /** @noinspection PhpIncludeInspection */
+    require_once $customBootstrap;
+}
+
 $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
 
 $container = Bref::getContainer();


### PR DESCRIPTION
While using bref with Laravel I wanted to cache the framework's config 
but after looking a bit at the source of both bref and laravel/vapor-core 
I realized this can only be done while bootstraping the runtime.

Caching Laravel's configuration is one use case for this new feature but
it could also be used to pre load some variables from ssm into the environement
just as laravel/vapor-core does.

I am actually pretty sure there is a broad array of potential use cases that I
haven't though about. So all in all letting people run a bit of their code during
the bootstrap process seems like a good idea.
