### PR TITLE
Support Europe/Spain region

### DIFF
--- a/runtime/layers/regions.json
+++ b/runtime/layers/regions.json
@@ -18,6 +18,7 @@
     "ap-southeast-1",
     "ap-southeast-2",
     "eu-south-1",
+    "eu-south-2",
     "af-south-1",
     "me-south-1"
 ]


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

Closes #1332 

Recently a new AWS region was launched in Europe/Spain
This PR adds support for "eu-south-2" and pushes layers to that region also
