### PR TITLE
Make sure we support query strings with period in them

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -171,8 +171,7 @@ final class HttpRequestEvent implements LambdaEvent
 
     public function getQueryParameters(): array
     {
-        parse_str($this->queryString, $query);
-        return $query;
+        return $this->queryStringToArray($this->queryString);
     }
 
     public function getRequestContext(): array
@@ -225,7 +224,7 @@ final class HttpRequestEvent implements LambdaEvent
             $queryString = $this->event['rawQueryString'] ?? '';
             // We re-parse the query string to make sure it is URL-encoded
             // Why? To match the format we get when using PHP outside of Lambda (we get the query string URL-encoded)
-            parse_str($queryString, $queryParameters);
+            $queryParameters = $this->queryStringToArray($queryString);
             return http_build_query($queryParameters);
         }
 
@@ -264,11 +263,9 @@ final class HttpRequestEvent implements LambdaEvent
                 }
             }
 
-            // parse_str will automatically `urldecode` any value that needs decoding. This will allow parameters
-            // like `?my_param[bref][]=first&my_param[bref][]=second` to properly work. `$decodedQueryParameters`
-            // will be an array with parameter names as keys.
-            parse_str($queryString, $decodedQueryParameters);
-
+            // This will allow parameters like `?my_param[bref][]=first&my_param[bref][]=second` to properly work.
+            // `$decodedQueryParameters` will be an array with parameter names as keys.
+            $decodedQueryParameters = $this->queryStringToArray($queryString);
             return http_build_query($decodedQueryParameters);
         }
 
@@ -283,7 +280,7 @@ final class HttpRequestEvent implements LambdaEvent
 
             // re-parse the query-string so it matches the format used when using PHP outside of Lambda
             // this is particularly important when using multi-value params - eg. myvar[]=2&myvar=3 ... = [2, 3]
-            parse_str(implode('&', $queryParameterStr), $queryParameters);
+            $queryParameters = $this->queryStringToArray(implode('&', $queryParameterStr));
             return http_build_query($queryParameters);
         }
 

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -4,7 +4,6 @@ namespace Bref\Event\Http;
 
 use Bref\Event\InvalidLambdaEvent;
 use Bref\Event\LambdaEvent;
