### PR TITLE
Add docs about applications with Symfony Runtime

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -68,6 +68,10 @@ menu:
                     text: Symfony
                     url: /docs/frameworks/symfony.html
                     title: Learn how to deploy serverless Symfony applications
+                symfony-runtime:
+                    text: Symfony Runtime
+                    url: /docs/frameworks/symfony-runtime.html
+                    title: Learn how to deploy serverless application prowed by the Runtime component
 
     functions:
         -   section: 'Bref for <strong class="text-gray-700">event-driven functions</strong>'

--- a/docs/frameworks/symfony-runtime.md
+++ b/docs/frameworks/symfony-runtime.md
@@ -4,7 +4,7 @@ current_menu: symfony-runtime
 introduction: Learn how to deploy serverless applications on AWS Lambda using Bref and Symfony Runtime component.
 ---
 
-The Symfony Runtime runtime component was release with Symfony 5.3. All new Symfony
+The Symfony Runtime component was released with Symfony 5.3. All new Symfony
 applications are using that component as default, but the component can also be
 used with non-Symfony applications.
 

--- a/docs/frameworks/symfony-runtime.md
+++ b/docs/frameworks/symfony-runtime.md
@@ -1,0 +1,48 @@
+---
+title: Serverless applications with Symfony Runtime
+current_menu: symfony-runtime
+introduction: Learn how to deploy serverless applications on AWS Lambda using Bref and Symfony Runtime component.
+---
+
+The Symfony Runtime runtime component was release with Symfony 5.3. All new Symfony
+applications are using that component as default, but the component can also be
+used with non-Symfony applications.
+
+This guide helps you run any PHP applications on AWS Lambda using Bref and the Symfony
+Runtime component.
+
+## Setup
+
+First, **follow the [Installation guide](../installation.md)** to create an AWS
+account and install the necessary tools.
+
+Next, in an any project using the [Symfony Runtime](https://symfony.com/doc/current/components/runtime.html),
+install the Bref Runtime package.
+
+```
+composer require runtime/bref
+```
+
+If you are using [Symfony Flex](https://flex.symfony.com/), it will automatically run
+the [runtime/bref recipe](https://github.com/symfony/recipes/tree/master/runtime/bref/0.2)
+which will perform the following tasks:
+
+- Create a `serverless.yml` configuration file.
+- Add the `.serverless` folder to the `.gitignore` file.
+- Add a `bootstrap` file in the project root.
+
+> Otherwise, you can create the files yourself at the root of your project.
+Take a look at the [serverless.yml](https://github.com/symfony/recipes/tree/master/runtime/bref/0.2/serverless.yaml)
+and [bootstrap](https://github.com/symfony/recipes/tree/master/runtime/bref/0.2/bootstrap)
+provided by the recipe.
+
+You may still have a few modifications to do make your application compatible
+with AWS Lambda. Since [the filesystem is readonly](/docs/environment/storage.md)
+except for `/tmp` we need to customize where to store the cache, logs etc.
+
+Take a look at the [Laravel](laravel.md) or [Symfony](symfony.md) setup guides how
+they solve the problem.
+
+## Deploy
+
+The application is now ready to be deployed. Follow [the deployment guide](/docs/deploy.md).


### PR DESCRIPTION
I thought about making this part of the existing Symfony page, however, it didn't really fit. First, the Runtime component works very well with Symfony apps, Laravel app, PSR-15 apps and pure PHP applications. I also didnt want to remove docs how to use Bref with non-runtime symfony applications. 

That is why I added a new page. This page describe how to install and deploy a pure PHP application with the Runtime component. If you want to add assets you still need to read the Symfony/Laravel docs. 

This PR follows the recipe: https://github.com/symfony/recipes/pull/1001