### PR TITLE
Remove init command for console apps in the docs

### DIFF
--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -21,7 +21,7 @@ The lambda function used for running console applications must use two Lambda la
 - the base PHP layer that provides the `php` binary,
 - the `console` layer that overrides the base runtime to execute our console commands.
 
-Below is a minimal `serverless.yml`. To create it automatically run `vendor/bin/bref init` and select "Console application".
+Below is a minimal `serverless.yml`.
 
 ```yaml
 service: app


### PR DESCRIPTION
As reported in https://github.com/brefphp/bref/issues/997, the `init` command doesn't offer the option to create a `Console Application` anymore.

If there is no plan to reintroduce it, this should be removed to avoid confusion.