### PR TITLE
Report a custom user agent to AWS Lambda

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -129,6 +129,8 @@ final class LambdaRuntime
             $this->handler = curl_init("http://{$this->apiUrl}/2018-06-01/runtime/invocation/next");
             curl_setopt($this->handler, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($this->handler, CURLOPT_FAILONERROR, true);
+            // Set a custom user agent so that AWS can estimate Bref usage in custom runtimes
+            curl_setopt($this->handler, CURLOPT_USERAGENT, "bref/{$this->layer}/");
         }
 
         // Retrieve invocation ID

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -130,7 +130,8 @@ final class LambdaRuntime
             curl_setopt($this->handler, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($this->handler, CURLOPT_FAILONERROR, true);
             // Set a custom user agent so that AWS can estimate Bref usage in custom runtimes
-            curl_setopt($this->handler, CURLOPT_USERAGENT, "bref/{$this->layer}/");
+            $phpVersion = substr(PHP_VERSION, 0, strpos(PHP_VERSION, '.', 2));
+            curl_setopt($this->handler, CURLOPT_USERAGENT, "bref/{$this->layer}/$phpVersion");
         }
 
         // Retrieve invocation ID


### PR DESCRIPTION
Teams at AWS are interested in estimating the usage of custom runtimes, including Bref, Rust (see https://github.com/awslabs/aws-lambda-rust-runtime/pull/363) and others.

While we already have some stats thanks to Bref ping (https://bref.sh/docs/runtimes/#bref-ping), which I'll detail below, that approach will allow AWS teams to directly get the info, and get that consistently across multiple runtimes.

The technique is to report a custom User-Agent to the Lambda Runtime API. It has been suggested the following pattern:

```
bref/<PHP version>-<Bref version>
```

However currently in the code we don't have the Bref version available in a handy way :/ 

Additionally, I think it's also important to report the layer actually used, because there's a huge difference between the FPM runtime and Function runtime ([more details](https://bref.sh/docs/runtimes/#bref-runtimes)).

Here is what this PR reports instead:

```
bref/<runtime name>/<php-major-minor-version>
```

`<runtime name>` could be `function`, `fpm` or `console` (again, see https://bref.sh/docs/runtimes/#bref-runtimes).

Here are some examples of values:

```
bref/function/8.0
bref/fpm/8.0
bref/function/7.4
bref/fpm/7.4
...
```

## Recap of current Bref stats

Total monthly invocations using Bref runtimes:

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/720328/141454785-866f2361-0218-4e00-8c15-faa709ece1d7.png">

We have passed 4 billion invocations/month.

(the last month is not complete)