### PR TITLE
Add Bahrain, Hong Kong, and Osaka regions

### DIFF
--- a/runtime/layers/regions.json
+++ b/runtime/layers/regions.json
@@ -10,11 +10,14 @@
     "us-east-2",
     "us-west-1",
     "us-west-2",
+    "ap-east-1",
     "ap-south-1",
     "ap-northeast-1",
     "ap-northeast-2",
+    "ap-northeast-3",
     "ap-southeast-1",
     "ap-southeast-2",
     "eu-south-1",
-    "af-south-1"
+    "af-south-1",
+    "me-south-1"
 ]


### PR DESCRIPTION
Things have changed since #681 and Osaka is now a standard AWS region:

https://aws.amazon.com/blogs/aws/aws-asia-pacific-osaka-region-now-open-to-all-with-three-azs-more-services/

Bahrain and Hong Kong need to be enabled manually on your account (opt-in required).