### PR TITLE
Make existing files just a warning instead of a crash

### DIFF
--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -5,6 +5,7 @@ namespace Bref\Console\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
@@ -20,6 +21,11 @@ final class Init extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $helper = $this->getHelper('question');
+
+        /**
+         * @param $filesToGitAdd<string>
+         */
         $filesToGitAdd = [];
         $exeFinder = new ExecutableFinder;
         if (! $exeFinder->find('serverless')) {
@@ -45,42 +51,51 @@ final class Init extends Command
         ][$choice];
 
         $fs = new Filesystem;
-        $rootPath = dirname(__DIR__, 3) . "/template/$templateDirectory";
 
-        $io->writeln('Creating index.php');
-        if (file_exists('index.php')) {
-            $io->warning('The directory already contains a `index.php` file. Skipping...');
-        }
-        else {
-            $fs->copy("$rootPath/index.php", 'index.php');
-            $filesToGitAdd[] = 'index.php';
-        }
+        $createFile = static function ($file) use ($templateDirectory, $io, $helper, $input, $output, &$filesToGitAdd): void {
+            $write = true;
+            $rootPath = dirname(__DIR__, 3) . "/template/$templateDirectory";
+            $io->writeln("Creating $file");
+            if (file_exists($file)) {
+                $question = new ConfirmationQuestion(
+                    "An $file file already exists, do you want to overwrite it? [Y/n]",
+                    false,
+                    '/^(y|j)/i'
+                );
 
-        $io->writeln('Creating serverless.yml');
-        if (file_exists('serverless.yml')) {
-            $io->warning('The directory already contains a `serverless.yml` file. Skipping...');
-        }
-        else {
-            $template = file_get_contents("$rootPath/serverless.yml");
-            $template = str_replace('PHP_VERSION', PHP_MAJOR_VERSION . PHP_MINOR_VERSION, $template);
-            file_put_contents('serverless.yml', $template);
-            $filesToGitAdd[] = 'serverless.yml';
-        }
+                $write = $helper->ask($input, $output, $question);
+            }
+
+            if ($write) {
+                $template = file_get_contents("$rootPath/$file");
+                $template = str_replace('PHP_VERSION', PHP_MAJOR_VERSION . PHP_MINOR_VERSION, $template);
+                file_put_contents($file, $template);
+                $filesToGitAdd[] = $file;
+            }
+        };
+
+        $createFile('index.php');
+        $createFile('serverless.yml');
 
         /*
          * We check if this is a git repository to automatically add files to git.
          */
-        if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0) {
+        if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0 && $filesToGitAdd) {
+            $files = implode(',', $filesToGitAdd);
             foreach ($filesToGitAdd as $file) {
                 (new Process(['git', 'add', $file]))->run();
             }
-            $io->success([
-                'Project initialized and ready to test or deploy.',
-                'The files created were automatically added to git.',
-            ]);
-        } else {
-            $io->success('Project initialized and ready to test or deploy.');
+
+            if ($filesToGitAdd !== []) {
+                $io->success([
+                    'Project initialized and ready to test or deploy.',
+                    "The file/s $files created automatically added to git.",
+                ]);
+            }
+            return 0;
         }
+
+        $io->success('Project initialized and ready to test or deploy.');
 
         return 0;
     }

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -23,9 +23,6 @@ final class Init extends Command
         $io = new SymfonyStyle($input, $output);
         $helper = $this->getHelper('question');
 
