### PR TITLE
Collect which layer was used for invocation

### DIFF
--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -26,7 +26,7 @@ if (getenv('BREF_DOWNLOAD_VENDOR')) {
     require $appRoot . '/vendor/autoload.php';
 }
 
-$lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
+$lambdaRuntime = LambdaRuntime::fromEnvironmentVariable('console');
 
 $handlerFile = $appRoot . '/' . getenv('_HANDLER');
 if (! is_file($handlerFile)) {

--- a/runtime/layers/fpm/bootstrap
+++ b/runtime/layers/fpm/bootstrap
@@ -25,7 +25,7 @@ if (getenv('BREF_DOWNLOAD_VENDOR')) {
     require $appRoot . '/vendor/autoload.php';
 }
 
-$lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
+$lambdaRuntime = LambdaRuntime::fromEnvironmentVariable('fpm');
 
 $handlerFile = $appRoot . '/' . getenv('_HANDLER');
 if (! is_file($handlerFile)) {

--- a/runtime/layers/function/bootstrap.php
+++ b/runtime/layers/function/bootstrap.php
@@ -24,7 +24,7 @@ if (getenv('BREF_DOWNLOAD_VENDOR')) {
     require $appRoot . '/vendor/autoload.php';
 }
 
-$lambdaRuntime = LambdaRuntime::fromEnvironmentVariable();
+$lambdaRuntime = LambdaRuntime::fromEnvironmentVariable('function');
 
 $container = Bref::getContainer();
 

--- a/runtime/ping/statsd.config.json
+++ b/runtime/ping/statsd.config.json
@@ -1,0 +1,7 @@
+  {
+    "debug": false,
+    "backends": ["aws-cloudwatch-statsd-backend"],
+    "cloudwatch": {
+      "region": "EU_WEST_1"
+    }
+  }

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -35,7 +35,7 @@ class LambdaRuntimeTest extends TestCase
     {
         ob_start();
         Server::start();
-        $this->runtime = new LambdaRuntime('localhost:8126');
+        $this->runtime = new LambdaRuntime('localhost:8126', 'phpunit');
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This Pull Request introduces a new StatsD metric to analyse Bref usage among different layers. One open question before merging is whether we want to collect PHP Version in use. My initial idea is that we can follow Composer installation stats to see php version usage trend, which makes the layer the most important informmation to extract from Bref.

Since LambdaRuntime is an internal and final class, we won't consider this a breaking change.