### PR TITLE
Allow only supported Symfony packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "ext-curl": "*",
         "ext-json": "*",
         "mnapoli/silly": "^1.7",
-        "symfony/filesystem": "^3.1|^4.0|^5.0",
-        "symfony/process": "^4.2|^5.0",
+        "symfony/filesystem": "^4.4|^5.3",
+        "symfony/process": "^4.4|^5.3",
         "psr/http-message": "^1.0",
         "hollodotme/fast-cgi-client": "^3.0",
         "riverline/multipart-parser": "^2.0.6",
@@ -32,8 +32,8 @@
         "async-aws/lambda": "^1.0",
         "nyholm/psr7": "^1.2",
         "psr/container": "^1.0|^2.0",
-        "symfony/yaml": "^3.1|^4.0|^5.0",
-        "symfony/http-client": "^4.4|^5.0"
+        "symfony/yaml": "^4.4|^5.3",
+        "symfony/http-client": "^4.4|^5.3"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.172",


### PR DESCRIPTION
According to Symfony release process: https://symfony.com/releases

The only supported versions are: `^4.4` & `^5.3`, thus there is no point to support the older ones.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
