### PR TITLE
Make function layer support normal lambda and runtime

### DIFF
--- a/runtime/layers/function/bootstrap
+++ b/runtime/layers/function/bootstrap
@@ -3,9 +3,17 @@
 # Fail on error
 set -e
 
+# if APP_RUNTIME does not exist
+if [[ -z "${APP_RUNTIME}" ]]; then
+  BOOTSTRAP="/opt/bref/bootstrap.php"
+else
+  # Split _HANDLER on ":" and take the first part
+  BOOTSTRAP=(${_HANDLER//:/ })
+fi
+
 while true
 do
     # We redirect stderr to stdout so that everything
     # written on the output ends up in Cloudwatch automatically
-    /opt/bin/php "/opt/bref/bootstrap.php" 2>&1
+    /opt/bin/php "${BOOTSTRAP}" 2>&1
 done


### PR DESCRIPTION
This is an alternative to #889 

It will reuse the function layer. It will avoid using `bootstrap.php` if `APP_RUNTIME` is defined. 

FYI @deleugpn 