### PR TITLE
Flush FPM logs in case of timeouts

### DIFF
--- a/demo/http.php
+++ b/demo/http.php
@@ -3,6 +3,7 @@
 require __DIR__ . '/../vendor/autoload.php';
 
 if (isset($_GET['sleep'])) {
+    error_log('This is a log');
     sleep(10);
 }
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -25,7 +25,7 @@ functions:
         handler: demo/function.php
         description: 'Bref CLI demo'
         layers:
-            - ${bref:layer.php-74}
+            - ${bref:layer.php-80}
         environment:
             BREF_LOOP_MAX: 100
 
@@ -34,7 +34,7 @@ functions:
         description: 'Bref HTTP demo'
         timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
         layers:
-            - ${bref:layer.php-74-fpm}
+            - ${bref:layer.php-80-fpm}
         events:
             -   http: 'ANY /'
 
@@ -43,7 +43,7 @@ functions:
         description: 'Bref HTTP demo with a PSR-7 handler'
         timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
         layers:
-            - ${bref:layer.php-74}
+            - ${bref:layer.php-80}
         events:
             -   http: 'ANY /psr7'
             -   httpApi: 'GET /psr7'
@@ -55,7 +55,7 @@ functions:
         description: 'Bref HTTP demo'
         timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
         layers:
-            - ${bref:layer.php-74-fpm}
+            - ${bref:layer.php-80-fpm}
         events:
             -   httpApi: '*'
 
@@ -64,5 +64,5 @@ functions:
         description: 'Bref console command demo'
         timeout: 900
         layers:
-            - ${bref:layer.php-74}
+            - ${bref:layer.php-80}
             - ${bref:layer.console}

--- a/src/Event/Http/FastCgi/Timeout.php
+++ b/src/Event/Http/FastCgi/Timeout.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\Http\FastCgi;
+
+/**
+ * There was a timeout while processing the PHP request
+ *
+ * @internal
+ */
+final class Timeout extends \Exception
+{
+    public function __construct(int $taskTimeoutInMs)
+    {
+        $message = "The request timed out after $taskTimeoutInMs ms. "
+            . 'Note: that duration may be lower than the Lambda timeout, don\'t be surprised, that is intentional. '
+            . 'Indeed, Bref stops the PHP-FPM request *before* a hard Lambda timeout, because a hard timeout prevents all logs to be written to CloudWatch.';
+
+        parent::__construct($message);
+    }
+}

--- a/tests/Handler/PhpFpm/timeout.php
+++ b/tests/Handler/PhpFpm/timeout.php
@@ -1,3 +1,5 @@
 <?php declare(strict_types=1);
 
+error_log('This is a log message');
+
 sleep((int) ($_GET['timeout'] ?? 10));


### PR DESCRIPTION
When Lambda times out with the PHP-FPM layer, the logs written by the PHP script are never flushed to stderr by PHP-FPM. **That means logs never reach CloudWatch**, which makes timeouts really hard to debug.

With this change, Bref waits for the FPM response until 1 second before the actual Lambda timeout (via a connection timeout on the FastCGI connection).

If Bref reaches that point, it will ask PHP-FPM to gracefully restart the PHP-FPM worker, which:

- flushes the logs (logs end up in CloudWatch, which is great)
- restarts a clean FPM worker, without doing a full FPM restart (which may take longer)

Follow up of #770, #772, #895, #1106

May address some of #862

Note: this does not change anything for the Function layer (only affects FPM). Also this does not show a full stack track of the place in the code where the timeout happens (#895 did). Still it's an improvement over the current status.

Here is an example of a timeout with the PHP logs correctly written to stderr:

<img width="1652" alt="Screen 2022-01-04 17-24" src="https://user-images.githubusercontent.com/720328/148089630-ebf8505d-bf10-4531-bc87-4adc884eb775.png">

I tried to make the error message as explicit as possible.

---

I would love for some of you to try this PR and confirm that it helps (that PHP logs end up in CloudWatch) and that there are no side effects.

You can do that via `composer.json`:

```diff
-    "bref/bref": "^1.0",
+    "bref/bref": "dev-timeouts-fpm",
```