-use League\Uri\Parser\QueryString;
 
 /**
  * Represents a Lambda event that comes from a HTTP request.

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -371,14 +371,13 @@ final class HttpRequestEvent implements LambdaEvent
      * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
      * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
      *
-     * @param string $query
      * @return array<string, string>
      */
     private function queryStringToArray(string $query): array
     {
         parse_str($query, $array);
         // Matches keys in the query that contain a dot
-        if (!preg_match('/(?:^|&)([^\[=&]*\.)/', $query)) {
+        if (! preg_match('/(?:^|&)([^\[=&]*\.)/', $query)) {
             return $array;
         }
 
@@ -390,16 +389,16 @@ final class HttpRequestEvent implements LambdaEvent
 
         // Create mapping of broken keys to original proper keys.
         foreach ($matches[1] as $value) {
-            if (false !== strpos($value, '.')) {
+            if (strpos($value, '.') !== false) {
                 $random = bin2hex(random_bytes(10));
                 $brokenKeys[$random] = $value;
             }
         }
 
-        if ([] !== $brokenKeys) {
+        if ($brokenKeys !== []) {
             $placeholder = array_flip($brokenKeys);
-            $modifiedQuery = preg_replace_callback($keyRegex, function($matches) use ($placeholder) {
-                if (!isset($placeholder[$matches[1]])) {
+            $modifiedQuery = preg_replace_callback($keyRegex, function ($matches) use ($placeholder) {
+                if (! isset($placeholder[$matches[1]])) {
                     return $matches[0];
                 }
                 return str_replace($matches[1], $placeholder[$matches[1]], $matches[0]);

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -224,8 +224,7 @@ final class HttpRequestEvent implements LambdaEvent
             $queryString = $this->event['rawQueryString'] ?? '';
             // We re-parse the query string to make sure it is URL-encoded
             // Why? To match the format we get when using PHP outside of Lambda (we get the query string URL-encoded)
-            $queryParameters = $this->queryStringToArray($queryString);
-            return http_build_query($queryParameters);
+            return http_build_query($this->queryStringToArray($queryString));
         }
 
         // It is likely that we do not need to differentiate between API Gateway (Version 1) and ALB. However,
@@ -263,10 +262,10 @@ final class HttpRequestEvent implements LambdaEvent
                 }
             }
 
-            // This will allow parameters like `?my_param[bref][]=first&my_param[bref][]=second` to properly work.
-            // `$decodedQueryParameters` will be an array with parameter names as keys.
-            $decodedQueryParameters = $this->queryStringToArray($queryString);
-            return http_build_query($decodedQueryParameters);
+            // queryStringToArray() will automatically `urldecode` any value that needs decoding. This will allow parameters
+            // like `?my_param[bref][]=first&my_param[bref][]=second` to properly work. `$decodedQueryParameters`
+            // will be an array with parameter names as keys.
+            return http_build_query($this->queryStringToArray($queryString));
         }
 
         if (isset($this->event['multiValueQueryStringParameters']) && $this->event['multiValueQueryStringParameters']) {
@@ -342,5 +341,81 @@ final class HttpRequestEvent implements LambdaEvent
     public function isFormatV2(): bool
     {
         return $this->payloadVersion === 2.0;
+    }
+
+    /**
+     * When keys within a URL query string contain dots, PHP's parse_str() method
+     * converts them to underscores. This method works around this issue so the
+     * requested query array returns the proper keys with dots.
+     *
+     * This method is heavily inspired from https://github.com/crwlrsoft/url.
+     *
+     * Copyright (c) 2023 Christian Olear
+     *
+     * Permission is hereby granted, free of charge, to any person obtaining
+     *  a copy of this software and associated documentation files (the
+     *  "Software"), to deal in the Software without restriction, including
+     *  without limitation the rights to use, copy, modify, merge, publish,
+     *  distribute, sublicense, and/or sell copies of the Software, and to
+     *  permit persons to whom the Software is furnished to do so, subject
+     *  to the following conditions:
+     *
+     *  The above copyright notice and this permission notice shall be
+     *  included in all copies or substantial portions of the Software.
+     *
+     *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+     *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+     *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+     *  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+     *  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+     *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+     *  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+     *
+     * @param string $query
+     * @return array<string, string>
+     */
+    private function queryStringToArray(string $query): array
+    {
+        parse_str($query, $array);
+        // Matches keys in the query that contain a dot
+        if (!preg_match('/(?:^|&)([^\[=&]*\.)/', $query)) {
+            return $array;
+        }
+
+        // Regex to find keys in query string.
+        $keyRegex = '/(?:^|&)([^=&\[]+)(?:[=&\[]|$)/';
+        $encodedQuery = urldecode($query);
+        preg_match_all($keyRegex, $encodedQuery, $matches);
+        $brokenKeys = $fixedArray = [];
+
+        // Create mapping of broken keys to original proper keys.
+        foreach ($matches[1] as $value) {
+            if (false !== strpos($value, '.')) {
+                $random = bin2hex(random_bytes(10));
+                $brokenKeys[$random] = $value;
+            }
+        }
+
+        if ([] !== $brokenKeys) {
+            $placeholder = array_flip($brokenKeys);
+            $modifiedQuery = preg_replace_callback($keyRegex, function($matches) use ($placeholder) {
+                if (!isset($placeholder[$matches[1]])) {
+                    return $matches[0];
+                }
+                return str_replace($matches[1], $placeholder[$matches[1]], $matches[0]);
+            }, $encodedQuery);
+            parse_str($modifiedQuery, $array);
+        }
+
+        // Recreate the array with the proper keys.
+        foreach ($array as $key => $value) {
+            if (isset($brokenKeys[$key])) {
+                $fixedArray[$brokenKeys[$key]] = $value;
+            } else {
+                $fixedArray[$key] = $value;
+            }
+        }
+
+        return $fixedArray;
     }
 }

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -4,6 +4,7 @@ namespace Bref\Event\Http;
 
 use Bref\Event\InvalidLambdaEvent;
 use Bref\Event\LambdaEvent;
+use League\Uri\Parser\QueryString;
 
 /**
  * Represents a Lambda event that comes from a HTTP request.

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -353,23 +353,23 @@ final class HttpRequestEvent implements LambdaEvent
      * Copyright (c) 2023 Christian Olear
      *
      * Permission is hereby granted, free of charge, to any person obtaining
-     *  a copy of this software and associated documentation files (the
-     *  "Software"), to deal in the Software without restriction, including
-     *  without limitation the rights to use, copy, modify, merge, publish,
-     *  distribute, sublicense, and/or sell copies of the Software, and to
-     *  permit persons to whom the Software is furnished to do so, subject
-     *  to the following conditions:
+     * a copy of this software and associated documentation files (the
+     * "Software"), to deal in the Software without restriction, including
+     * without limitation the rights to use, copy, modify, merge, publish,
+     * distribute, sublicense, and/or sell copies of the Software, and to
+     * permit persons to whom the Software is furnished to do so, subject
+     * to the following conditions:
      *
-     *  The above copyright notice and this permission notice shall be
-     *  included in all copies or substantial portions of the Software.
+     * The above copyright notice and this permission notice shall be
+     * included in all copies or substantial portions of the Software.
      *
-     *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-     *  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-     *  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-     *  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-     *  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-     *  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-     *  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+     * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+     * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+     * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+     * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+     * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+     * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
      *
      * @param string $query
      * @return array<string, string>

--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -350,27 +350,6 @@ final class HttpRequestEvent implements LambdaEvent
      *
      * This method is heavily inspired from https://github.com/crwlrsoft/url.
      *
-     * Copyright (c) 2023 Christian Olear
-     *
-     * Permission is hereby granted, free of charge, to any person obtaining
-     * a copy of this software and associated documentation files (the
-     * "Software"), to deal in the Software without restriction, including
-     * without limitation the rights to use, copy, modify, merge, publish,
-     * distribute, sublicense, and/or sell copies of the Software, and to
-     * permit persons to whom the Software is furnished to do so, subject
-     * to the following conditions:
-     *
-     * The above copyright notice and this permission notice shall be
-     * included in all copies or substantial portions of the Software.
-     *
-     * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-     * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-     * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-     * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-     * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-     * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-     * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-     *
      * @return array<string, string>
      */
     private function queryStringToArray(string $query): array

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -88,9 +88,9 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
         $this->fromFixture(__DIR__ . "/Fixture/ag-v$version-query-string.json");
 
         $this->assertPath('/path');
-        $this->assertQueryParameters(['foo' => 'bar']);
-        $this->assertQueryString('foo=bar');
-        $this->assertUri('/path?foo=bar');
+        $this->assertQueryParameters(['foo' => 'bar', 'baz.bar' => 'foo']);
+        $this->assertQueryString('foo=bar&baz.bar=foo');
+        $this->assertUri('/path?foo=bar&baz.bar=foo');
     }
 
     /**
@@ -106,9 +106,10 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
             'colors' => [['red'], ['blue']],
             'shapes' => ['a' => ['square', 'triangle']],
             'myvar' => 'abc',
+            'foo.bar' => ['baz'],
         ]);
-        $this->assertQueryString('foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc');
-        $this->assertUri('/path?foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc');
+        $this->assertQueryString('foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz');
+        $this->assertUri('/path?foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz');
     }
 
     /**
@@ -123,15 +124,16 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
                 'val1' => 'foo',
                 'val2' => ['bar'],
             ],
+            'foo.bar' => ['baz'],
         ]);
         if ($version === 2) {
             // Numeric keys are added as an artifact of us parsing the query string
             // Both format are valid and semantically identical
-            $this->assertQueryString('vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar');
-            $this->assertUri('/path?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar');
+            $this->assertQueryString('vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar&foo.bar%5B0%5D=baz');
+            $this->assertUri('/path?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar&foo.bar%5B0%5D=baz');
         } else {
-            $this->assertQueryString('vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar');
-            $this->assertUri('/path?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar');
+            $this->assertQueryString('vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar&foo.bar%5B%5D=baz');
+            $this->assertUri('/path?vars%5Bval1%5D=foo&vars%5Bval2%5D%5B%5D=bar&foo.bar%5B%5D=baz');
         }
     }
 

--- a/tests/Event/Http/Fixture/ag-v1-query-string-arrays.json
+++ b/tests/Event/Http/Fixture/ag-v1-query-string-arrays.json
@@ -16,7 +16,8 @@
     },
     "queryStringParameters": {
         "vars[val1]": "foo",
-        "vars[val2][]": "bar"
+        "vars[val2][]": "bar",
+        "foo.bar[]": "baz"
     },
     "pathParameters": null,
     "stageVariables": null,

--- a/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
@@ -22,7 +22,8 @@
         "cards[]": ["birthday"],
         "colors[][]": ["red", "blue"],
         "shapes[a][]": ["square", "triangle"],
-        "myvar": ["abc"]
+        "myvar": ["abc"],
+        "foo.bar[]": ["baz"]
     },
     "pathParameters": null,
     "stageVariables": null,

--- a/tests/Event/Http/Fixture/ag-v1-query-string.json
+++ b/tests/Event/Http/Fixture/ag-v1-query-string.json
@@ -15,7 +15,8 @@
         "X-Forwarded-Proto": "https"
     },
     "queryStringParameters": {
-        "foo": "bar"
+        "foo": "bar",
+        "baz.bar": "foo"
     },
     "pathParameters": null,
     "stageVariables": null,

--- a/tests/Event/Http/Fixture/ag-v2-query-string-arrays.json
+++ b/tests/Event/Http/Fixture/ag-v2-query-string-arrays.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "routeKey": "ANY /path",
     "rawPath": "/path",
-    "rawQueryString": "vars[val1]=foo&vars[val2][]=bar",
+    "rawQueryString": "vars[val1]=foo&vars[val2][]=bar&foo.bar[]=baz",
     "headers": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",
@@ -16,7 +16,8 @@
     },
     "queryStringParameters": {
         "vars[val1]": "foo",
-        "vars[val2][]": "bar"
+        "vars[val2][]": "bar",
+        "foo.bar[]": "baz"
     },
     "stageVariables": null,
     "requestContext": {

--- a/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "routeKey": "ANY /path",
     "rawPath": "/path",
-    "rawQueryString": "foo[]=bar&foo[]=baz&cards[]=birthday&colors[][]=red&colors[][]=blue&shapes[a][]=square&shapes[a][]=triangle&myvar=abc",
+    "rawQueryString": "foo[]=bar&foo[]=baz&cards[]=birthday&colors[][]=red&colors[][]=blue&shapes[a][]=square&shapes[a][]=triangle&myvar=abc&foo.bar[]=baz",
     "headers": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",

--- a/tests/Event/Http/Fixture/ag-v2-query-string.json
+++ b/tests/Event/Http/Fixture/ag-v2-query-string.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "routeKey": "ANY /path",
     "rawPath": "/path",
-    "rawQueryString": "foo=bar",
+    "rawQueryString": "foo=bar&baz.bar=foo",
     "cookies": [],
     "headers": {
         "accept": "*/*",
@@ -16,7 +16,8 @@
         "x-forwarded-proto": "https"
     },
     "queryStringParameters": {
-        "foo": "bar"
+        "foo": "bar",
+        "baz.bar": "foo"
     },
     "requestContext": {
         "accountId": "123400000000",

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -168,6 +168,10 @@ class HttpRequestEventTest extends CommonHttpTest
 
     public function queryStringProvider()
     {
+        yield ['', []];
+        yield ['foo_bar=2',  [
+            'foo_bar' => '2',
+        ]];
         yield ['foo_bar=v1&foo.bar=v2',  [
             'foo_bar' => 'v1',
             'foo.bar' => 'v2',
@@ -185,11 +189,6 @@ class HttpRequestEventTest extends CommonHttpTest
             'foo_bar' => 'v1',
             'k' => ['foo.bar' => 'v2'],
         ]];
-        yield ['', []];
-        yield ['foo_bar=2',  [
-            'foo_bar' => '2',
-        ]];
-
         yield ['k.1=v.1&k.2[s.k1]=v.2&k.2[s.k2]=v.3',  [
             'k.1' => 'v.1',
             'k.2' => [

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -230,4 +230,74 @@ class HttpRequestEventTest extends CommonHttpTest
             ],
         ];
     }
+
+    /**
+     * @dataProvider provide Querystrings
+     */
+    public function test querystring will be parsed correctly(array $expected, string $normalizedQs, string $queryString)
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'version' => '2.0',
+            'rawQueryString' => $queryString,
+        ]);
+
+        self::assertSame($expected, $event->getQueryParameters());
+        self::assertSame($normalizedQs, $event->getQueryString());
+    }
+
+    public function provide Querystrings()
+    {
+        return [
+            [['foo' => 'bar'], 'foo=bar', 'foo=bar'],
+            [['foo' => 'bar'], 'foo=bar', '   foo=bar  '],
+            [['foo' => 'bar'], '?foo=bar', '?foo=bar'],
+            [['#foo' => 'bar'], '%23foo=bar', '#foo=bar'],
+            [['foo' => 'bar'], 'foo=bar', '&foo=bar'],
+            [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo', 'foo=bar&bar=foo'],
+            [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo', 'foo=bar&&bar=foo'],
+            [['foo' => ['bar' => ['baz' => ['bax' => 'bar']]]], 'foo%5Bbar%5D%5Bbaz%5D%5Bbax%5D=bar', 'foo[bar][baz][bax]=bar'],
+            [['foo' => ['bar' => 'bar']], 'foo%5Bbar%5D=bar', 'foo[bar] [baz]=bar'],
+            [['foo' => ['bar' => ['baz' => ['bar', 'foo']]]], 'foo%5Bbar%5D%5Bbaz%5D%5B0%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B1%5D=foo', 'foo[bar][baz][]=bar&foo[bar][baz][]=foo'],
+            [['foo' => ['bar' => [['bar'], ['foo']]]], 'foo%5Bbar%5D%5B0%5D%5B0%5D=bar&foo%5Bbar%5D%5B1%5D%5B0%5D=foo', 'foo[bar][][]=bar&foo[bar][][]=foo'],
+            [['option' => ''], 'option=', 'option'],
+            [['option' => '0'], 'option=0', 'option=0'],
+            [['option' => '1'], 'option=1', 'option=1'],
+            [['foo' => 'bar=bar=='], 'foo=bar%3Dbar%3D%3D', 'foo=bar=bar=='],
+            [['options' => ['option' => '0']], 'options%5Boption%5D=0', 'options[option]=0'],
+            [['options' => ['option' => 'foobar']], 'options%5Boption%5D=foobar', 'options[option]=foobar'],
+            [['sum' => '10\\2=5'], 'sum=10%5C2%3D5', 'sum=10%5c2%3d5'],
+
+            // Special cases
+            [
+                [
+                    'a' => '<==  foo bar  ==>',
+                    'b' => '###Hello World###',
+                ],
+                'a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+                'a=%3c%3d%3d%20%20foo+bar++%3d%3d%3e&b=%23%23%23Hello+World%23%23%23',
+            ],
+            [
+                ['str' => "A string with containing \0\0\0 nulls"],
+                'str=A+string+with+containing+%00%00%00+nulls',
+                'str=A%20string%20with%20containing%20%00%00%00%20nulls',
+            ],
+            [
+                [
+                    'arr_1' => 'sid',
+                    'arr' => ['4' => 'fred'],
+                ],
+                'arr%5B1=sid&arr%5B4%5D=fred',
+                'arr[1=sid&arr[4][2=fred',
+            ],
+            [
+                [
+                    'arr_1' => 'sid',
+                    'arr' => ['4' => ['[2' => 'fred']],
+                ],
+                'arr%5B1=sid&arr%5B4%5D%5B%5B2%5D=fred',
+                'arr[1=sid&arr[4][[2][3[=fred',
+            ],
+        ];
+    }
 }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -166,40 +166,68 @@ class HttpRequestEventTest extends CommonHttpTest
         $this->assertEquals($expectedOutput, $result);
     }
 
-    public function queryStringProvider()
+    public function queryStringProvider(): iterable
     {
         yield ['', []];
-        yield ['foo_bar=2',  [
-            'foo_bar' => '2',
-        ]];
-        yield ['foo_bar=v1&foo.bar=v2',  [
-            'foo_bar' => 'v1',
-            'foo.bar' => 'v2',
-        ]];
-        yield ['foo_bar=v1&foo.bar=v2&foo.bar_extra=v3&foo_bar3=v4',  [
-            'foo_bar' => 'v1',
-            'foo.bar' => 'v2',
-            'foo.bar_extra' => 'v3',
-            'foo_bar3' => 'v4',
-        ]];
-       yield ['foo_bar.baz=v1',  [
-            'foo_bar.baz' => 'v1',
-        ]];
-        yield ['foo_bar=v1&k[foo.bar]=v2',  [
-            'foo_bar' => 'v1',
-            'k' => ['foo.bar' => 'v2'],
-        ]];
-        yield ['k.1=v.1&k.2[s.k1]=v.2&k.2[s.k2]=v.3',  [
-            'k.1' => 'v.1',
-            'k.2' => [
-                's.k1' => 'v.2',
-                's.k2' => 'v.3',
-            ]
-        ]];
-        yield ['foo.bar%5B0%5D=v1&foo.bar_extra%5B0%5D=v2&foo.bar.extra%5B0%5D=v3',  [
-            'foo.bar' => ['v1'],
-            'foo.bar_extra' => ['v2'],
-            'foo.bar.extra' => ['v3'],
-        ]];
+
+        yield [
+            'foo_bar=2',
+            [
+                'foo_bar' => '2',
+            ],
+        ];
+
+        yield [
+            'foo_bar=v1&foo.bar=v2',
+            [
+                'foo_bar' => 'v1',
+                'foo.bar' => 'v2',
+            ],
+        ];
+
+        yield [
+            'foo_bar=v1&foo.bar=v2&foo.bar_extra=v3&foo_bar3=v4',
+            [
+                'foo_bar' => 'v1',
+                'foo.bar' => 'v2',
+                'foo.bar_extra' => 'v3',
+                'foo_bar3' => 'v4',
+            ],
+        ];
+
+        yield [
+            'foo_bar.baz=v1',
+            [
+                'foo_bar.baz' => 'v1',
+            ],
+        ];
+
+        yield [
+            'foo_bar=v1&k[foo.bar]=v2',
+            [
+                'foo_bar' => 'v1',
+                'k' => ['foo.bar' => 'v2'],
+            ],
+        ];
+
+        yield [
+            'k.1=v.1&k.2[s.k1]=v.2&k.2[s.k2]=v.3',
+            [
+                'k.1' => 'v.1',
+                'k.2' => [
+                    's.k1' => 'v.2',
+                    's.k2' => 'v.3',
+                ],
+            ],
+        ];
+
+        yield [
+            'foo.bar%5B0%5D=v1&foo.bar_extra%5B0%5D=v2&foo.bar.extra%5B0%5D=v3',
+            [
+                'foo.bar' => ['v1'],
+                'foo.bar_extra' => ['v2'],
+                'foo.bar.extra' => ['v3'],
+            ],
+        ];
     }
 }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -250,8 +250,8 @@ class HttpRequestEventTest extends CommonHttpTest
     {
         return [
             [['foo' => 'bar'], 'foo=bar', 'foo=bar'],
-            [['foo' => 'bar'], 'foo=bar', '   foo=bar  '],
-            [['foo' => 'bar'], '?foo=bar', '?foo=bar'],
+            [['foo' => 'bar  '], 'foo=bar++', '   foo=bar  '],
+            [['?foo' => 'bar'], '%3Ffoo=bar', '?foo=bar'],
             [['#foo' => 'bar'], '%23foo=bar', '#foo=bar'],
             [['foo' => 'bar'], 'foo=bar', '&foo=bar'],
             [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo', 'foo=bar&bar=foo'],
@@ -287,7 +287,7 @@ class HttpRequestEventTest extends CommonHttpTest
                     'arr_1' => 'sid',
                     'arr' => ['4' => 'fred'],
                 ],
-                'arr%5B1=sid&arr%5B4%5D=fred',
+                'arr_1=sid&arr%5B4%5D=fred',
                 'arr[1=sid&arr[4][2=fred',
             ],
             [
@@ -295,7 +295,7 @@ class HttpRequestEventTest extends CommonHttpTest
                     'arr_1' => 'sid',
                     'arr' => ['4' => ['[2' => 'fred']],
                 ],
-                'arr%5B1=sid&arr%5B4%5D%5B%5B2%5D=fred',
+                'arr_1=sid&arr%5B4%5D%5B%5B2%5D=fred',
                 'arr[1=sid&arr[4][[2][3[=fred',
             ],
         ];

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -152,4 +152,55 @@ class HttpRequestEventTest extends CommonHttpTest
 
         new HttpRequestEvent(null);
     }
