### PR TITLE
Opt-in: throw exceptions on lambda invoke errors

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -94,6 +94,10 @@ final class LambdaRuntime
         } catch (\Throwable $e) {
             $this->signalFailure($context->getAwsRequestId(), $e);
 
+            if (in_array(getenv('BREF_INVOKE_LAMBDA_ERROR_THROW_EXCEPTIONS'), ['true', '1'], true)) {
+                throw $e;
+            }
+
             return false;
         }
 

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -339,6 +339,42 @@ ERROR;
         $this->assertErrorInLogs('Exception', 'The lambda handler must be a callable or implement handler interfaces');
     }
 
+    public function test_throw_exception_if_env_is_set_to_true()
+    {
+        putenv('BREF_INVOKE_LAMBDA_ERROR_THROW_EXCEPTIONS=true');
+
+        // Will throw exception
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessage('The lambda handler must be a callable or implement handler interfaces');
+
+        $eventData = json_decode(file_get_contents(__DIR__ . '/../Event/Http/Fixture/ag-v1-simple.json'), true);
+        $this->givenAnEvent($eventData);
+
+        $this->runtime->processNextEvent(null);
+
+        // Will log exception
+        $this->assertInvocationErrorResult('Exception', 'The lambda handler must be a callable or implement handler interfaces');
+        $this->assertErrorInLogs('Exception', 'The lambda handler must be a callable or implement handler interfaces');
+    }
+
+    public function test_throw_exception_if_env_is_set_to_one()
+    {
+        putenv('BREF_INVOKE_LAMBDA_ERROR_THROW_EXCEPTIONS=1');
+
+        // Will throw exception
+        $this->expectException(\Throwable::class);
+        $this->expectExceptionMessage('The lambda handler must be a callable or implement handler interfaces');
+
+        $eventData = json_decode(file_get_contents(__DIR__ . '/../Event/Http/Fixture/ag-v1-simple.json'), true);
+        $this->givenAnEvent($eventData);
+
+        $this->runtime->processNextEvent(null);
+
+        // Will log exception
+        $this->assertInvocationErrorResult('Exception', 'The lambda handler must be a callable or implement handler interfaces');
+        $this->assertErrorInLogs('Exception', 'The lambda handler must be a callable or implement handler interfaces');
+    }
+
     /**
      * @param mixed $event
      */


### PR DESCRIPTION
**Motivation**

When an exception is thrown by an invokation, the exception is getting swallowed.
This basically means, that it's impossible to do exception handling.

In my opinion, a package should throw exceptions and let the user determine how to handle them.

I understand the reasoning for why to log errors in a CW way, but i think that having the opportunity to opt-in on exceptions instead, is a great add to the package.

**Example**

Here's a simple example of an application using Bref that does the following:

1. Get an event from a lambda-invoke (using Bref's EventBridgeEvent class)
2. Parse the event
3. Store parsed data to DynamoDB

In this case the AWS SDK throws an exception, but rather than the application has a chance to "catch" the exception and gracefully handle it. It silently get's catched, and the error is echo'ed out ( fine with the echo, since it does it in the CW style. )

As you also can see on the screenshot. This is echoed out to stdout, which means it's really hard to destinguish logs on their level. (INFO, WARNING. ERROR etc.) - this can of course be done, by parsing all CW-logs and looking for the word "Invoke error" and then transform the log into an error-log instead, but that seems really cumbersome.

Screenshot:
![image](https://user-images.githubusercontent.com/2228675/196255330-5dbb4e7a-3bbe-456e-979c-5931a0191f63.png)

