### PR TITLE
Support Symfony 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "ext-curl": "*",
         "ext-json": "*",
         "mnapoli/silly": "^1.7",
-        "symfony/filesystem": "^3.1|^4.0|^5.0",
-        "symfony/process": "^4.2|^5.0",
+        "symfony/filesystem": "^3.1|^4.0|^5.0|^6.0",
+        "symfony/process": "^4.2|^5.0|^6.0",
         "psr/http-message": "^1.0",
         "hollodotme/fast-cgi-client": "^3.0",
         "riverline/multipart-parser": "^2.0.6",
@@ -32,8 +32,8 @@
         "async-aws/lambda": "^1.0",
         "nyholm/psr7": "^1.2",
         "psr/container": "^1.0|^2.0",
-        "symfony/yaml": "^3.1|^4.0|^5.0",
-        "symfony/http-client": "^4.4|^5.0"
+        "symfony/yaml": "^3.1|^4.0|^5.0|^6.0",
+        "symfony/http-client": "^4.4|^5.0|^6.0"
     },
     "require-dev": {
         "aws/aws-sdk-php": "^3.172",


### PR DESCRIPTION
Symfony 6.0 was just released.

This PR brings support for the 6.x range of Symfony components

One major BC break for Symfony is the addition of types for arguments and return. 

Let's hope there's no impact :crossed_fingers: 