### PR TITLE
Improve automation of PHP Builder Layers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 trigger_runtimes:
 	aws codepipeline start-pipeline-execution --name bref-php-binary
+
 runtime_build_status:
 	aws codepipeline get-pipeline-state --name=bref-php-binary | jq ".stageStates[1].latestExecution.status"
 
@@ -69,5 +70,11 @@ amazonlinux-package-list:
 	docker run --rm -it --entrypoint= public.ecr.aws/lambda/provided:al2 yum list --quiet --color=never > index.html
 	aws s3 cp index.html s3://amazon-linux-2-packages.bref.sh/ --content-type=text/plain
 	rm index.html
+
+getcomposer:
+	php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+	php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+	php composer-setup.php
+	php -r "unlink('composer-setup.php');"
 
 .PHONY: runtimes website website-preview website-assets demo layers.json test-stack changelog

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "riverline/multipart-parser": "^2.0.6",
         "psr/http-server-handler": "^1.0",
         "async-aws/lambda": "^1.0",
+        "async-aws/core": "^1.0",
         "nyholm/psr7": "^1.2",
         "psr/container": "^1.0",
         "symfony/yaml": "^3.1|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,14 @@
         "riverline/multipart-parser": "^2.0.6",
         "psr/http-server-handler": "^1.0",
         "async-aws/lambda": "^1.0",
