### PR TITLE
[proposal] Allow to specify AWS profile when publishing layers

### DIFF
--- a/runtime/layers/publish.php
+++ b/runtime/layers/publish.php
@@ -41,7 +41,7 @@ if ($singleRegion) {
 }
 
 /** Get profile, fallback to default */
-$profile = getenv('PUBLISH_PROFILE') ?? 'default';
+$profile = getenv('AWS_PROFILE') ?? 'default';
 
 // Publish the layers
 /** @var Process[] $publishingProcesses */


### PR DESCRIPTION
This PR will allow to specify the AWS cli profile used to publish the layers.

### Why ?
I have multiple AWS accounts to keep my projects organized. So I need to be able to publish custom layers to a specific AWS account.

### Checklist
- [ ] Test build process specifying `AWS_PROFILE` env variable
- [ ] Update `README.md` with new environment variable
- [ ] Mark PR as Ready for review