### PR TITLE
Rewrite query string parsing to avoid use parse_str

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -339,35 +339,35 @@ final class HttpRequestEvent implements LambdaEvent
             }
 
             $tokens = explode('[', $key);
-            $current = &$parameters;
-            foreach ($tokens as $idx => $token) {
-                if ($idx !== 0 && substr($token, -1) !== ']') {
-                    // Malformed string: unclosed parameter index
-                    return [];
+            $tokenCount = count($tokens);
+            for ($i = 1; $i < $tokenCount; ++$i) {
+                if (substr($tokens[$i], -1) === ']') {
+                    continue;
                 }
 
+                // Malformed string: unclosed parameter index
+                $tokens = [implode('[', $tokens)];
+                break;
+            }
+
+            $current = &$parameters;
+            foreach ($tokens as $idx => $token) {
+                $token = preg_replace('/]$/', '', $token);
                 if ($idx === count($tokens) - 1) {
-                    if ($token === ']') {
+                    if ($token === '') {
                         $current[] = $value;
                         break;
                     }
 
-                    $token = preg_replace('/]$/', '', $token);
                     $current[$token] = $value;
                     break;
                 }
 
-                if ($token === ']') {
+                if ($token === '') {
                     $current[] = [];
                     end($current);
                     $nextKey = key($current);
                 } else {
-                    $token = preg_replace('/]$/', '', $token);
-                    if ($idx === count($tokens) - 1) {
-                        $current[$token] = $value;
-                        break;
-                    }
-
                     if (! isset($current[$token])) {
                         $current[$token] = [];
                     }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -135,4 +135,75 @@ class HttpRequestEventTest extends CommonHttpTest
 
         new HttpRequestEvent(null);
     }
+
+    /**
+     * @dataProvider provide Querystrings
+     */
+    public function test querystring will be parsed correctly(array $expected, string $normalizedQs, string $queryString)
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'version' => '2.0',
+            'rawQueryString' => $queryString,
+        ]);
+
+        self::assertSame($expected, $event->getQueryParameters());
+        self::assertSame($normalizedQs, $event->getQueryString());
+    }
+
+    public function provide Querystrings()
+    {
+        return [
+            [[], '', ''],
+            [['foo' => 'bar'], 'foo=bar', 'foo=bar'],
+            [['foo' => 'bar'], 'foo=bar', '   foo=bar  '],
+            [['foo' => 'bar'], 'foo=bar', '?foo=bar'],
+            [['foo' => 'bar'], 'foo=bar', '#foo=bar'],
+            [['foo' => 'bar'], 'foo=bar', '&foo=bar'],
+            [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo', 'foo=bar&bar=foo'],
+            [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo', 'foo=bar&&bar=foo'],
+            [['foo' => ['bar' => ['baz' => ['bax' => 'bar']]]], 'foo%5Bbar%5D%5Bbaz%5D%5Bbax%5D=bar', 'foo[bar][baz][bax]=bar'],
+            [['foo' => ['bar' => 'bar']], 'foo%5Bbar%5D=bar', 'foo[bar] [baz]=bar'],
+            [['foo' => ['bar' => ['baz' => ['bar', 'foo']]]], 'foo%5Bbar%5D%5Bbaz%5D%5B0%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B1%5D=foo', 'foo[bar][baz][]=bar&foo[bar][baz][]=foo'],
+            [['foo' => ['bar' => [['bar'], ['foo']]]], 'foo%5Bbar%5D%5B0%5D%5B0%5D=bar&foo%5Bbar%5D%5B1%5D%5B0%5D=foo', 'foo[bar][][]=bar&foo[bar][][]=foo'],
+            [['option' => ''], 'option=', 'option'],
+            [['option' => '0'], 'option=0', 'option=0'],
+            [['option' => '1'], 'option=1', 'option=1'],
+            [['foo' => 'bar=bar=='], 'foo=bar%3Dbar%3D%3D', 'foo=bar=bar=='],
+            [['options' => ['option' => '0']], 'options%5Boption%5D=0', 'options[option]=0'],
+            [['options' => ['option' => 'foobar']], 'options%5Boption%5D=foobar', 'options[option]=foobar'],
+            [['sum' => '10\\2=5'], 'sum=10%5C2%3D5', 'sum=10%5c2%3d5'],
+
+            // Special cases
+            [
+                [
+                    'a' => '<==  foo bar  ==>',
+                    'b' => '###Hello World###',
+                ],
+                'a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+                'a=%3c%3d%3d%20%20foo+bar++%3d%3d%3e&b=%23%23%23Hello+World%23%23%23',
+            ],
+            [
+                ['str' => "A string with containing \0\0\0 nulls"],
+                'str=A+string+with+containing+%00%00%00+nulls',
+                'str=A%20string%20with%20containing%20%00%00%00%20nulls',
+            ],
+            [
+                [
+                    'arr_1' => 'sid',
+                    'arr' => ['4' => 'fred'],
+                ],
+                'arr%5B1=sid&arr%5B4%5D=fred',
+                'arr[1=sid&arr[4][2=fred',
+            ],
+            [
+                [
+                    'arr_1' => 'sid',
+                    'arr' => ['4' => ['[2' => 'fred']],
+                ],
+                'arr%5B1=sid&arr%5B4%5D%5B%5B2%5D=fred',
+                'arr[1=sid&arr[4][[2][3[=fred',
+            ],
+        ];
+    }
 }

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -115,6 +115,204 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
+    public function test request with with encoded data()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'a=%3c%3d%3d%20%20foo+bar++%3d%3d%3e&b=%23%23%23Hello+World%23%23%23',
+            'queryStringParameters' => [
+                'a' => '<==  foo bar  ==>',
+                'b' => '###Hello World###',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'a' => '<==  foo bar  ==>',
+                'b' => '###Hello World###',
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'a' => '<==  foo bar  ==>',
+                'b' => '###Hello World###',
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with with single quotes()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'firstname=Billy&surname=O%27Reilly',
+            'queryStringParameters' => [
+                'firstname' => 'Billy',
+                'surname' => 'O\'Reilly',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'firstname' => 'Billy',
+                'surname' => 'O\'Reilly',
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'firstname' => 'Billy',
+                'surname' => 'O\'Reilly',
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?firstname=Billy&surname=O%27Reilly',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'firstname=Billy&surname=O%27Reilly',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with with backslash characters()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'sum=10%5c2%3d5',
+            'queryStringParameters' => [
+                'sum' => '10\\2=5',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'sum' => '10\\2=5',
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'sum' => '10\\2=5',
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?sum=10%5C2%3D5',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'sum=10%5C2%3D5',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with with null characters()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'str=A%20string%20with%20containing%20%00%00%00%20nulls',
+            'queryStringParameters' => [
+                'str' => "A string with containing \0\0\0 nulls",
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'str' => "A string with containing \0\0\0 nulls",
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'str' => "A string with containing \0\0\0 nulls",
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?str=A+string+with+containing+%00%00%00+nulls',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'str=A+string+with+containing+%00%00%00+nulls',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with with badly formed string()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'arr[1=sid&arr[4][2=fred',
+            'queryStringParameters' => [
+                'arr[1' => 'sid',
+                'arr[4][2' => 'fred',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'arr_1' => 'sid',
+                'arr' => [
+                    '4' => 'fred',
+                ],
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'arr_1' => 'sid',
+                'arr' => [
+                    '4' => 'fred',
+                ],
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?arr%5B1=sid&arr%5B4%5D%5B2=fred',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'arr%5B1=sid&arr%5B4%5D%5B2=fred',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
     /**
      * @dataProvider provide API Gateway versions
      */

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -299,11 +299,11 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
                 ],
             ],
             '$_SERVER' => [
-                'REQUEST_URI' => '/hello?arr%5B1=sid&arr%5B4%5D%5B2=fred',
+                'REQUEST_URI' => '/hello?arr%5B1=sid&arr%5B4%5D=fred',
                 'PHP_SELF' => '/hello',
                 'PATH_INFO' => '/hello',
                 'REQUEST_METHOD' => 'GET',
-                'QUERY_STRING' => 'arr%5B1=sid&arr%5B4%5D%5B2=fred',
+                'QUERY_STRING' => 'arr%5B1=sid&arr%5B4%5D=fred',
                 'CONTENT_LENGTH' => '0',
                 'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
                 'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -115,7 +115,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test request with with encoded data()
+    public function test request with encoded data()
     {
         $event = [
             'version' => '2.0',
@@ -155,7 +155,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test request with with single quotes()
+    public function test request with single quotes()
     {
         $event = [
             'version' => '2.0',
@@ -195,7 +195,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test request with with backslash characters()
+    public function test request with backslash characters()
     {
         $event = [
             'version' => '2.0',
@@ -232,7 +232,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test request with with null characters()
+    public function test request with null characters()
     {
         $event = [
             'version' => '2.0',
@@ -269,7 +269,7 @@ class FpmHandlerTest extends TestCase implements HttpRequestProxyTest
         ]);
     }
 
-    public function test request with with badly formed string()
+    public function test request with badly formed string()
     {
         $event = [
             'version' => '2.0',


### PR DESCRIPTION
I've encountered the same problems described in #756, so I've checked how PHP implemented the parse string filter and rewrote it in PHP to avoid using `parse_str` itself.

Spaces and dots are preserved in the resulting array keys.
The behavior of the parser on case of unclosed bracket is retained too.