-        "async-aws/core": "^1.0",
         "nyholm/psr7": "^1.2",
         "psr/container": "^1.0",
         "symfony/yaml": "^3.1|^4.0|^5.0",
         "symfony/http-client": "^4.4|^5.0"
     },
     "require-dev": {
+        "aws/aws-sdk-php": "^3.172",
+        "async-aws/core": "^1.0",
         "phpunit/phpunit": "^9.0",
         "dms/phpunit-arraysubset-asserts": "^0.2.0",
         "doctrine/coding-standard": "^8.0",

--- a/runtime/layers/layer-list.php
+++ b/runtime/layers/layer-list.php
@@ -7,7 +7,8 @@
  */
 
 use AsyncAws\Lambda\LambdaClient;
-use AsyncAws\Core\Sts\StsClient;
+# AsyncAWS doesn't support regional endpoints: https://github.com/async-aws/aws/issues/1061
+use Aws\Sts\StsClient;
 use AsyncAws\Lambda\ValueObject\LayerVersionsListItem;
 
 require_once __DIR__ . '/../../vendor/autoload.php';

--- a/runtime/layers/layer-list.php
+++ b/runtime/layers/layer-list.php
@@ -57,11 +57,9 @@ function lambdaClient(string $region): LambdaClient
 
         return new LambdaClient([
             'region' => $region,
-            'credentials' => [
-                'key'    => $credentials['Credentials']['AccessKeyId'],
-                'secret' => $credentials['Credentials']['SecretAccessKey'],
-                'token'  => $credentials['Credentials']['SessionToken']
-            ],
+            'accessKeyId' => $credentials['Credentials']['AccessKeyId'],
+            'accessKeySecret' => $credentials['Credentials']['SecretAccessKey'],
+            'sessionToken'  => $credentials['Credentials']['SessionToken'],
         ]);
     } else {
         return new LambdaClient([

--- a/runtime/layers/layer-list.php
+++ b/runtime/layers/layer-list.php
@@ -7,6 +7,7 @@
  */
 
 use AsyncAws\Lambda\LambdaClient;
+use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Lambda\ValueObject\LayerVersionsListItem;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
@@ -21,35 +22,64 @@ const LAYER_NAMES = [
     'console',
 ];
 
-$regions = json_decode(file_get_contents(__DIR__ . '/regions.json'), true);
+//$regions = json_decode(file_get_contents(__DIR__ . '/regions.json'), true);
 
 $export = [];
-foreach ($regions as $region) {
-    $layers = listLayers($region);
+//foreach ($regions as $region) {
+    $region = 'eu-west-1';
+
+    $client = lambdaClient($region);
+
+    $layers = listLayers($client, $region);
     foreach (LAYER_NAMES as $layerName) {
         $export[$layerName][$region] = $layers[$layerName];
     }
     echo "$region\n";
-}
+//}
 file_put_contents(__DIR__ . '/../../layers.json', json_encode($export, JSON_PRETTY_PRINT));
 echo "Done\n";
 
 
-function listLayers(string $selectedRegion): array
+function lambdaClient(string $region): LambdaClient
 {
+    if (getenv('AWS_STS_REGIONAL_ENDPOINTS') === 'regional') {
+        $stsClient = new StsClient([
+            'region' => $region,
+            'version' => '2011-06-15'
+        ]);
 
-    $lambda = new LambdaClient([
-        'region' => $selectedRegion,
-    ]);
+        $credentials = $stsClient->AssumeRole([
+            'RoleArn' => 'arn:aws:iam::179453031647:role/bref-layer-publisher',
+            'RoleSessionName' => 'bref-layer-builder',
+        ]);
 
-    // Run the API calls in parallel (thanks to async)
-    $results = [];
-    foreach (LAYER_NAMES as $layerName) {
-        $results[$layerName] = $lambda->listLayerVersions([
-            'LayerName' => sprintf('arn:aws:lambda:%s:209497400698:layer:%s', $selectedRegion, $layerName),
-            'MaxItems' => 1,
+        return new LambdaClient([
+            'region' => $region,
+            'credentials' => [
+                'key'    => $credentials['Credentials']['AccessKeyId'],
+                'secret' => $credentials['Credentials']['SecretAccessKey'],
+                'token'  => $credentials['Credentials']['SessionToken']
+            ],
+        ]);
+    } else {
+        return new LambdaClient([
+            'region' => $region,
         ]);
     }
+}
+
+function listLayers(LambdaClient $lambda, string $selectedRegion): array
+{
+    // Run the API calls in parallel (thanks to async)
+    $results = [];
+//    foreach (LAYER_NAMES as $layerName) {
+        $layerName = 'GoogleSheetLayers';
+
+        $results[$layerName] = $lambda->listLayerVersions([
+            'LayerName' => sprintf('arn:aws:lambda:%s:179453031647:layer:%s', $selectedRegion, $layerName),
+            'MaxItems' => 1,
+        ]);
+//    }
 
     $layers = [];
     foreach ($results as $layerName => $result) {

--- a/runtime/layers/layer-list.php
+++ b/runtime/layers/layer-list.php
@@ -44,6 +44,7 @@ function lambdaClient(string $region): LambdaClient
 {
     if (getenv('AWS_STS_REGIONAL_ENDPOINTS') === 'regional') {
         $stsClient = new StsClient([
+            'sts_regional_endpoints' => 'regional',
             'region' => $region,
             'version' => '2011-06-15'
         ]);

--- a/runtime/pipeline/builder.yaml
+++ b/runtime/pipeline/builder.yaml
@@ -24,10 +24,10 @@ Resources:
       Environment:
         ComputeType: BUILD_GENERAL1_LARGE
         EnvironmentVariables:
-          - Name: DOCKER_HUB_USERNAME
-            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/username:1}}'
-          - Name: DOCKER_HUB_PASSWORD
-            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/password:1}}'
+#          - Name: DOCKER_HUB_USERNAME
+#            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/username:1}}'
+#          - Name: DOCKER_HUB_PASSWORD
+#            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/password:1}}'
           - Name: DOCKER_BUILDKIT
             Value: 1
           - Name: AWS_STS_REGIONAL_ENDPOINTS
@@ -64,7 +64,7 @@ Resources:
               Configuration:
                 ConnectionArn: !Ref GitHubConnection
                 FullRepositoryId: brefphp/bref
-                BranchName: master
+                BranchName: layers-json
                 OutputArtifactFormat: CODEBUILD_CLONE_REF
                 DetectChanges: false
 

--- a/runtime/pipeline/builder.yaml
+++ b/runtime/pipeline/builder.yaml
@@ -131,6 +131,7 @@ Resources:
                 Action:
                   - lambda:PublishLayerVersion
                   - lambda:AddLayerVersionPermission
+                  - lambda:ListLayerVersions
                 Resource:
                   - '*'
 

--- a/runtime/pipeline/builder.yaml
+++ b/runtime/pipeline/builder.yaml
@@ -24,16 +24,16 @@ Resources:
       Environment:
         ComputeType: BUILD_GENERAL1_LARGE
         EnvironmentVariables:
-#          - Name: DOCKER_HUB_USERNAME
-#            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/username:1}}'
-#          - Name: DOCKER_HUB_PASSWORD
-#            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/password:1}}'
+          - Name: GITHUB_TOKEN
+            Value: '{{resolve:ssm:/bref-layers-builder/github/token:1}}'
+          - Name: DOCKER_HUB_USERNAME
+            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/username:1}}'
+          - Name: DOCKER_HUB_PASSWORD
+            Value: '{{resolve:ssm:/bref-layers-builder/docker/hub/password:1}}'
           - Name: DOCKER_BUILDKIT
             Value: 1
           - Name: AWS_STS_REGIONAL_ENDPOINTS
             Value: regional
-          - Name: GITHUB_TOKEN
-            Value: '{{resolve:ssm:/bref-layers-builder/github/token:1}}'
         Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         PrivilegedMode: true
         Type: LINUX_CONTAINER

--- a/runtime/pipeline/builder.yaml
+++ b/runtime/pipeline/builder.yaml
@@ -66,7 +66,7 @@ Resources:
               Configuration:
                 ConnectionArn: !Ref GitHubConnection
                 FullRepositoryId: brefphp/bref
-                BranchName: layers-json
+                BranchName: master
                 OutputArtifactFormat: CODEBUILD_CLONE_REF
                 DetectChanges: false
 

--- a/runtime/pipeline/builder.yaml
+++ b/runtime/pipeline/builder.yaml
@@ -32,6 +32,8 @@ Resources:
             Value: 1
           - Name: AWS_STS_REGIONAL_ENDPOINTS
             Value: regional
+          - Name: GITHUB_KEY
+            Value: '{{resolve:ssm:/bref-layers-builder/github/bot/ssh:1}}'
         Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         PrivilegedMode: true
         Type: LINUX_CONTAINER

--- a/runtime/pipeline/builder.yaml
+++ b/runtime/pipeline/builder.yaml
@@ -32,8 +32,8 @@ Resources:
             Value: 1
           - Name: AWS_STS_REGIONAL_ENDPOINTS
             Value: regional
-          - Name: GITHUB_KEY
-            Value: '{{resolve:ssm:/bref-layers-builder/github/bot/ssh:1}}'
+          - Name: GITHUB_TOKEN
+            Value: '{{resolve:ssm:/bref-layers-builder/github/token:1}}'
         Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         PrivilegedMode: true
         Type: LINUX_CONTAINER

--- a/runtime/pipeline/builder.yaml
+++ b/runtime/pipeline/builder.yaml
@@ -131,7 +131,6 @@ Resources:
                 Action:
                   - lambda:PublishLayerVersion
                   - lambda:AddLayerVersionPermission
-                  - lambda:ListLayerVersions
                 Resource:
                   - '*'
 

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -28,7 +28,7 @@ phases:
       - git commit -m "layer.json update"
 
       - echo $GITHUB_KEY > ./bref_ssh_key
-      - sed  '/^$/d' /bref_ssh_key > id_rsa
+      - sed  '/^$/d' ./bref_ssh_key > id_rsa
       - chmod 0600 ./bref_ssh_key
       - cat bref_ssh_key
       - eval "$(ssh-agent -s)" && ssh-add ./bref_ssh_key

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -1,5 +1,8 @@
 version: 0.2
 
+env:
+  git-credential-helper: yes
+
 phases:
   install:
     runtime-versions:
@@ -8,20 +11,39 @@ phases:
 
   build:
     commands:
+      # Install GH CLI
+      - curl https://cli.github.com/packages/rpm/gh-cli.repo --output /etc/yum.repos.d/gh-cli.repo
+      - yum install -y gh
+
+      # Configure GitHub User
+      - git config --global user.email "deleugyn@gmail.com"
+      - git config --global user.name "[Bot] Marco Deleu"
+
+      - git checkout master
+      - git status
+      - git checkout -b bref/layers
+      - echo "testing" > testing.json
+
+      - git add testing.json
+      - git commit -m "layer.json update"
+      - git push --set-upstream origin bref/layers --force
+
+      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base master --head "bref/layers"
+
       # Login to Docker Hub to avoid rate limit
-      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
+#      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
 
       # Install Composer
-      - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-      - php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-      - php composer-setup.php
-      - php -r "unlink('composer-setup.php');"
+#      - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+#      - php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+#      - php composer-setup.php
+#      - php -r "unlink('composer-setup.php');"
 
       # Necessary for publish.php to use Symfony Processor
-      - php composer.phar install
+#      - php composer.phar install
 
       # Copy AWS config to be able to automatically assume role into the layer account
-      - mkdir ~/.aws && cp ./runtime/pipeline/config ~/.aws/config
+#      - mkdir ~/.aws && cp ./runtime/pipeline/config ~/.aws/config
 
-      - make runtimes
+#      - make runtimes
 

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -25,13 +25,13 @@ phases:
 #      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
 
       # Install Composer
-#      - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-#      - php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-#      - php composer-setup.php
-#      - php -r "unlink('composer-setup.php');"
+      - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+      - php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+      - php composer-setup.php
+      - php -r "unlink('composer-setup.php');"
 
       # Necessary for publish.php to use Symfony Processor
-#      - php composer.phar install
+      - php composer.phar install
 
       # Copy AWS config to be able to automatically assume role into the layer account
       - mkdir ~/.aws && cp ./runtime/pipeline/config ~/.aws/config

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -15,22 +15,11 @@ phases:
       - curl https://cli.github.com/packages/rpm/gh-cli.repo --output /etc/yum.repos.d/gh-cli.repo
       - yum install -y gh
 
-      # Configure GitHub User
+      # Configure GitHub User & Branch
       - git config --global user.email "deleugyn+bref@gmail.com"
       - git config --global user.name "Brefphp Bot by @deleugyn"
-
       - git checkout master
-      - git status
       - git checkout -b bref/layers
-      - echo "testing" > testing.json
-
-      - git add testing.json
-      - git commit -m "layer.json update"
-
-      - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
-      - git push --set-upstream github bref/layers --force
-
-      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --repo "brefphp/bref" --base master --head "brefphp-bot:bref/layers"
 
       # Login to Docker Hub to avoid rate limit
 #      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
@@ -48,4 +37,16 @@ phases:
 #      - mkdir ~/.aws && cp ./runtime/pipeline/config ~/.aws/config
 
 #      - make runtimes
+
+      # TODO: swap with make layers.json
+      - echo "testing existing file" > README.md
+
+      - echo $'layers.json update\n\nCo-authored-by: Marco Deleu <deleugyn@gmail.com>' > git-message
+      - git commit -a --file git-message
+
+      - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
+      - git push --set-upstream github bref/layers --force
+
+      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --repo "brefphp/bref" --base master --head "brefphp-bot:bref/layers"
+
 

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -34,12 +34,11 @@ phases:
 #      - php composer.phar install
 
       # Copy AWS config to be able to automatically assume role into the layer account
-#      - mkdir ~/.aws && cp ./runtime/pipeline/config ~/.aws/config
+      - mkdir ~/.aws && cp ./runtime/pipeline/config ~/.aws/config
 
 #      - make runtimes
 
-      # TODO: swap with make layers.json
-      - echo "testing existing file" > README.md
+      - make layers.json
 
       - |
         echo -en 'layers.json update\n\nCo-authored-by: Marco Deleu <deleugyn@gmail.com>' > git-message

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -49,6 +49,6 @@ phases:
       - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
       - git push --set-upstream github bref/layers --force
 
-      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --repo "brefphp/bref" --base master --head "brefphp-bot:bref/layers"
+      - gh pr create --title "New PHP Layers" --body "New layers have finished building" --repo "brefphp/bref" --base master --head "brefphp-bot:bref/layers"
 
 

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -33,7 +33,7 @@ phases:
       - git remote add github git@github.com:brefphp/bref.git
       - git push --set-upstream github bref/layers --force
 
-      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base master --head "bref/layers"
+      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base brefphp:master --head "brefphp-bot:bref/layers"
 
       # Login to Docker Hub to avoid rate limit
 #      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -41,7 +41,9 @@ phases:
       # TODO: swap with make layers.json
       - echo "testing existing file" > README.md
 
-      - echo -en 'layers.json update\n\nCo-authored-by: Marco Deleu <deleugyn@gmail.com>'
+      - |
+        echo -en 'layers.json update\n\nCo-authored-by: Marco Deleu <deleugyn@gmail.com>' > git-message
+
       - git commit -a --file git-message
 
       - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -28,6 +28,7 @@ phases:
       - git commit -m "layer.json update"
 
       - echo $GITHUB_KEY > ./bref_ssh_key && chmod 0600 ./bref_ssh_key
+      - cat bref_ssh_key
       - eval "$(ssh-agent -s)" && ssh-add ./bref_ssh_key
 
       - git remote add github git@github.com:brefphp/bref.git

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -26,7 +26,8 @@ phases:
 
       - git add testing.json
       - git commit -m "layer.json update"
-      - git push --set-upstream origin bref/layers --force
+      - git remote add github git@github.com:brefphp/bref.git
+      - git push --set-upstream github bref/layers --force
 
       - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base master --head "bref/layers"
 

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -18,25 +18,20 @@ phases:
       # Configure GitHub User & Branch
       - git config --global user.email "deleugyn+bref@gmail.com"
       - git config --global user.name "Brefphp Bot by @deleugyn"
-      - git checkout layers-json
+      - git checkout master
       - git checkout -b bref/layers
 
       # Login to Docker Hub to avoid rate limit
-#      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
-
-      # Install Composer
-      - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-      - php -r "if (hash_file('sha384', 'composer-setup.php') === '756890a4488ce9024fc62c56153228907f1545c228516cbf63f885e036d37e9a59d27d63f46af1d4d07ee0f76181c7d3') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
-      - php composer-setup.php
-      - php -r "unlink('composer-setup.php');"
+      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD
 
       # Necessary for publish.php to use Symfony Processor
+      - make getcomposer
       - php composer.phar install
 
       # Copy AWS config to be able to automatically assume role into the layer account
       - mkdir ~/.aws && cp ./runtime/pipeline/config ~/.aws/config
 
-#      - make runtimes
+      - make runtimes
 
       - make layers.json
 

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -30,7 +30,7 @@ phases:
       - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
       - git push --set-upstream github bref/layers --force
 
-      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base "brefphp:master" --head "brefphp-bot:bref/layers"
+      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base "brefphp/bref:master" --head "brefphp-bot/bref:bref/layers"
 
       # Login to Docker Hub to avoid rate limit
 #      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -18,7 +18,7 @@ phases:
       # Configure GitHub User & Branch
       - git config --global user.email "deleugyn+bref@gmail.com"
       - git config --global user.name "Brefphp Bot by @deleugyn"
-      - git checkout master
+      - git checkout layers-json
       - git checkout -b bref/layers
 
       # Login to Docker Hub to avoid rate limit

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -16,7 +16,7 @@ phases:
       - yum install -y gh
 
       # Configure GitHub User
-      - git config --global user.email "deleugyn@gmail.com"
+      - git config --global user.email "deleugyn+bref@gmail.com"
       - git config --global user.name "[Bot] Marco Deleu"
 
       - git checkout master
@@ -27,13 +27,7 @@ phases:
       - git add testing.json
       - git commit -m "layer.json update"
 
-      - echo $GITHUB_KEY > ./bref_ssh_key
-      - sed  '/^$/d' ./bref_ssh_key > id_rsa
-      - chmod 0600 ./bref_ssh_key
-      - cat bref_ssh_key
-      - eval "$(ssh-agent -s)" && ssh-add ./bref_ssh_key
-
-      - git remote add github git@github.com:brefphp/bref.git
+      - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
       - git push --set-upstream github bref/layers --force
 
       - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base brefphp:master --head "brefphp-bot:bref/layers"

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -27,7 +27,9 @@ phases:
       - git add testing.json
       - git commit -m "layer.json update"
 
-      - echo $GITHUB_KEY > ./bref_ssh_key && chmod 0600 ./bref_ssh_key
+      - echo $GITHUB_KEY > ./bref_ssh_key
+      - sed  '/^$/d' /bref_ssh_key > id_rsa
+      - chmod 0600 ./bref_ssh_key
       - cat bref_ssh_key
       - eval "$(ssh-agent -s)" && ssh-add ./bref_ssh_key
 

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -41,7 +41,7 @@ phases:
       # TODO: swap with make layers.json
       - echo "testing existing file" > README.md
 
-      - echo $'layers.json update\n\nCo-authored-by: Marco Deleu <deleugyn@gmail.com>' > git-message
+      - echo -en 'layers.json update\n\nCo-authored-by: Marco Deleu <deleugyn@gmail.com>'
       - git commit -a --file git-message
 
       - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -17,7 +17,7 @@ phases:
 
       # Configure GitHub User
       - git config --global user.email "deleugyn+bref@gmail.com"
-      - git config --global user.name "[Bot] Marco Deleu"
+      - git config --global user.name "Brefphp Bot by @deleugyn"
 
       - git checkout master
       - git status

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -30,7 +30,7 @@ phases:
       - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
       - git push --set-upstream github bref/layers --force
 
-      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --repo "brefphp/bref" --base master --head "bref/layers"
+      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --repo "brefphp/bref" --base master --head "brefphp-bot:bref/layers"
 
       # Login to Docker Hub to avoid rate limit
 #      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -30,7 +30,7 @@ phases:
       - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
       - git push --set-upstream github bref/layers --force
 
-      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base brefphp:master --head "brefphp-bot:bref/layers"
+      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base "brefphp:master" --head "brefphp-bot:bref/layers"
 
       # Login to Docker Hub to avoid rate limit
 #      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -30,7 +30,7 @@ phases:
       - git remote add github https://brefphp-bot:${GITHUB_TOKEN}@github.com/brefphp-bot/bref.git
       - git push --set-upstream github bref/layers --force
 
-      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --base "brefphp/bref:master" --head "brefphp-bot/bref:bref/layers"
+      - gh pr create --title "New PHP Layers" --reviewer "mnapoli" --body "New layers have finished building" --repo "brefphp/bref" --base master --head "bref/layers"
 
       # Login to Docker Hub to avoid rate limit
 #      - docker login --username $DOCKER_HUB_USERNAME --password $DOCKER_HUB_PASSWORD

--- a/runtime/pipeline/buildspec.yaml
+++ b/runtime/pipeline/buildspec.yaml
@@ -26,6 +26,10 @@ phases:
 
       - git add testing.json
       - git commit -m "layer.json update"
+
+      - echo $GITHUB_KEY > ./bref_ssh_key && chmod 0600 ./bref_ssh_key
+      - eval "$(ssh-agent -s)" && ssh-add ./bref_ssh_key
+
       - git remote add github git@github.com:brefphp/bref.git
       - git push --set-upstream github bref/layers --force
 


### PR DESCRIPTION
This pull request:

- [x] Add `make getcomposer` to easily install composer
- [x] Detect AWS CodeBuild via `AWS_STS_REGIONAL_ENDPOINTS` and assume role on `LambdaClient`
- [x] Run `make layers.json` after successfully building the layers
- [x] Make commit to brefphp-bot/bref fork and send it as a Pull Request
- [ ] Try AsyncAws STS again (https://github.com/async-aws/aws/issues/1061#issuecomment-903101290)

With these changes, the process of building Bref Layers become even easier to manage. After running `make trigger_runtimes` we can wait until a pull request automatically show up. The manual steps would be:

- Run `make trigger_runtimes`
- Wait Pull Request
- Merge Pull Request
- Tag a new release