+
+    /**
+     * @dataProvider queryStringProvider
+     */
+    public function testQueryStringToArray(string $query, array $expectedOutput)
+    {
+        $reflection = new \ReflectionClass(HttpRequestEvent::class);
+        $method = $reflection->getMethod('queryStringToArray');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($reflection->newInstanceWithoutConstructor(), [$query]);
+
+        $this->assertEquals($expectedOutput, $result);
+    }
+
+    public function queryStringProvider()
+    {
+        yield ['foo_bar=v1&foo.bar=v2',  [
+            'foo_bar' => 'v1',
+            'foo.bar' => 'v2',
+        ]];
+        yield ['foo_bar=v1&foo.bar=v2&foo.bar_extra=v3&foo_bar3=v4',  [
+            'foo_bar' => 'v1',
+            'foo.bar' => 'v2',
+            'foo.bar_extra' => 'v3',
+            'foo_bar3' => 'v4',
+        ]];
+       yield ['foo_bar.baz=v1',  [
+            'foo_bar.baz' => 'v1',
+        ]];
+        yield ['foo_bar=v1&k[foo.bar]=v2',  [
+            'foo_bar' => 'v1',
+            'k' => ['foo.bar' => 'v2'],
+        ]];
+        yield ['', []];
+        yield ['foo_bar=2',  [
+            'foo_bar' => '2',
+        ]];
+
+        yield ['k.1=v.1&k.2[s.k1]=v.2&k.2[s.k2]=v.3',  [
+            'k.1' => 'v.1',
+            'k.2' => [
+                's.k1' => 'v.2',
+                's.k2' => 'v.3',
+            ]
+        ]];
+        yield ['foo.bar%5B0%5D=v1&foo.bar_extra%5B0%5D=v2&foo.bar.extra%5B0%5D=v3',  [
+            'foo.bar' => ['v1'],
+            'foo.bar_extra' => ['v2'],
+            'foo.bar.extra' => ['v3'],
+        ]];
+    }
 }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -154,9 +154,9 @@ class HttpRequestEventTest extends CommonHttpTest
     }
 
     /**
-     * @dataProvider queryStringProvider
+     * @dataProvider provide query strings
      */
