### PR TITLE
Upgrade `openssl` to `1.1.1n`

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -117,7 +117,7 @@ RUN set -xe; \
 # Needed by:
 #   - curl
 #   - php
-ENV VERSION_OPENSSL=1.1.1m
+ENV VERSION_OPENSSL=1.1.1n
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"


### PR DESCRIPTION
To address [CVE-2022-0778](https://github.com/advisories/GHSA-x3mh-jvjw-3xwx). Full change log at https://www.openssl.org/news/changelog.html#openssl-111.