### PR TITLE
Change from 'error' to 'warning' if `serverless` not installed

### DIFF
--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -22,12 +22,12 @@ final class Init extends Command
         $io = new SymfonyStyle($input, $output);
         $exeFinder = new ExecutableFinder;
         if (! $exeFinder->find('serverless')) {
-            $io->error(
+            $io->warning(
                 'The `serverless` command is not installed.' . PHP_EOL .
-                'Please follow the instructions at https://bref.sh/docs/installation.html'
+                'You will not be able to deploy your application unless it is installed' . PHP_EOL .
+                'Please follow the instructions at https://bref.sh/docs/installation.html' . PHP_EOL .
+                'If you have the `serverless` command available elsewhere (eg in a Docker container) you can ignore this warning'
             );
-
-            return 1;
         }
 
         if (file_exists('serverless.yml') || file_exists('index.php')) {


### PR DESCRIPTION
If `serverless` isn't installed in the local env, we should warn the user instead of blocking them from proceeding, as they may already have serverless available via another container (if using Docker, for example).

Closes #1262 