-    public function testQueryStringToArray(string $query, array $expectedOutput)
+    public function test query string to array(string $query, array $expectedOutput)
     {
         $reflection = new \ReflectionClass(HttpRequestEvent::class);
         $method = $reflection->getMethod('queryStringToArray');
@@ -166,7 +166,7 @@ class HttpRequestEventTest extends CommonHttpTest
         $this->assertEquals($expectedOutput, $result);
     }
 
-    public function queryStringProvider(): iterable
+    public function provide query strings(): iterable
     {
         yield ['', []];
 
@@ -232,9 +232,9 @@ class HttpRequestEventTest extends CommonHttpTest
     }
 
     /**
-     * @dataProvider provide Querystrings
+     * @dataProvider provide query strings for event
      */
-    public function test querystring will be parsed correctly(array $expected, string $normalizedQs, string $queryString)
+    public function test query string will be parsed correctly(array $expected, string $normalizedQs, string $queryString)
     {
         $event = new HttpRequestEvent([
             'httpMethod' => 'GET',
@@ -246,7 +246,7 @@ class HttpRequestEventTest extends CommonHttpTest
         self::assertSame($normalizedQs, $event->getQueryString());
     }
 
-    public function provide Querystrings()
+    public function provide query strings for event(): array
     {
         return [
             [['foo' => 'bar'], 'foo=bar', 'foo=bar'],

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -1289,7 +1289,6 @@ Year,Make,Model
         $this->fpm->start();
     }
 
-
     public function test request with encoded data()
     {
         $event = [

--- a/tests/Handler/FpmHandlerTest.php
+++ b/tests/Handler/FpmHandlerTest.php
@@ -1288,4 +1288,203 @@ Year,Make,Model
         $this->fpm = new FpmHandler($handler, __DIR__ . '/PhpFpm/php-fpm.conf');
         $this->fpm->start();
     }
+
+
+    public function test request with encoded data()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'a=%3c%3d%3d%20%20foo+bar++%3d%3d%3e&b=%23%23%23Hello+World%23%23%23',
+            'queryStringParameters' => [
+                'a' => '<==  foo bar  ==>',
+                'b' => '###Hello World###',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'a' => '<==  foo bar  ==>',
+                'b' => '###Hello World###',
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'a' => '<==  foo bar  ==>',
+                'b' => '###Hello World###',
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with single quotes()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'firstname=Billy&surname=O%27Reilly',
+            'queryStringParameters' => [
+                'firstname' => 'Billy',
+                'surname' => 'O\'Reilly',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'firstname' => 'Billy',
+                'surname' => 'O\'Reilly',
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'firstname' => 'Billy',
+                'surname' => 'O\'Reilly',
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?firstname=Billy&surname=O%27Reilly',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'firstname=Billy&surname=O%27Reilly',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with backslash characters()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'sum=10%5c2%3d5',
+            'queryStringParameters' => [
+                'sum' => '10\\2=5',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'sum' => '10\\2=5',
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'sum' => '10\\2=5',
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?sum=10%5C2%3D5',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'sum=10%5C2%3D5',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with null characters()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'str=A%20string%20with%20containing%20%00%00%00%20nulls',
+            'queryStringParameters' => [
+                'str' => "A string with containing \0\0\0 nulls",
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'str' => "A string with containing \0\0\0 nulls",
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'str' => "A string with containing \0\0\0 nulls",
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?str=A+string+with+containing+%00%00%00+nulls',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'str=A+string+with+containing+%00%00%00+nulls',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
+
+    public function test request with badly formed string()
+    {
+        $event = [
+            'version' => '2.0',
+            'httpMethod' => 'GET',
+            'path' => '/hello',
+            'rawPath' => '/hello',
+            'rawQueryString' => 'arr[1=sid&arr[4][2=fred',
+            'queryStringParameters' => [
+                'arr[1' => 'sid',
+                'arr[4][2' => 'fred',
+            ],
+        ];
+        $this->assertGlobalVariables($event, [
+            '$_GET' => [
+                'arr_1' => 'sid',
+                'arr' => [
+                    '4' => 'fred',
+                ],
+            ],
+            '$_POST' => [],
+            '$_FILES' => [],
+            '$_COOKIE' => [],
+            '$_REQUEST' => [
+                'arr_1' => 'sid',
+                'arr' => [
+                    '4' => 'fred',
+                ],
+            ],
+            '$_SERVER' => [
+                'REQUEST_URI' => '/hello?arr_1=sid&arr%5B4%5D=fred',
+                'PHP_SELF' => '/hello',
+                'PATH_INFO' => '/hello',
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'arr_1=sid&arr%5B4%5D=fred',
+                'CONTENT_LENGTH' => '0',
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+                'LAMBDA_INVOCATION_CONTEXT' => json_encode($this->fakeContext),
+                'LAMBDA_REQUEST_CONTEXT' => '[]',
+            ],
+            'HTTP_RAW_BODY' => '',
+        ]);
+    }
 }


### PR DESCRIPTION
This PR will pick up the work from @DaMitchell in #769. 

I used all existing tests and added a few new. I took inspiration from [this method](https://github.com/crwlrsoft/url/blob/v2.0.2/src/Helpers.php#L308-L330) from https://github.com/crwlrsoft/url by @otsch. 
I decided not to use that package as a dependency for two reasons: 
1. We only needed one small method. 
2. It wasn't 100% perfect

Im pinging Otsch so they can see what I did and maybe implement those changes in `crwlrsoft/url`. (Sorry for not making a PR to your package too). I did add your copyright text and credit in the method description. 

The main thing is that I wanted to support query strings with both "a_b" and "a.b". 
