### PR TITLE
Upgrade to PHP 7.4.29, 8.0.20, 8.1.7

### DIFF
--- a/runtime/base/php-74.Dockerfile
+++ b/runtime/base/php-74.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=7.4.29
+ENV VERSION_PHP=7.4.30
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php

--- a/runtime/base/php-80.Dockerfile
+++ b/runtime/base/php-80.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=8.0.19
+ENV VERSION_PHP=8.0.20
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php

--- a/runtime/base/php-81.Dockerfile
+++ b/runtime/base/php-81.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=8.1.6
+ENV VERSION_PHP=8.1.7
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php


### PR DESCRIPTION
Fixes CVE-2022-31626, CVE-2022-31625. PHP 8.1.7 is also the first release to properly support openssl 3 - a separate PR coming later to upgrade that.