-        /**
-         * @param $filesToGitAdd<string>
-         */
         $filesToGitAdd = [];
         $exeFinder = new ExecutableFinder;
         if (! $exeFinder->find('serverless')) {

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -23,7 +23,6 @@ final class Init extends Command
     {
         $this->io = $io = new SymfonyStyle($input, $output);
 
-        $filesToGitAdd = [];
         $exeFinder = new ExecutableFinder;
         if (! $exeFinder->find('serverless')) {
             $io->warning(

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -11,8 +11,20 @@ use Symfony\Component\Process\Process;
 
 final class Init extends Command
 {
-    private SymfonyStyle $io;
-    private string $rootPath;
+    /**
+     * Symfony console input/output handler
+     *
+     * @var SymfonyStyle
+     */
+    private $io;
+
+    /**
+     * Absolute path pointing into project's
+     * template directory
+     *
+     * @var string
+     */
+    private $rootPath;
 
     protected function configure(): void
     {

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -5,14 +5,15 @@ namespace Bref\Console\Command;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\Process;
 
 final class Init extends Command
 {
+    private SymfonyStyle $io;
+    private string $rootPath;
+
     protected function configure(): void
     {
         $this->setName('init');
@@ -20,8 +21,7 @@ final class Init extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $io = new SymfonyStyle($input, $output);
-        $helper = $this->getHelper('question');
+        $this->io = $io = new SymfonyStyle($input, $output);
 
         $filesToGitAdd = [];
         $exeFinder = new ExecutableFinder;
@@ -42,58 +42,49 @@ final class Init extends Command
             ],
             'Web application',
         );
+
         $templateDirectory = [
             'Web application' => 'http',
             'Event-driven function' => 'function',
         ][$choice];
 
-        $fs = new Filesystem;
+        $this->rootPath = dirname(__DIR__, 3) . "/template/$templateDirectory";
 
-        $createFile = static function ($file) use ($templateDirectory, $io, $helper, $input, $output, &$filesToGitAdd): void {
-            $write = true;
-            $rootPath = dirname(__DIR__, 3) . "/template/$templateDirectory";
-            $io->writeln("Creating $file");
-            if (file_exists($file)) {
-                $question = new ConfirmationQuestion(
-                    "An $file file already exists, do you want to overwrite it? [Y/n]",
-                    false,
-                    '/^(y|j)/i'
-                );
-
-                $write = $helper->ask($input, $output, $question);
-            }
-
-            if ($write) {
-                $template = file_get_contents("$rootPath/$file");
-                $template = str_replace('PHP_VERSION', PHP_MAJOR_VERSION . PHP_MINOR_VERSION, $template);
-                file_put_contents($file, $template);
-                $filesToGitAdd[] = $file;
-            }
-        };
-
-        $createFile('index.php');
-        $createFile('serverless.yml');
-
-        /*
-         * We check if this is a git repository to automatically add files to git.
-         */
-        if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0 && $filesToGitAdd) {
-            $files = implode(',', $filesToGitAdd);
-            foreach ($filesToGitAdd as $file) {
-                (new Process(['git', 'add', $file]))->run();
-            }
-
-            if ($filesToGitAdd !== []) {
-                $io->success([
-                    'Project initialized and ready to test or deploy.',
-                    "The file/s $files created automatically added to git.",
-                ]);
-            }
-            return 0;
-        }
+        self::createFile('index.php');
+        self::createFile('serverless.yml');
 
         $io->success('Project initialized and ready to test or deploy.');
 
         return 0;
+    }
+
+    /**
+     * Creates files from the template directory and automatically adds
+     * them to git
+     */
+    private function createFile(string $file): void
+    {
+        $overwrite = true;
+
+        $this->io->writeln("Creating $file");
+
+        if (file_exists($file)) {
+            $overwrite = $this->io->confirm("An $file file already exists, do you want to overwrite it?", true);
+        }
+
+        if ($overwrite) {
+            $template = file_get_contents("$this->rootPath/$file");
+            $template = str_replace('PHP_VERSION', PHP_MAJOR_VERSION . PHP_MINOR_VERSION, $template);
+            file_put_contents($file, $template);
+
+            /*
+             * We check if this is a git repository to automatically add file to git.
+             */
+            if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0) {
+                    (new Process(['git', 'add', $file]))->run();
+            }
+
+            $this->io->success("$file successfully created and added to git automatically.");
+        }
     }
 }

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -80,7 +80,7 @@ final class Init extends Command
         $this->io->writeln("Creating $file");
 
         if (file_exists($file)) {
-            $overwrite = $this->io->confirm("An $file file already exists, do you want to overwrite it?", true);
+            $overwrite = $this->io->confirm("A file named $file already exists, do you want to overwrite it?", true);
         }
 
         if ($overwrite) {

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -91,11 +91,13 @@ final class Init extends Command
             /*
              * We check if this is a git repository to automatically add file to git.
              */
+            $message = "$file successfully created";
             if ((new Process(['git', 'rev-parse', '--is-inside-work-tree']))->run() === 0) {
-                    (new Process(['git', 'add', $file]))->run();
+                (new Process(['git', 'add', $file]))->run();
+                $message .= ' and added to git automatically';
             }
 
-            $this->io->success("$file successfully created and added to git automatically.");
+            $this->io->success("$message.");
         }
     }
 }

