### PR TITLE
Control FPM timeout to give time to flush out logs

### DIFF
--- a/runtime/layers/fpm/bootstrap
+++ b/runtime/layers/fpm/bootstrap
@@ -32,7 +32,12 @@ if (! is_file($handlerFile)) {
     $lambdaRuntime->failInitialization("Handler `$handlerFile` doesn't exist");
 }
 
+$timeout = getenv('BREF_FPM_TIMEOUT');
+
 $phpFpm = new FpmHandler($handlerFile);
+
+$phpFpm->setTimeout((int) $timeout);
+
 try {
     $phpFpm->start();
 } catch (\Throwable $e) {

--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -48,11 +48,18 @@ final class FpmHandler extends HttpHandler
     private $configFile;
     /** @var Process|null */
     private $fpm;
+    /** @var int */
+    private $timeout = 900000;
 
     public function __construct(string $handler, string $configFile = self::CONFIG)
     {
         $this->handler = $handler;
         $this->configFile = $configFile;
+    }
+
+    public function setTimeout(int $timeout)
+    {
+        $this->timeout = $timeout;
     }
 
     /**
@@ -83,7 +90,7 @@ final class FpmHandler extends HttpHandler
         });
 
         $this->client = new Client;
-        $this->connection = new UnixDomainSocket(self::SOCKET, 1000, 900000);
+        $this->connection = new UnixDomainSocket(self::SOCKET, 1000, $this->timeout);
 
         $this->waitUntilReady();
     }


### PR DESCRIPTION
One of the most common issues we face is with Lambda timeout that doesn't signal anything (logs or etc) when running Lambda inside a VPC without a NAT. This proposal makes it so that FPM timeout faster than Lambda so that there's enough time to at least flush out logs and help developers debug why their lambda is timing out.

One thing to consider is that this solution is FPM-only and doesn't improve the situation on the other layers.