### PR TITLE
Support for events without size attribute

### DIFF
--- a/src/Event/S3/S3Record.php
+++ b/src/Event/S3/S3Record.php
@@ -41,7 +41,7 @@ final class S3Record
     public function getObject(): BucketObject
     {
         $bucket = $this->record['s3']['object'];
-        return new BucketObject($bucket['key'], $bucket['size'], $bucket['versionId'] ?? null);
+        return new BucketObject($bucket['key'], $bucket['size'] ?? 0, $bucket['versionId'] ?? null);
     }
 
     public function getEventTime(): DateTimeImmutable

--- a/tests/Event/S3/S3EventTest.php
+++ b/tests/Event/S3/S3EventTest.php
@@ -37,4 +37,12 @@ class S3EventTest extends TestCase
         $this->expectExceptionMessage('This handler expected to be invoked with a S3 event. Instead, the handler was invoked with invalid event data');
         new S3Event([]);
     }
+
+    public function test event without size attribute()
+    {
+        $event = json_decode(file_get_contents(__DIR__ . '/s3-object-removed.json'), true);
+
+        $record = (new S3Event($event))->getRecords()[0];
+        $this->assertSame(0, $record->getObject()->getSize());
+    }
 }

--- a/tests/Event/S3/s3-object-removed.json
+++ b/tests/Event/S3/s3-object-removed.json
@@ -1,0 +1,36 @@
+{
+    "Records":[
+        {
+            "eventVersion":"2.1",
+            "eventSource":"aws:s3",
+            "awsRegion":"us-east-1",
+            "eventTime":"2019-08-05T15:30:00.000Z",
+            "eventName":"ObjectRemoved:Delete",
+            "userIdentity":{
+                "principalId":"SEDAJDPLKLG7UEXAMPLE"
+            },
+            "requestParameters":{
+                "sourceIPAddress":"127.0.0.1"
+            },
+            "responseElements":{
+                "x-amz-request-id":"C3D13FE58DE4C810",
+                "x-amz-id-2":"FMyUVURIY8/IgAtTv8xRjskZQpcIZ9KG4V5Wp6S7S/JRWeUWerMUE5JgHvANOjpD"
+            },
+            "s3":{
+                "s3SchemaVersion":"1.0",
+                "configurationId":"testConfigRule",
+                "bucket":{
+                    "name":"mybucket",
+                    "ownerIdentity":{
+                        "principalId":"A3NL1KOZZKExample"
+                    },
+                    "arn":"arn:aws:s3:::mybucket"
+                },
+                "object":{
+                    "key":"folder/hello.jpg",
+                    "eTag":"d41d8cd98f00b204e9800998ecf8427e"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
I stumbled upon an undocumented inconsistency in the AWS API. The `s3:ObjectRemoved:Delete` event should have a `size` attribute. [The documentation says so](https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html).

I've send a message to AWS about this, but it seems to be an old problem. [This Stackoverflow question](https://stackoverflow.com/questions/48546482/how-to-get-file-size-from-aws-s3-objectremoveddelete-event) from January 2018 mentions the same issue.

But this inconsistency breaks Bref, because it requires a `size` attribute in `S3Record->getObject()`. This solution is a bit hacky, but making `BucketObject->size` nullable or remove it for this kind of events breaks backward compatibility.

Hopefully we can find a solution for this annoying problem.