### PR TITLE
Upgrade zlib to 1.2.13 (security fix)

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -83,7 +83,7 @@ RUN mkdir -p ${BUILD_DIR}  \
 #   - php
 # Used By:
 #   - xml2
-ENV VERSION_ZLIB=1.2.12
+ENV VERSION_ZLIB=1.2.13
 ENV ZLIB_BUILD_DIR=${BUILD_DIR}/xml2
 
 RUN set -xe; \


### PR DESCRIPTION
Note: this fixes the currently broken build in #1292 because version 1.2.12 was removed.

Version 1.2.13 of zlib was released yesterday (2022-10-13).

From the website:
> Version 1.2.13 has these key updates from 1.2.12:
> 
> - Fix a bug when getting a gzip header extra field with inflateGetHeader(). This remedies CVE-2022-37434.
> - Fix a bug in block type selection when Z_FIXED used. Now the smallest block type is selected, for better compression.
> - Fix a configure issue that discarded the provided CC definition.
> - Correct incorrect inputs provided to the CRC functions. This mitigates a bug in Java.
> - Repair prototypes and exporting of the new CRC functions.
> - Fix inflateBack to detect invalid input with distances too far.
> 
> _Due to the first bug fix, any installations of 1.2.12 or earlier should be replaced with 1.2.13._

Link to CVE: https://nvd.nist.gov/vuln/detail/CVE-2022-37434 (severity: 9.8, critical).