### PR TITLE
close #1187: we log the AWS request id when timeout-ing

### DIFF
--- a/src/Event/Http/FastCgi/Timeout.php
+++ b/src/Event/Http/FastCgi/Timeout.php
@@ -9,9 +9,9 @@ namespace Bref\Event\Http\FastCgi;
  */
 final class Timeout extends \Exception
 {
-    public function __construct(int $taskTimeoutInMs)
+    public function __construct(int $taskTimeoutInMs, string $requestId)
     {
-        $message = "The request timed out after $taskTimeoutInMs ms. "
+        $message = "The request $requestId timed out after $taskTimeoutInMs ms. "
             . 'Note: that duration may be lower than the Lambda timeout, don\'t be surprised, that is intentional. '
             . 'Indeed, Bref stops the PHP-FPM request *before* a hard Lambda timeout, because a hard timeout prevents all logs to be written to CloudWatch.';
 

--- a/src/Event/Http/FpmHandler.php
+++ b/src/Event/Http/FpmHandler.php
@@ -148,7 +148,7 @@ final class FpmHandler extends HttpHandler
             // - this is reported as a Lambda execution error ("error rate" metrics are accurate)
             // - the CloudWatch logs correctly reflect that an execution error occurred
             // - the 500 response is the same as if an exception happened in Bref
-            throw new Timeout($timeoutDelayInMs);
+            throw new Timeout($timeoutDelayInMs, $context->getAwsRequestId());
         } catch (Throwable $e) {
             printf(
                 "Error communicating with PHP-FPM to read the HTTP response. Bref will restart PHP-FPM now. Original exception message: %s %s\n",


### PR DESCRIPTION
so that it's easier when using tools like graphana/kibana to find all the
logs related to the same request that ultimately failed

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
