### PR TITLE
Chore: Update command documentation to not use PHP in docker-compose run

### DIFF
--- a/docs/web-apps/local-development.md
+++ b/docs/web-apps/local-development.md
@@ -178,5 +178,5 @@ services:
 Then commands can be run via:
 
 ```bash
-docker-compose run console php bin/console <your-command>
+docker-compose run console bin/console <your-command>
 ```


### PR DESCRIPTION
# What
Removes `php` from the `docker-compose run console` documentation

# Why
The example given suggests to run 
` docker-compose run console php bin/console`

Given the entrypoint is already `php` in the docker-compose.yml example given above.
The `php` in the `Then commands can be run via:` section causes a `Could not open input file: php` error.

