### PR TITLE
Let LambdaRuntime::processNextEvent() return boolean

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -89,9 +89,10 @@ final class LambdaRuntime
      *     $lambdaRuntime->processNextEvent(function ($event, Context $context) {
      *         return 'Hello ' . $event['name'] . '. We have ' . $context->getRemainingTimeInMillis()/1000 . ' seconds left';
      *     });
+     * @return bool true if event was successfully handled
      * @throws Exception
      */
-    public function processNextEvent($handler): void
+    public function processNextEvent($handler): bool
     {
         [$event, $context] = $this->waitNextInvocation();
         \assert($context instanceof Context);
@@ -104,7 +105,11 @@ final class LambdaRuntime
             $this->sendResponse($context->getAwsRequestId(), $result);
         } catch (\Throwable $e) {
             $this->signalFailure($context->getAwsRequestId(), $e);
+
+            return false;
         }
+
+        return true;
     }
 
     /**

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -48,10 +48,11 @@ class LambdaRuntimeTest extends TestCase
     {
         $this->givenAnEvent(['Hello' => 'world!']);
 
-        $this->runtime->processNextEvent(function () {
+        $output = $this->runtime->processNextEvent(function () {
             return ['hello' => 'world'];
         });
 
+        $this->assertTrue($output);
         $this->assertInvocationResult(['hello' => 'world']);
     }
 
@@ -73,10 +74,11 @@ class LambdaRuntimeTest extends TestCase
     {
         $this->givenAnEvent(['Hello' => 'world!']);
 
-        $this->runtime->processNextEvent(function () {
+        $output = $this->runtime->processNextEvent(function () {
             throw new \RuntimeException('This is an exception');
         });
 
+        $this->assertFalse($output);
         $this->assertInvocationErrorResult('RuntimeException', 'This is an exception');
         $this->assertErrorInLogs('RuntimeException', 'This is an exception');
     }


### PR DESCRIPTION
I would like to know if a handler succeeds or not. Since the LambdaRuntime is echo out data on error, we might run into issues when keeping the process alive for multiple requests. 

See https://github.com/php-runtime/bref/blob/0.1.1/src/BrefRunner.php#L34

A simple fix would be to stop the `while(true)` on error. 