### PR TITLE
Upgrade openssl to 1.1.1r

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -117,7 +117,7 @@ RUN set -xe; \
 # Needed by:
 #   - curl
 #   - php
-ENV VERSION_OPENSSL=1.1.1q
+ENV VERSION_OPENSSL=1.1.1r
 ENV OPENSSL_BUILD_DIR=${BUILD_DIR}/openssl
 ENV CA_BUNDLE_SOURCE="https://curl.se/ca/cacert.pem"
 ENV CA_BUNDLE="${INSTALL_DIR}/ssl/cert.pem"


### PR DESCRIPTION
Link to the changelog: https://www.openssl.org/news/cl111.txt

Excerpt:

>  Changes between 1.1.1q and 1.1.1r [11 Oct 2022]
> 
>   *) Fixed the linux-mips64 Configure target which was missing the
>      SIXTY_FOUR_BIT bn_ops flag. This was causing heap corruption on that
>      platform.
>      [Adam Joseph]
> 
>   *) Fixed a strict aliasing problem in bn_nist. Clang-14 optimisation was
>      causing incorrect results in some cases as a result.
>      [Paul Dale]
> 
>   *) Fixed SSL_pending() and SSL_has_pending() with DTLS which were failing to
>      report correct results in some cases
>      [Matt Caswell]
> 
>   *) Fixed a regression introduced in 1.1.1o for re-signing certificates with
>      different key sizes
>      [Todd Short]
> 
>   *) Added the loongarch64 target
>      [Shi Pujin]
> 
>   *) Fixed a DRBG seed propagation thread safety issue
>      [Bernd Edlinger]
> 
>   *) Fixed a memory leak in tls13_generate_secret
>      [Bernd Edlinger]
> 
>   *) Fixed reported performance degradation on aarch64. Restored the
>      implementation prior to commit 2621751 ("aes/asm/aesv8-armx.pl: avoid
>      32-bit lane assignment in CTR mode") for 64bit targets only, since it is
>      reportedly 2-17% slower and the silicon errata only affects 32bit targets.
>      The new algorithm is still used for 32 bit targets.
>      [Bernd Edlinger]
> 
>   *) Added a missing header for memcmp that caused compilation failure on some
>      platforms
>      [Gregor Jasny]