### PR TITLE
Upgrade to PHP 8.2.0RC2

### DIFF
--- a/runtime/base/php-82.Dockerfile
+++ b/runtime/base/php-82.Dockerfile
@@ -36,7 +36,7 @@ RUN set -xe; \
     make install
 
 
-ENV VERSION_PHP=8.2.0RC1
+ENV VERSION_PHP=8.2.0RC2
 
 
 ENV PHP_BUILD_DIR=${BUILD_DIR}/php
@@ -46,7 +46,7 @@ RUN set -xe; \
     # --location will follow redirects
     # --silent will hide the progress, but also the errors: we restore error messages with --show-error
     # --fail makes sure that curl returns an error instead of fetching the 404 page
-    curl --location --silent --show-error --fail https://downloads.php.net/~pierrick/php-${VERSION_PHP}.tar.gz \
+    curl --location --silent --show-error --fail https://downloads.php.net/~sergey/php-${VERSION_PHP}.tar.gz \
   | tar xzC ${PHP_BUILD_DIR} --strip-components=1
 # Move into the unpackaged code directory
 WORKDIR  ${PHP_BUILD_DIR}/


### PR DESCRIPTION
It was released a week ago but I didn't get the notification in my RSS reader 😓 

Announcement: https://www.php.net/archive/2022.php#2022-09-15-1
Files are available from Sergey's folder: https://downloads.php.net/~sergey/