### PR TITLE
Remove `@internal` tags on classes that now become public API

### DIFF
--- a/src/Bref.php
+++ b/src/Bref.php
@@ -23,7 +23,7 @@ class Bref
     }
 
     /**
-     * @internal
+     * @internal Used by the Bref runtime
      */
     public static function getContainer(): ContainerInterface
     {

--- a/src/Context/ContextBuilder.php
+++ b/src/Context/ContextBuilder.php
@@ -2,9 +2,6 @@
 
 namespace Bref\Context;
 
-/**
- * @internal
- */
 final class ContextBuilder
 {
     private string $awsRequestId;

--- a/src/Event/Http/Psr7Bridge.php
+++ b/src/Event/Http/Psr7Bridge.php
@@ -15,8 +15,6 @@ use function str_starts_with;
 
 /**
  * Bridges PSR-7 requests and responses with API Gateway or ALB event/response formats.
- *
- * @internal
  */
 final class Psr7Bridge
 {

--- a/src/Event/S3/Bucket.php
+++ b/src/Event/S3/Bucket.php
@@ -10,9 +10,6 @@ final class Bucket
     private string $name;
     private string $arn;
 
-    /**
-     * @internal
-     */
     public function __construct(string $name, string $arn)
     {
         $this->name = $name;

--- a/src/Event/S3/BucketObject.php
+++ b/src/Event/S3/BucketObject.php
@@ -11,9 +11,6 @@ final class BucketObject
     private int $size;
     private ?string $versionId;
 
-    /**
-     * @internal
-     */
     public function __construct(string $key, int $size, ?string $versionId = null)
     {
         $this->key = $key;

--- a/src/Event/S3/S3Event.php
+++ b/src/Event/S3/S3Event.php
@@ -15,9 +15,6 @@ final class S3Event implements LambdaEvent
 {
     private array $event;
 
-    /**
-     * @internal
-     */
     public function __construct(mixed $event)
     {
         if (! is_array($event) || ! isset($event['Records'])) {

--- a/src/Event/S3/S3Record.php
+++ b/src/Event/S3/S3Record.php
@@ -12,9 +12,6 @@ final class S3Record
 {
     private array $record;
 
-    /**
-     * @internal
-     */
     public function __construct(mixed $record)
     {
         if (! is_array($record) || ! isset($record['eventSource']) || $record['eventSource'] !== 'aws:s3') {

--- a/src/Runtime/FileHandlerLocator.php
+++ b/src/Runtime/FileHandlerLocator.php
@@ -11,7 +11,6 @@ use Psr\Container\ContainerInterface;
  * Whenever a Lambda function executes, this class will `require` that PHP file
  * and return what the file returns.
  *
- * @internal
  * @see \Bref\Bref::setContainer()
  */
 class FileHandlerLocator implements ContainerInterface


### PR DESCRIPTION
Fix #1291

In previous open-source projects, I never thought twice about making classes `@internal`. That meant that any code I wrote for internal purposes was instantly part of the public API of the package.

Over the years, this caused me a lot of issues because I had to keep backward compatibility for that code. Even though (very likely) nobody was actually using it. This made maintenance and refactorings much harder.

When I worked on Bref, I added the `@internal` tag by default on all code I wrote that wasn't meant to be used by end users.

Now that we have a few years of experience, I can see that some of this code is very stable (no need to refactor it), and could actually be useful outside of Bref.

So let's open it up! This PR removes a lot of `@internal` tags and makes this internal code part of the public API. It will be maintained and free of breaking changes in minor versions.