### PR TITLE
Upgrade to libxml2 2.10.3 (security fix)

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -275,7 +275,7 @@ RUN set -xe; \
 #   - zlib
 # Needed by:
 #   - php
-ENV VERSION_XML2=2.10.2
+ENV VERSION_XML2=2.10.3
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 
 RUN set -xe; \


### PR DESCRIPTION
Fixes CVE-2022-40304 and CVE-2022-40303.