### PR TITLE
Allow installing psr/container:^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "psr/http-server-handler": "^1.0",
         "async-aws/lambda": "^1.0",
         "nyholm/psr7": "^1.2",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "symfony/yaml": "^3.1|^4.0|^5.0",
         "symfony/http-client": "^4.4|^5.0"
     },


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
Fixes #1057

The only breaking change in 2.0 is that the bool type hint has been added on Container::has()

This should not have an impact on Bref internals. 