### PR TITLE
Upgrade to openssl `1.1.1l`

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -117,7 +117,7 @@ RUN set -xe; \
 # Needed by:
 #   - curl
 #   - php
-ENV VERSION_OPENSSL=1.1.1k
+ENV VERSION_OPENSSL=1.1.1l
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"


### PR DESCRIPTION
Fixes [`CVE-2021-3711`](https://nvd.nist.gov/vuln/detail/CVE-2021-3711) (9.8 CRITICAL) and [`CVE-2021-3712`](https://nvd.nist.gov/vuln/detail/CVE-2021-3712) (7.4 HIGH).