### PR TITLE
Fill HttpRequestEvent with sourceIp

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -190,6 +190,15 @@ final class HttpRequestEvent implements LambdaEvent
         return $this->event['pathParameters'] ?? [];
     }
 
+    public function getSourceIp(): string
+    {
+        if ($this->isFormatV2()) {
+            return $this->event['requestContext']['http']['sourceIp'] ?? '127.0.0.1';
+        }
+
+        return $this->event['requestContext']['identity']['sourceIp'] ?? '127.0.0.1';
+    }
+
     private function rebuildQueryString(): string
     {
         if ($this->isFormatV2()) {

--- a/src/Event/Http/Psr7Bridge.php
+++ b/src/Event/Http/Psr7Bridge.php
@@ -33,6 +33,7 @@ final class Psr7Bridge
             'QUERY_STRING' => $event->getQueryString(),
             'DOCUMENT_ROOT' => getcwd(),
             'REQUEST_URI' => $event->getUri(),
+            'REMOTE_ADDR' => $event->getSourceIp(),
         ];
 
         $headers = $event->getHeaders();

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -34,6 +34,7 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
         ]);
         $this->assertMethod('GET');
         $this->assertUri('/path');
+        $this->assertSourceIp('1.1.1.1');
     }
 
     /**
@@ -68,6 +69,7 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
         $this->assertServerPort(443);
         $this->assertUri('/path');
         $this->assertHasMultiHeader(false);
+        $this->assertSourceIp('1.1.1.1');
     }
 
     public function test v1 stage prefix is not included in the URL()
@@ -471,6 +473,8 @@ Year,Make,Model
     abstract protected function assertHasMultiHeader(bool $expected): void;
 
     abstract protected function assertParsedBody(array $expected): void;
+
+    abstract protected function assertSourceIp(string $expected): void;
 
     abstract protected function assertUploadedFile(
         string $key,

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -105,6 +105,11 @@ class HttpRequestEventTest extends CommonHttpTest
         $this->assertEquals($expected, $this->event->hasMultiHeader());
     }
 
+    protected function assertSourceIp(string $expected): void
+    {
+        $this->assertEquals($expected, $this->event->getSourceIp());
+    }
+
     protected function assertParsedBody(array $expected): void
     {
         // Not applicable here since the class doesn't parse the body

--- a/tests/Event/Http/Psr7BridgeTest.php
+++ b/tests/Event/Http/Psr7BridgeTest.php
@@ -152,4 +152,9 @@ class Psr7BridgeTest extends CommonHttpTest
         unset($parameters['lambda-event'], $parameters['lambda-context']);
         $this->assertEquals($expected, $parameters);
     }
+
+    protected function assertSourceIp(string $expected): void
+    {
+        $this->assertEquals($expected, $this->request->getServerParams()['REMOTE_ADDR']);
+    }
 }


### PR DESCRIPTION
After fast testing of new version of symfony-bridge (https://github.com/brefphp/symfony-bridge/releases/tag/0.2.0-beta1) we had noticed, what client ip parameter is empty ($_SERVER['REMOTE_ADDR']).

This PR should solve the problem.
