### PR TITLE
Update Laravel documentation to clarify headers to whitelist if using Lift

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -164,6 +164,26 @@ constructs:
       '/favicon.ico': public/favicon.ico
       '/robots.txt': public/robots.txt
       # add here any file or directory that needs to be served from S3
+    # Laravel uses some headers that are not in CloudFront's default whitelist.
+    # To add any, we need to list all accepted headers to pass through.
+    # https://github.com/getlift/lift/blob/master/docs/server-side-website.md#forwarded-headers
+    forwardedHeaders:
+      - Accept
+      - Accept-Language
+      - Authorization
+      - Content-Type
+      - Origin
+      - Referer
+      - User-Agent
+      - X-Forwarded-Host
+      - X-Requested-With
+      # Laravel Framework Headers
+      - X-Csrf-Token
+      - X-Xsrf-Token
+      # Laravel Telescope
+      - Location
+      # Other Headers, e.g. Livewire
+      - X-Livewire
 ```
 
 Before deploying, compile your assets using Laravel Mix.

--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -170,7 +170,6 @@ constructs:
     forwardedHeaders:
       - Accept
       - Accept-Language
-      - Authorization
       - Content-Type
       - Origin
       - Referer
@@ -179,9 +178,6 @@ constructs:
       - X-Requested-With
       # Laravel Framework Headers
       - X-Csrf-Token
-      - X-Xsrf-Token
-      # Laravel Telescope
-      - Location
       # Other Headers, e.g. Livewire
       - X-Livewire
 ```


### PR DESCRIPTION
I recently struggled to get Livewire and Telescope for Laravel working. I was encountering [419 errors all over the place](https://github.com/livewire/livewire/discussions/5031). It turns out Cloudfront was not forwarding some necessary HTTP Headers as configured by default via the severless-lift plugin. This update to documentation makes more clear the necessity of explicitly whitelisting certain headers, though it's not exhaustive. I did a quick search in the core Laravel framework for calls to header (`grep header\(`), and at the very least I left out `X-Socket-ID` from [BroadcastManager.php](https://github.com/laravel/framework/blob/9.x/src/Illuminate/Broadcasting/BroadcastManager.php#L129) since there's already a lot of headers listed and the Lift documentation says there's a max of 10 headers you can whitelist. However I can't find any AWS documentation to support that assertion and I am already listing more than ten, seemingly successfully.
