### PR TITLE
Avoid legacy global endpoint for S3 bucket

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -100,7 +100,7 @@ aws s3 sync public/ s3://<bucket-name>/ --delete --exclude index.php
 Then, the assets need to be included from S3. In the production `.env` file you can now set that variable:
 
 ```dotenv
-MIX_ASSET_URL=https://<bucket-name>.s3.amazonaws.com
+MIX_ASSET_URL=https://<bucket-name>.s3.<region>.amazonaws.com
 ```
 
 ### Assets in templates

--- a/docs/websites.md
+++ b/docs/websites.md
@@ -96,7 +96,7 @@ resources:
 
 Don't forget to replace `<bucket-name>` with the bucket name of your choice. Note that the name must be universally unique within Amazon (so you can't use `assets`) otherwise you'll get this error when you deploy: `Assets - assets already exists.`
 
-After [deploying with `serverless deploy`](/docs/deploy.md), the static files will be served from `https://<bucket>.s3.amazonaws.com/`. Read the next section to upload your files.
+After [deploying with `serverless deploy`](/docs/deploy.md), the static files will be served from `https://<bucket>.s3.<region>.amazonaws.com/`. Read the next section to upload your files.
 
 You can either [setup a custom domain to point to this URL](environment/custom-domains.md#custom-domains-for-static-files-on-s3) or setup CloudFront as explained below.
 


### PR DESCRIPTION
The global S3 endpoint is called [legacy](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility) and creates a redirection response to the region endpoint URL. Using the region endpoint directly, is cheaper and saves one request round trip.