### PR TITLE
feat(runtimes): build and publish PHP 8.1 docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,11 @@ publish-docker-images: docker-images
 	  "bref/php-73" "bref/php-73-fpm" "bref/php-73-console" "bref/php-73-fpm-dev" \
 	  "bref/php-74" "bref/php-74-fpm" "bref/php-74-console" "bref/php-74-fpm-dev" \
 	  "bref/php-80" "bref/php-80-fpm" "bref/php-80-console" "bref/php-80-fpm-dev" \
+	  "bref/php-81" "bref/php-81-fpm" "bref/php-81-console" "bref/php-81-fpm-dev" \
 	  "bref/build-php-73" \
 	  "bref/build-php-74" \
 	  "bref/build-php-80" \
+	  "bref/build-php-81" \
 	  "bref/fpm-dev-gateway"; \
 	do \
 		docker image tag $$image:latest $$image:${DOCKER_TAG} ; \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -62,7 +62,7 @@ docker-images:
 	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev --build-arg PHP_VERSION=73 .
 	cd layers/fpm-dev ; docker build -t bref/php-74-fpm-dev --build-arg PHP_VERSION=74 .
 	cd layers/fpm-dev ; docker build -t bref/php-80-fpm-dev --build-arg PHP_VERSION=80 .
-	#cd layers/fpm-dev ; docker build -t bref/php-81-fpm-dev --build-arg PHP_VERSION=81 . # xdebug not ok
+	cd layers/fpm-dev ; docker build -t bref/php-81-fpm-dev --build-arg PHP_VERSION=81 --target=without_extensions .
 	cd layers/web; docker build -t bref/fpm-dev-gateway .
 	# Run tests
 	php layers/tests.php

--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -1,4 +1,16 @@
 ARG PHP_VERSION
+FROM bref/php-${PHP_VERSION}-fpm as without_extensions
+
+# Override the config so that PHP-FPM listens on port 9000
+COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
+
+EXPOSE 9001
+
+# Clear the parent entrypoint
+ENTRYPOINT []
+
+ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d:/var/task/php/conf.dev.d"
+
 FROM bref/build-php-$PHP_VERSION as build_extensions
 
 RUN pecl install xdebug
@@ -12,18 +24,6 @@ FROM bref/php-${PHP_VERSION}-fpm as build_dev
 USER root
 COPY --from=build_extensions /tmp/*.so /tmp/
 RUN cp /tmp/*.so $(php -r "echo ini_get('extension_dir');")
-
-FROM bref/php-${PHP_VERSION}-fpm as without_extensions
-
-# Override the config so that PHP-FPM listens on port 9000
-COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
-
-EXPOSE 9001
-
-# Clear the parent entrypoint
-ENTRYPOINT []
-
-ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d:/var/task/php/conf.dev.d"
 
 # Run PHP-FPM
 # opcache.validate_timestamps=1 : cancels the flag in the base configuration so that files are reloaded

--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -13,9 +13,8 @@ USER root
 COPY --from=build_extensions /tmp/*.so /tmp/
 RUN cp /tmp/*.so $(php -r "echo ini_get('extension_dir');")
 
-FROM bref/php-${PHP_VERSION}-fpm
+FROM bref/php-${PHP_VERSION}-fpm as without_extensions
 
-COPY --from=build_dev  /opt /opt
 # Override the config so that PHP-FPM listens on port 9000
 COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
 
@@ -29,3 +28,7 @@ ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d:/var/task/ph
 # Run PHP-FPM
 # opcache.validate_timestamps=1 : cancels the flag in the base configuration so that files are reloaded
 CMD /opt/bin/php-fpm --nodaemonize --fpm-config /opt/bref/etc/php-fpm.conf -d opcache.validate_timestamps=1 --force-stderr
+
+FROM without_extensions
+
+COPY --from=build_dev  /opt /opt

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -18,7 +18,7 @@ $allLayers = [
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
-    // 'bref/php-81-fpm-dev',
+    'bref/php-81-fpm-dev',
 ];
 foreach ($allLayers as $layer) {
     // Working directory
@@ -51,7 +51,7 @@ $fpmLayers = [
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
-    // 'bref/php-81-fpm-dev',
+    'bref/php-81-fpm-dev',
 ];
 foreach ($fpmLayers as $layer) {
     // PHP-FPM is installed


### PR DESCRIPTION
:whale: will allow to test locally bref with php 8.1 when the docker images will get published :tada: 
:point_right: Related to https://github.com/brefphp/bref/pull/980/files#r695552502
:warning: For now xdebug & blackfire are not included because no php 8.1 version available yet.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
