### PR TITLE
Function runtime: force restarting the process for failed invocations

### DIFF
--- a/docs/environment/performances.md
+++ b/docs/environment/performances.md
@@ -90,6 +90,8 @@ In the example above, the PHP process will restart only every 100 invocations, r
 
 In that case, be careful with clearing in-memory data between every event.
 
+> Note: the PHP process will be restarted in case of a failed invocation (PHP exception thrown in the handler).
+
 ## Cold starts
 
 Code on AWS Lambda runs on-demand. When a new Lambda instance boots to handle a request, the initialization time is what we call a *cold start*. To learn more, [you can read this article](https://hackernoon.com/im-afraid-you-re-thinking-about-aws-lambda-cold-starts-all-wrong-7d907f278a4f).

--- a/runtime/layers/function/bootstrap.php
+++ b/runtime/layers/function/bootstrap.php
@@ -40,5 +40,10 @@ while (true) {
     if (++$loops > $loopMax) {
         exit(0);
     }
-    $lambdaRuntime->processNextEvent($handler);
+    $success = $lambdaRuntime->processNextEvent($handler);
+    // In case the execution failed, we force starting a new process regardless of BREF_LOOP_MAX
+    // Why: an exception could have left the application in a non-clean state, this is preventive
+    if (! $success) {
+        exit(0);
+    }
 }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -89,9 +89,10 @@ final class LambdaRuntime
      *     $lambdaRuntime->processNextEvent(function ($event, Context $context) {
      *         return 'Hello ' . $event['name'] . '. We have ' . $context->getRemainingTimeInMillis()/1000 . ' seconds left';
      *     });
+     * @return bool true if event was successfully handled
      * @throws Exception
      */
-    public function processNextEvent($handler): void
+    public function processNextEvent($handler): bool
     {
         [$event, $context] = $this->waitNextInvocation();
         \assert($context instanceof Context);
@@ -104,7 +105,11 @@ final class LambdaRuntime
             $this->sendResponse($context->getAwsRequestId(), $result);
         } catch (\Throwable $e) {
             $this->signalFailure($context->getAwsRequestId(), $e);
+
+            return false;
         }
+
+        return true;
     }
 
     /**

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -48,10 +48,11 @@ class LambdaRuntimeTest extends TestCase
     {
         $this->givenAnEvent(['Hello' => 'world!']);
 
-        $this->runtime->processNextEvent(function () {
+        $output = $this->runtime->processNextEvent(function () {
             return ['hello' => 'world'];
         });
 
+        $this->assertTrue($output);
         $this->assertInvocationResult(['hello' => 'world']);
     }
 
@@ -73,10 +74,11 @@ class LambdaRuntimeTest extends TestCase
     {
         $this->givenAnEvent(['Hello' => 'world!']);
 
-        $this->runtime->processNextEvent(function () {
+        $output = $this->runtime->processNextEvent(function () {
             throw new \RuntimeException('This is an exception');
         });
 
+        $this->assertFalse($output);
         $this->assertInvocationErrorResult('RuntimeException', 'This is an exception');
         $this->assertErrorInLogs('RuntimeException', 'This is an exception');
     }


### PR DESCRIPTION
This is a continuation of #1013.

In the function runtime, the PHP process will now always be restarted if the invocation failed. That change only impacts apps that use `BREF_LOOP_MAX` to keep the process alive.

The reason for this is that, in most cases, a failed invocation means the PHP application threw an exception.

When using `BREF_LOOP_MAX`, the PHP process is kept alive, and it is important for the application to cleanup global state.

If an exception was thrown, it is likely the cleanup wasn't done, or wasn't done properly. It sounds much safer to restart the process.

The downside is a slight performance cost: around 10ms to restart the process. But that provides a safer execution environment.