### PR TITLE
Test the codebase against php 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
                     # sudo apt-get install -y php$version-fpm
                     whereis php
                     which php
+                    whereis php-fpm
+                    php-fpm -v
                     sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
                     echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
             -   name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
                 env:
                     version: ${{ matrix.php }}
                 run: |
-                    sudo apt-get install -y php$version-fpm
+                    # sudo apt-get install -y php$version-fpm
+                    whereis php
+                    which php
                     sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
                     echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
             -   name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         strategy:
-            fail-fast: false
             matrix:
                 php: [ '8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
                     which php
                     whereis php-fpm
                     php-fpm -v
-                    sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
+                    # sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
                     echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
             -   name: Install dependencies
                 run: 'composer update ${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [ '8.1', '8.0', '7.4', '7.3' ]
+                php: [ '8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]
                 platform-reqs: [ '' ]
                 include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,17 +38,13 @@ jobs:
                     ini-values: expose_php=1
             # See https://github.com/shivammathur/setup-php/issues/280
             -   name: Setup php-fpm
+                if: ${{ matrix.php != '8.1' }}
                 env:
                     version: ${{ matrix.php }}
                 run: |
-                    # sudo apt-get install -y php$version-fpm
-                    whereis php
-                    which php
-                    whereis php-fpm
-                    php-fpm -v
-                    php -i | grep ini
-                    # sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
-                    # echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
+                    sudo apt-get install -y php$version-fpm
+                    sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
+                    echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
             -   name: Install dependencies
                 run: 'composer update ${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ignore-platform-req=php'
             -   name: Execute Unit Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.1', '8.0', '7.4', '7.3' ]
+                php: [ '8.1' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '7.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         timeout-minutes: 15
         strategy:
             matrix:
-                php: [ '8.0', '7.4', '7.3' ]
+                php: [ '8.1', '8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '7.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         strategy:
+            fail-fast: false
             matrix:
-                php: [ '8.1' ]
+                php: [ '8.1', '8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]
                 include:
                     -   php: '7.3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,12 @@ jobs:
             matrix:
                 php: [ '8.1', '8.0', '7.4', '7.3' ]
                 dependency-version: [ '' ]
+                platform-reqs: [ '' ]
                 include:
                     -   php: '7.3'
                         dependency-version: '--prefer-lowest'
+                    -   php: '8.1'
+                        platform-reqs: '--ignore-platform-req=php' # see https://github.com/phpspec/prophecy/pull/533#issuecomment-891606803
         steps:
             -   name: Checkout
                 uses: actions/checkout@v2
@@ -46,7 +49,7 @@ jobs:
                     sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
                     echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
             -   name: Install dependencies
-                run: 'composer update ${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ignore-platform-req=php'
+                run: 'composer update ${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress ${{ matrix.platform-reqs }}'
             -   name: Execute Unit Tests
                 run: 'vendor/bin/phpunit --testsuite small'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
                     # sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
                     # echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
             -   name: Install dependencies
-                run: 'composer update ${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress'
+                run: 'composer update ${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ignore-platform-req=php'
             -   name: Execute Unit Tests
                 run: 'vendor/bin/phpunit --testsuite small'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,9 @@ jobs:
                     which php
                     whereis php-fpm
                     php-fpm -v
+                    php -i | grep ini
                     # sudo cp /usr/sbin/php-fpm$version /usr/bin/php-fpm # copy to /usr/bin
-                    echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
+                    # echo 'expose_php=1' | sudo tee -a /etc/php/$version/fpm/php.ini
             -   name: Install dependencies
                 run: 'composer update ${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress'
             -   name: Execute Unit Tests

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -732,7 +732,8 @@ Year,Make,Model
             ],
             'body' => $body,
         ];
-        $this->assertGlobalVariables($event, [
+
+        $expectedGlobalVariables = [
             '$_GET' => [],
             '$_POST' => [],
             '$_FILES' => [
@@ -742,6 +743,7 @@ Year,Make,Model
                     'error' => 0,
                     'size' => 57,
                     'content' => "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit.\n",
+                    'full_path' => 'lorem.txt',
                 ],
                 'bar' => [
                     'name' => 'cars.csv',
@@ -749,6 +751,7 @@ Year,Make,Model
                     'error' => 0,
                     'size' => 51,
                     'content' => "Year,Make,Model\n1997,Ford,E350\n2000,Mercury,Cougar\n",
+                    'full_path' => 'cars.csv',
                 ],
             ],
             '$_COOKIE' => [],
@@ -767,7 +770,15 @@ Year,Make,Model
                 'LAMBDA_REQUEST_CONTEXT' => '[]',
             ],
             'HTTP_RAW_BODY' => '',
-        ]);
+        ];
+
+        if (\PHP_VERSION_ID < 80100) {
+            // full_path was introduced in PHP 8.1, remove it for lower versions
+            unset($expectedGlobalVariables['$_FILES']['foo']['full_path']);
+            unset($expectedGlobalVariables['$_FILES']['bar']['full_path']);
+        }
+
+        $this->assertGlobalVariables($event, $expectedGlobalVariables);
     }
 
     /**
@@ -1117,7 +1128,7 @@ Year,Make,Model
         // Test global variables that never change (simplifies all the tests)
         $response = $this->assertCommonServerVariables($response, $expectedGlobalVariables);
 
-        self::assertArraySubset($expectedGlobalVariables, $response);
+        self::assertEquals($expectedGlobalVariables, $response);
     }
 
     private function assertCommonServerVariables(array $response, array $expectedGlobalVariables): array

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -1117,7 +1117,7 @@ Year,Make,Model
         // Test global variables that never change (simplifies all the tests)
         $response = $this->assertCommonServerVariables($response, $expectedGlobalVariables);
 
-        self::assertEquals($expectedGlobalVariables, $response);
+        self::assertArraySubset($expectedGlobalVariables, $response);
     }
 
     private function assertCommonServerVariables(array $response, array $expectedGlobalVariables): array


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
As PHP 8.1 is coming and support is already considered in https://github.com/brefphp/bref/pull/980, I think its needed to run tests against 8.1 in the CI to ensure that the code doesn't break and eventually spot something, be it in Bref, php or a downstream dependency.