### PR TITLE
Add missing "type" in lift `constructs`

### DIFF
--- a/docs/websites.md
+++ b/docs/websites.md
@@ -90,7 +90,8 @@ Now add your domain name and certificate in your `serverless.yml` file
 ...
 constructs:
   website:
-    # ...
+    # You need to select "type" that matches your needs, see: https://github.com/getlift/lift#constructs
+    type: server-side-website
     domain: mywebsite.com
     certificate: <your certificate ARN>
 ```


### PR DESCRIPTION
Otherwise erros popups:
```
Error:
The construct 'website' has no 'type' defined.
```

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
