### PR TITLE
Upgrade `libxml2` to `2.9.13`

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -275,14 +275,14 @@ RUN set -xe; \
 #   - zlib
 # Needed by:
 #   - php
-ENV VERSION_XML2=2.9.12
+ENV VERSION_XML2=2.9.13
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 
 RUN set -xe; \
     mkdir -p ${XML2_BUILD_DIR}; \
 # Download and upack the source code
-    curl -Ls http://xmlsoft.org/sources/libxml2-${VERSION_XML2}.tar.gz \
-  | tar xzC ${XML2_BUILD_DIR} --strip-components=1
+    curl -Ls https://download.gnome.org/sources/libxml2/2.9/libxml2-${VERSION_XML2}.tar.xz \
+  | tar xJC ${XML2_BUILD_DIR} --strip-components=1
 
 # Move into the unpackaged code directory
 WORKDIR  ${XML2_BUILD_DIR}/


### PR DESCRIPTION
Fixes CVE-2022-23308 and other security issues not assigned a CVE. See https://gitlab.gnome.org/GNOME/libxml2/-/blob/master/NEWS#L10.