### PR TITLE
[DOCS] Add DynamoDB cache setup in frameworks docs

### DIFF
--- a/docs/environment/storage.md
+++ b/docs/environment/storage.md
@@ -121,6 +121,6 @@ provider:
                         - dynamodb:UpdateItem
                         - dynamodb:DeleteItem
     environment:
-        # That environment variable will contain the table name
-        DYNAMODB_TABLE: !Ref CacheTable
+        # This environment variable will contain the table name
+        DYNAMODB_CACHE_TABLE: !Ref CacheTable
 ```

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -74,6 +74,28 @@ By default, the Bref bridge will move Laravel's cache directory to `/tmp` to avo
 The `/tmp` directory isn't shared across Lambda instances: while this works, this isn't the ideal solution for production workloads.
 If you plan on actively using the cache, or anything that uses it (like API rate limiting), you should instead use Redis or DynamoDB.
 
+### Using DynamoDB
+
+To use DynamoDB as a cache store, change this configuration in `config/cache.php`
+
+```diff
+  # config/cache.php
+  'dynamodb' => [
+      'driver' => 'dynamodb',
+      'key' => env('AWS_ACCESS_KEY_ID'),
+      'secret' => env('AWS_SECRET_ACCESS_KEY'),
+      'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
+      'table' => env('DYNAMODB_CACHE_TABLE', 'cache'),
+      'endpoint' => env('DYNAMODB_ENDPOINT'),
++     'attributes' => [
++         'key' => 'id',
++         'expiration' => 'ttl',
++     ]  
+  ],
+```
+
+Then follow [this section of the documentation](/docs/environment/storage.md#deploying-dynamodb-tables) to deploy your DynamoDB table using the Serverless Framework.
+
 ## Laravel Artisan
 
 As you may have noticed, we define a function named "artisan" in `serverless.yml`. That function is using the [Console runtime](/docs/runtimes/console.md), which lets us run Laravel Artisan on AWS Lambda.

--- a/docs/frameworks/symfony.md
+++ b/docs/frameworks/symfony.md
@@ -221,4 +221,16 @@ A dedicated Bref package is available for this: [bref/symfony-messenger](https:/
 
 As mentioned above the filesystem is readonly, so if you need a persistent cache it must be stored somewhere else (such as Redis, an RDBMS, or DynamoDB).
 
-A Symfony bundle is available for using AWS DynamoDB as cache backend system: [rikudou/psr6-dynamo-db-bundle](https://github.com/RikudouSage/DynamoDbCachePsr6Bundle)
+### Using DynamoDB for cache
+
+A Symfony bundle is available to use AWS DynamoDB as cache store: [rikudou/psr6-dynamo-db-bundle](https://github.com/RikudouSage/DynamoDbCachePsr6Bundle)
+
+First install the bundle
+
+```bash
+composer require rikudou/psr6-dynamo-db-bundle
+```
+
+Thanks to Symfony Flex, the bundle comes pre-configured to run in Lambda. 
+
+Now, you can follow [this section of the documentation](/docs/environment/storage.md#deploying-dynamodb-tables) to deploy your DynamoDB table using the Serverless Framework.


### PR DESCRIPTION
Having the section about DynamoDB for caching (https://github.com/brefphp/bref/pull/1055) is nice, making it easily discoverable is better.

I think that as a new comer, I wouldn't search this in the Storage section of Bref documentation but it makes sense to have it there.

So I thought it would be nice to add instructions in frameworks docs (Laravel & Symfony) and link to that page. 

For Symfony, it is based on the asumption that the following PR is merged
* https://github.com/symfony/recipes-contrib/pull/1288