--- a/src/Console/Command/Init.php
+++ b/src/Console/Command/Init.php
@@ -20,6 +20,7 @@ final class Init extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+        $filesToGitAdd = [];
         $exeFinder = new ExecutableFinder;
         if (! $exeFinder->find('serverless')) {
             $io->warning(
@@ -28,12 +29,6 @@ final class Init extends Command
                 'Please follow the instructions at https://bref.sh/docs/installation.html' . PHP_EOL .
                 'If you have the `serverless` command available elsewhere (eg in a Docker container) you can ignore this warning'
             );
-        }
-
-        if (file_exists('serverless.yml') || file_exists('index.php')) {
-            $io->error('The directory already contains a `serverless.yml` and/or `index.php` file.');
-
-            return 1;
         }
 
         $choice = $io->choice(
@@ -53,17 +48,24 @@ final class Init extends Command
         $rootPath = dirname(__DIR__, 3) . "/template/$templateDirectory";
 
         $io->writeln('Creating index.php');
-        $fs->copy("$rootPath/index.php", 'index.php');
+        if (file_exists('index.php')) {
+            $io->warning('The directory already contains a `index.php` file. Skipping...');
+        }
+        else {
+            $fs->copy("$rootPath/index.php", 'index.php');
+            $filesToGitAdd[] = 'index.php';
+        }
 
         $io->writeln('Creating serverless.yml');
-
-        $template = file_get_contents("$rootPath/serverless.yml");
-
-        $template = str_replace('PHP_VERSION', PHP_MAJOR_VERSION . PHP_MINOR_VERSION, $template);
-
-        file_put_contents('serverless.yml', $template);
-
-        $filesToGitAdd = ['index.php', 'serverless.yml'];
+        if (file_exists('serverless.yml')) {
+            $io->warning('The directory already contains a `serverless.yml` file. Skipping...');
+        }
+        else {
+            $template = file_get_contents("$rootPath/serverless.yml");
+            $template = str_replace('PHP_VERSION', PHP_MAJOR_VERSION . PHP_MINOR_VERSION, $template);
+            file_put_contents('serverless.yml', $template);
+            $filesToGitAdd[] = 'serverless.yml';
+        }
 
         /*
          * We check if this is a git repository to automatically add files to git.


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

## Make existing files warnings (index.php & serverless.yml)

So I've just started out with serverless and I've noticed a strange 'feature', that whether I own `serverless.yml` or `index.php`, I cannot initialize bref. I'm creating both workshops and converting old projects into serverless applications. The problem here is, that most often old applications, as well as workshops, have predefined `index.php`. I cannot simply dive into serverless without having a use-case (which most often contains **just** `index.php`).

I would find it much less annoying to tell my audience: 
```
Now, initialize bref!
```
much rather then
```
Now save the contents of index.php file
Delete index.php file
Initialize bref
Overwrite the contents of the new index.php with the old contents you copied.
```

Once I added this for `index.php`, I was looking at that `serverless.yml` restriction and made them both warnings rather than critical errors.

### Explanation
If this init command can only work with fresh projects, I would much rather go off creating my own files, rather than modifying the project to use the command to create files. Possibly if this is not something of your interest, you could separate the init command into init-entry and init-serverless or give out options within init itself. I just need something which isn't a critical error.

Best,
Tomas