### PR TITLE
Re-enable xdebug in the PHP 8.1 dev container following #980 and #1007

### DIFF
--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -62,7 +62,7 @@ docker-images:
 	cd layers/fpm-dev ; docker build -t bref/php-73-fpm-dev --build-arg PHP_VERSION=73 .
 	cd layers/fpm-dev ; docker build -t bref/php-74-fpm-dev --build-arg PHP_VERSION=74 .
 	cd layers/fpm-dev ; docker build -t bref/php-80-fpm-dev --build-arg PHP_VERSION=80 .
-	cd layers/fpm-dev ; docker build -t bref/php-81-fpm-dev --build-arg PHP_VERSION=81 --target=without_extensions .
+	cd layers/fpm-dev ; docker build -t bref/php-81-fpm-dev --build-arg PHP_VERSION=81 .
 	cd layers/web; docker build -t bref/fpm-dev-gateway .
 	# Run tests
 	php layers/tests.php

--- a/runtime/layers/fpm-dev/Dockerfile
+++ b/runtime/layers/fpm-dev/Dockerfile
@@ -1,20 +1,4 @@
 ARG PHP_VERSION
-FROM bref/php-${PHP_VERSION}-fpm as without_extensions
-
-# Override the config so that PHP-FPM listens on port 9000
-COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
-
-ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d:/var/task/php/conf.dev.d"
-
-EXPOSE 9001
-
-# Clear the parent entrypoint
-ENTRYPOINT []
-
-# Run PHP-FPM
-# opcache.validate_timestamps=1 : cancels the flag in the base configuration so that files are reloaded
-CMD /opt/bin/php-fpm --nodaemonize --fpm-config /opt/bref/etc/php-fpm.conf -d opcache.validate_timestamps=1 --force-stderr
-
 FROM bref/build-php-$PHP_VERSION as build_extensions
 
 RUN pecl install xdebug
@@ -29,9 +13,19 @@ USER root
 COPY --from=build_extensions /tmp/*.so /tmp/
 RUN cp /tmp/*.so $(php -r "echo ini_get('extension_dir');")
 
-FROM without_extensions
+FROM bref/php-${PHP_VERSION}-fpm
 
 COPY --from=build_dev  /opt /opt
-
 # Override the config so that PHP-FPM listens on port 9000
 COPY php-fpm.conf /opt/bref/etc/php-fpm.conf
+
+EXPOSE 9001
+
+# Clear the parent entrypoint
+ENTRYPOINT []
+
+ENV PHP_INI_SCAN_DIR="/opt/bref/etc/php/conf.d:/var/task/php/conf.d:/var/task/php/conf.dev.d"
+
+# Run PHP-FPM
+# opcache.validate_timestamps=1 : cancels the flag in the base configuration so that files are reloaded
+CMD /opt/bin/php-fpm --nodaemonize --fpm-config /opt/bref/etc/php-fpm.conf -d opcache.validate_timestamps=1 --force-stderr

--- a/runtime/layers/tests.php
+++ b/runtime/layers/tests.php
@@ -65,7 +65,7 @@ $devLayers = [
     'bref/php-73-fpm-dev',
     'bref/php-74-fpm-dev',
     'bref/php-80-fpm-dev',
-    // 'bref/php-81-fpm-dev',
+    'bref/php-81-fpm-dev',
 ];
 $devExtensions = [
     'xdebug',


### PR DESCRIPTION
This PR re-enables xdebug and blackfire for PHP 8.1.

These extensions were skipped in #980 and #1007 because they were not ready for PHP 8.1. They now are.

I've reverted the Dockerfile content to an older version: https://github.com/brefphp/bref/blob/126ccf9b90c6a394a35f8551ec69688678786f49/runtime/layers/fpm-dev/Dockerfile