### PR TITLE
Allow setting PHP as a runtime in serverless.yml

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -119,10 +119,7 @@ extension=pdo_pgsql
 
 ### Extra extensions
 
-Due to space limitations in AWS Lambda, Bref cannot provide every possible extension.
-There are a list of additional PHP extensions that can be installed as a separate
-layer. They are less common extensions or extensions that for some reasons should
-not be in the normal Bref layer.
+Due to space limitations in AWS Lambda, Bref runtimes cannot include every possible PHP extensions. These additional PHP extensions can be included as separate AWS Lambda layers.
 
 All extra PHP extensions are found in [brefphp/extra-php-extensions](https://github.com/brefphp/extra-php-extensions).
 
@@ -139,13 +136,13 @@ To create your custom layer, you will need to:
 - compile the extension (and any required libraries) in the same environment as AWS Lambda and Bref
 - include the compiled extension (and required libraries) in a layer
 - upload the layer to AWS Lambda
-- include it in your project **after the Bref layer**
+- include the in your project
 - enable the extension in a custom `php.ini`
 
 To compile the extension, Bref provides the `bref/build-php-*` Docker images. Here is an example with Blackfire:
 
 ```dockerfile
-FROM bref/build-php-74
+FROM bref/build-php-80
 
 RUN curl -A "Docker" -o /tmp/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/1.42.0/blackfire-php-linux_amd64-php-74.so"
 

--- a/docs/environment/serverless-yml.md
+++ b/docs/environment/serverless-yml.md
@@ -15,7 +15,6 @@ service: app
 
 provider:
     name: aws
-    runtime: provided.al2
 
 plugins:
     - ./vendor/bref/bref
@@ -23,8 +22,7 @@ plugins:
 functions:
     foo:
         handler: index.php
-        layers:
-            - ${bref:layer.php-74} # PHP
+        runtime: php-81
 
 resources:
     Resources:
@@ -67,18 +65,14 @@ The `provider` section also lets us configure global options on all functions:
 ```yaml
 provider:
     name: aws
+    runtime: php-81
     timeout: 10
-    runtime: provided.al2
 
 functions:
     foo:
         handler: foo.php
-        layers:
-            - ${bref:layer.php-74}
     bar:
         handler: bar.php
-        layers:
-            - ${bref:layer.php-74}
 
 # ...
 ```
@@ -92,16 +86,12 @@ provider:
 functions:
     foo:
         handler: foo.php
+        runtime: php-81
         timeout: 10
-        runtime: provided.al2
-        layers:
-            - ${bref:layer.php-74}
     bar:
         handler: bar.php
+        runtime: php-81
         timeout: 10
-        runtime: provided.al2
-        layers:
-            - ${bref:layer.php-74}
 
 # ...
 ```
@@ -115,7 +105,7 @@ plugins:
 
 [Serverless plugins](https://serverless.com/framework/docs/providers/aws/guide/plugins/) are JavaScript plugins that extend the behavior of the Serverless framework.
 
-Bref provides a plugin via the Composer package, which explains why the path is a relative path into the `vendor` directory. This plugin provides [variables to easily use Bref layers](../runtimes/#usage), it is necessary to include it for the `${bref:layer.xxx}` variables to work.
+Bref provides a plugin via the Composer package, which explains why the path is a relative path into the `vendor` directory. This plugin provides [support for the Bref runtimes and layers](../runtimes/#usage), it is necessary to include it.
 
 Most other Serverless plugins [are installed via `npm`](https://serverless.com/framework/docs/providers/aws/guide/plugins/).
 
@@ -146,17 +136,15 @@ Read more about the `package` configuration [in the serverless.yml documentation
 functions:
     foo:
         handler: foo.php
-        layers:
-            - ${bref:layer.php-74}
+        runtime: php-81
     bar:
         handler: bar.php
-        layers:
-            - ${bref:layer.php-74}
+        runtime: php-81
 ```
 
 Functions are AWS Lambda functions. You can find all options available [in this Serverless documentation page](https://serverless.com/framework/docs/providers/aws/guide/functions/).
 
-Note that it is possible to mix PHP functions with functions written in other languages. The PHP support provided by Bref works via the AWS Lambda layers.
+Note that it is possible to mix PHP functions with functions written in other languages in the same `serverless.yml` config.
 
 ### Permissions
 

--- a/docs/environment/storage.md
+++ b/docs/environment/storage.md
@@ -8,7 +8,7 @@ Here is a simplified overview of the filesystem on AWS Lambda:
 
 ```bash
 /opt/
-    # Where Lambda layers (like Bref) are unzipped
+    # Where Lambda runtimes and layers (like Bref) are unzipped
 /var/task/
     # Where your application code is unzipped
 /tmp/

--- a/docs/function/cron.md
+++ b/docs/function/cron.md
@@ -13,8 +13,7 @@ AWS Lambda lets us run [PHP functions](/docs/runtimes/function.md) as cron tasks
 functions:
     console:
         handler: function.php
-        layers:
-            - ${bref:layer.php-74}
+        runtime: php-81
         events:
             - schedule: rate(1 hour)
 ```

--- a/docs/function/handlers.md
+++ b/docs/function/handlers.md
@@ -239,14 +239,12 @@ Since a handler is a controller for a specific route, we can use API Gateway's r
 functions:
     create-article:
         handler: create-article-handler.php
-        layers:
-            - ${bref:layer.php-74}
+        runtime: php-81
         events:
             - httpApi: 'POST /articles'
     get-article:
         handler: get-article-handler.php
-        layers:
-            - ${bref:layer.php-74}
+        runtime: php-81
         events:
             - httpApi: 'GET /articles/{id}'
 ```

--- a/docs/function/local-development.md
+++ b/docs/function/local-development.md
@@ -35,8 +35,7 @@ return function (array $event) {
 functions:
     hello:
         handler: my-function.php
-        layers:
-            - ${bref:layer.php-81}
+        runtime: php-81
 ```
 
 You can invoke it with or without event data:

--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -12,7 +12,7 @@ next:
 
 There is no built-in support for PHP on AWS Lambda. Instead, we can use 3rd party runtimes via [AWS Lambda *layers*](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html).
 
-Bref provides the runtimes (or "layers") to run PHP on Lambda.
+**Bref provides open-source runtimes to run PHP on Lambda** (distributed as AWS Lambda layers).
 
 ## Bref runtimes
 
@@ -27,7 +27,7 @@ These runtimes are available as AWS Lambda layers that you can use (explained be
 
 ### Web apps
 
-Name: `php-82-fpm`, `php-81-fpm`, `php-80-fpm` and `php-74-fpm`.
+Name: `php-82-fpm`, `php-81-fpm`, and `php-80-fpm`.
 
 This runtime uses PHP-FPM to run **web applications** on AWS Lambda.
 
@@ -37,11 +37,11 @@ It's **the easiest to start with**: it works like traditional PHP hosting and is
 
 ### Event-driven functions
 
-Name: `php-82`, `php-81`, `php-80` and `php-74`.
+Name: `php-82`, `php-81`, and `php-80`.
 
 AWS Lambda was initially created to run _functions_ (yes, functions of code) in the cloud.
 
-The Bref function runtime lets you create Lambda functions in PHP like with any other language.
+The Bref "function" runtime lets you create Lambda functions in PHP like with any other language.
 
 This runtime works great to create **event-driven micro-services**.
 
@@ -49,9 +49,11 @@ _Note: if you are getting started, we highly recommend using the FPM runtime ins
 
 [Get started with the Function runtime in "Bref for event-driven functions"](/docs/runtimes/function.md).
 
-### Console: `console`
+### Console
 
-This runtime lets you run console commands on Lambda.
+Name: `php-82-console`, `php-81-console`, and `php-80-console`.
+
+This runtime lets you run CLI console commands on Lambda.
 
 For example, we can run the [Symfony Console](https://symfony.com/doc/master/components/console.html) or [Laravel Artisan](https://laravel.com/docs/artisan).
 
@@ -59,7 +61,94 @@ For example, we can run the [Symfony Console](https://symfony.com/doc/master/com
 
 ## Usage
 
-To use a runtime, import the corresponding layer in `serverless.yml`:
+To use a runtime, set it on each function in `serverless.yml`:
+
+```yaml
+service: app
+provider:
+    name: aws
+plugins:
+    - ./vendor/bref/bref
+functions:
+    hello:
+        # ...
+        runtime: php-81
+        # or:
+        runtime: php-81-fpm
+        # or:
+        runtime: php-81-console
+```
+
+Bref currently provides runtimes for PHP 8.0, 8.1 and 8.2:
+
+- `php-82`
+- `php-81`
+- `php-80`
+- `php-82-fpm`
+- `php-81-fpm`
+- `php-80-fpm`
+- `php-82-console`
+- `php-81-console`
+- `php-80-console`
+
+> `php-80` means PHP 8.0.\*. It is not possible to require a specific "patch" version. The latest Bref versions always aim to support the latest PHP versions, so upgrade frequently to keep PHP up to date.
+
+### ARM runtimes
+
+It is possible to run AWS Lambda functions on [ARM-based AWS Graviton processors](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/). This is usually considered a way to reduce costs and improve performance.
+
+You can deploy to ARM by using the `arm64` architecture:
+
+```diff
+functions:
+    api:
+        handler: public/index.php
+        runtime: php-81-fpm
++       architecture: arm64
+```
+
+The Bref plugin will detect that change and automatically use the Bref ARM Lambda layers.
+
+### The Bref plugin for serverless.yml
+
+Make sure to always include the Bref plugin in your `serverless.yml` config:
+
+```yaml
+plugins:
+    - ./vendor/bref/bref
+```
+
+This plugin is what makes `runtime: php-81` work (as well as other utilities). It is explained in more details in the section below.
+
+### AWS Lambda layers
+
+The `runtime: php-xxx` runtimes we use in `serverless.yml` are not _real_ AWS Lambda runtimes. Indeed, PHP is not supported natively on AWS Lambda.
+
+What the Bref plugin for `serverless.yml` (the one we include with `./vendor/bref/bref`) does is it automatically turns this:
+
+```yaml
+functions:
+    hello:
+        # ...
+        runtime: php-81
+```
+
+into this:
+
+```yaml
+functions:
+    hello:
+        # ...
+        runtime: provided.al2
+        layers:
+            - 'arn:aws:lambda:us-east-1:534081306603:layer:php-81:21'
+```
+
+☝️ `provided.al2` [is the generic Linux environment for custom runtimes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html#runtimes-custom-use), and the `layers` config points to Bref's AWS Lambda layers.
+
+Thanks to the Bref plugin, our `serverless.yml` is simpler. It also automatically adapts to the AWS region in use, and automatically points to the correct layer version. You will learn more about "layers" below in this page.
+
+If you want to reference AWS Lambda layers directly (instead of using the simpler `runtime: php-81` syntax), the Bref plugin also provides simple `serverless.yml` variables. These were the default in Bref v1.x, so you may find this older syntax on tutorials and blog posts:
 
 ```yaml
 service: app
@@ -70,14 +159,14 @@ plugins:
     - ./vendor/bref/bref
 functions:
     hello:
-        ...
+        # ...
         layers:
             - ${bref:layer.php-80}
             # or:
             - ${bref:layer.php-80-fpm}
 ```
 
-The `${...}` notation is the [syntax to use variables](https://serverless.com/framework/docs/providers/aws/guide/variables/) in `serverless.yml`. Bref provides a serverless plugin ("`./vendor/bref/bref`") that provides those variables:
+The `${...}` notation is the [syntax to use variables](https://serverless.com/framework/docs/providers/aws/guide/variables/) in `serverless.yml`. The Bref plugin provides the following variables:
 
 - `${bref:layer.php-82}`
 - `${bref:layer.php-81}`
@@ -87,40 +176,9 @@ The `${...}` notation is the [syntax to use variables](https://serverless.com/fr
 - `${bref:layer.php-80-fpm}`
 - `${bref:layer.console}`
 
-Bref currently provides runtimes for PHP 8.0, 8.1 and 8.2.
+Bref ARM layers are the same as the x86 layers, but with the `arm-` prefix in their name, for example `${bref:layer.arm-php-82}`. The only exception is `${bref:layer.console}` (this is the same layer for both x86 and ARM).
 
-> `php-80` means PHP 8.0.\*. It is not possible to require a specific "patch" version.
-
-### ARM runtimes
-
-> **Note**
-> ARM runtimes are currently in beta.
-
-Since 2021, it is possible to run AWS Lambda functions on [ARM-based AWS Graviton processors](https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2-processor-run-your-functions-on-arm-and-get-up-to-34-better-price-performance/). This is usually considered a way to reduce costs and improve performance.
-
-You can deploy to ARM by using the `arm64` runtime and switching to ARM Bref layers in `serverless.yml`:
-
-```diff
-functions:
-    api:
-        handler: public/index.php
-+        architecture: arm64
-        layers:
--            - ${bref:layer.php-81-fpm}
-+            - ${bref:layer.arm-php-81-fpm}
-        // ...
-```
-
-Bref ARM layers are the same as the x86 layers, but the `arm-` prefix in their name:
-
-- `${bref:layer.arm-php-81}`
-- `${bref:layer.arm-php-80}`
-- `${bref:layer.arm-php-81-fpm}`
-- `${bref:layer.arm-php-80-fpm}`
-- `${bref:layer.console}` (this is the same layer for both x86 and ARM)
-
-> **Warning**
-> ARM runtimes are built from Amazon Linux Extras packages, which only provides **PHP 8.1 and 8.0** for now.
+> **Note**: to be clear, it is easier and recommended to use the `runtime: php-xxx` option instead of setting `layers` directly.
 
 ## Lambda layers in details
 
@@ -130,18 +188,18 @@ Bref ARM layers are the same as the x86 layers, but the `arm-` prefix in their n
 >
 > ▶ [**Get started with web apps**](/docs/runtimes/http.md).
 
-Bref runtimes are [AWS Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). While Bref provides a Serverless plugin to simplify how to use them, you can use the layers directly.
+Bref runtimes are distributed as [AWS Lambda layers](https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). While Bref provides a Serverless plugin to simplify how to use them, you can use the layers directly.
 
 The layer names follow this pattern:
 
 ```
 arn:aws:lambda:<region>:534081306603:layer:<layer-name>:<layer-version>
 
-For example:
+# For example:
 arn:aws:lambda:us-east-1:534081306603:layer:php-80:21
 ```
 
-You can use layers via their full ARN, or example in `serverless.yml`:
+You can use layers via their full ARN, for example in `serverless.yml`:
 
 ```yaml
 service: app
@@ -174,6 +232,10 @@ Bref layers work with AWS Lambda regardless of the tool you use to deploy your a
 
 > Remember: the layer ARN contains a region. **You need to use the same region as the rest of your application** else Lambda will not find the layer.
 
+### Layers NPM package
+
+You can use [the `@bref.sh/layers.js` NPM package](https://github.com/brefphp/layers.js) to get up-to-date layer ARNs in Node applications, for example with the AWS CDK.
+
 ### Layer version (`<layer-version>`)
 
 The latest of runtime versions can be found at [**runtimes.bref.sh**](https://runtimes.bref.sh/).
@@ -188,7 +250,7 @@ You can also find the appropriate ARN/version for your current Bref version by r
 serverless bref:layers
 ```
 
-**Watch out:** if you use the layer ARN directly instead of the `${bref:layer.php-80}` variables (which only work in `serverless.yml`), you may need to update the ARN (the `<version>` part) when you update Bref. Follow the Bref release notes closely.
+**Watch out:** if you use the layer ARN directly, you may need to update the ARN (the `<version>` part) when you update Bref. Follow the Bref release notes closely.
 
 ### Bref ping
 

--- a/docs/runtimes/console.md
+++ b/docs/runtimes/console.md
@@ -16,27 +16,21 @@ This can be used to run PHP scripts, the [Symfony Console](https://symfony.com/d
 
 ## Configuration
 
-The lambda function used for running console applications must use two Lambda layers:
-
-- the base PHP layer that provides the `php` binary,
-- the `console` layer that overrides the base runtime to execute our console commands.
-
-Below is a minimal `serverless.yml`.
+The lambda function used for running console applications must use the `php-xx-console` runtime. Here is an example `serverless.yml`:
 
 ```yaml
 service: app
 provider:
     name: aws
-    runtime: provided.al2
 plugins:
     - ./vendor/bref/bref
 functions:
     hello:
         handler: bin/console # or 'artisan' for Laravel
-        layers:
-            - ${bref:layer.php-74} # PHP runtime
-            - ${bref:layer.console} # Console layer
+        runtime: php-81-console
 ```
+
+Behind the scenes, the `php-xx-console` runtime will deploy a Lambda function configured to use Bref's `php-81` AWS Lambda layer plus Bref's `console` layer (read more about these in the [runtimes documentation](./README.md)).
 
 ## Usage
 
@@ -46,7 +40,7 @@ To run a console command on AWS Lambda, run `serverless bref:cli` on your comput
 serverless bref:cli --args="<command to run in lambda>"
 ```
 
-The `bref:cli` command will automatically detect which function (in `serverless.yml`) uses the `console` layer and will run the command on that function.
+The `bref:cli` command will automatically detect which function (in `serverless.yml`) uses the `console` runtime and will run the command on that function.
 
 Pass your command arguments and options in the `--args` flag (shortcut: `-a`). Remember to escape quotes properly. Some examples:
 

--- a/docs/runtimes/function.md
+++ b/docs/runtimes/function.md
@@ -88,11 +88,10 @@ plugins:
 functions:
     hello:
         handler: my-function.php
-        layers:
-            - ${bref:layer.php-74}
+        runtime: php-81
 ```
 
-The runtime (aka layer) to use is `php-XX`. To learn more check out [the runtimes documentation](/docs/runtimes/README.md).
+The runtime to use is `php-XX`. To learn more check out [the runtimes documentation](/docs/runtimes/README.md).
 
 ## Invocation
 

--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -34,8 +34,7 @@ plugins:
 functions:
     app:
         handler: index.php
-        layers:
-            - ${bref:layer.php-74-fpm}
+        runtime: php-81-fpm
         events:
             - httpApi: '*'
 ```
@@ -56,13 +55,12 @@ functions:
 
 ## Runtime
 
-For web apps, the runtime (aka layer) to use is the **FPM** runtime (`php-74-fpm`):
+For web apps, the runtime to use is the **FPM** runtime (`php-81-fpm`):
 
 ```yaml
 functions:
     app:
-        layers:
-            - ${bref:layer.php-74-fpm}
+        runtime: php-81-fpm
 ```
 
 To learn more check out [the runtimes documentation](/docs/runtimes/README.md).

--- a/docs/upgrading/v2.md
+++ b/docs/upgrading/v2.md
@@ -33,6 +33,24 @@ serverless --version
 
 If you need to upgrade, [read the Serverless Framework documentation](https://www.serverless.com/framework/docs/getting-started#upgrade) (short version: run `npm install -g serverless`).
 
+## PHP runtimes
+
+There is a new (simpler) syntax to use Bref's PHP runtimes in `serverless.yml`:
+
+```yaml
+functions:
+    hello:
+        # ...
+        runtime: php-81
+        
+        # instead of:
+        runtime: provided.al2
+        layers:
+          - ${bref:layer.php-81}
+```
+
+The [bref.sh](https://bref.sh) documentation now uses the simpler `runtime: php-81` syntax, but `${bref:layer.php-xxx}` variables still work! These variables are not deprecated. There are no breaking changes here.
+
 ## Bref CLI
 
 The following commands of `vendor/bin/bref` have changed:

--- a/docs/web-apps/cron.md
+++ b/docs/web-apps/cron.md
@@ -16,9 +16,7 @@ AWS Lambda lets us run [console commands](/docs/runtimes/console.md) as cron tas
 functions:
     cron:
         handler: bin/console # or 'artisan' for Laravel
-        layers:
-            - ${bref:layer.php-74} # PHP runtime
-            - ${bref:layer.console} # Console layer
+        runtime: php-81-console
         events:
             - schedule:
                   rate: rate(1 hour)

--- a/docs/web-apps/docker.md
+++ b/docs/web-apps/docker.md
@@ -75,7 +75,7 @@ functions:
             - httpApi: '*'
 ```
 
-Instead of having a `handler` and a `layer`, we'll declare an
+Instead of having a `handler` and a `runtime`, we'll declare an
 `image`. In the `provider` block, we'll declare Docker images
 that we want to build and deploy.
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,6 @@ service: bref-demo
 
 provider:
     name: aws
-    runtime: provided.al2
     region: us-east-2
     logs:
         restApi: true
@@ -23,27 +22,25 @@ package:
 functions:
     function:
         handler: demo/function.php
-        description: 'Bref CLI demo'
-        layers:
-            - ${bref:layer.php-81}
+        runtime: php-81
+        description: 'Bref function demo'
         environment:
             BREF_LOOP_MAX: 100
 
     http:
         handler: demo/http.php
+        runtime: php-81-fpm
+        architecture: arm64
         description: 'Bref HTTP demo'
         timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
-        layers:
-            - ${bref:layer.php-81-fpm}
         events:
             -   http: 'ANY /'
 
     psr7:
         handler: demo/psr7.php
+        runtime: php-81
         description: 'Bref HTTP demo with a PSR-7 handler'
         timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
-        layers:
-            - ${bref:layer.php-81}
         events:
             -   http: 'ANY /psr7'
             -   httpApi: 'GET /psr7'
@@ -52,17 +49,14 @@ functions:
 
     http-api:
         handler: demo/http.php
+        runtime: php-81-fpm
         description: 'Bref HTTP demo'
         timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
-        layers:
-            - ${bref:layer.php-81-fpm}
         events:
             -   httpApi: '*'
 
     console:
         handler: demo/console.php
+        runtime: php-81-console
         description: 'Bref console command demo'
         timeout: 5
-        layers:
-            - ${bref:layer.php-81}
-            - ${bref:layer.console}

--- a/template/function/serverless.yml
+++ b/template/function/serverless.yml
@@ -3,7 +3,6 @@ service: app
 provider:
     name: aws
     region: us-east-1
-    runtime: provided.al2
 
 plugins:
     - ./vendor/bref/bref
@@ -12,8 +11,7 @@ functions:
     hello:
         handler: index.php
         description: ''
-        layers:
-            - ${bref:layer.php-PHP_VERSION}
+        runtime: php-PHP_VERSION
 
 # Exclude files from deployment
 package:

--- a/template/http/serverless.yml
+++ b/template/http/serverless.yml
@@ -3,7 +3,6 @@ service: app
 provider:
     name: aws
     region: us-east-1
-    runtime: provided.al2
 
 plugins:
     - ./vendor/bref/bref
@@ -12,9 +11,8 @@ functions:
     api:
         handler: index.php
         description: ''
+        runtime: php-PHP_VERSION-fpm
         timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
-        layers:
-            - ${bref:layer.php-PHP_VERSION-fpm}
         events:
             -   httpApi: '*'
 


### PR DESCRIPTION
TODO:

- [x] Gather feedback from the community
- [x] Update docs
- [x] Update templates

---

This new feature allows setting PHP as a runtime when deploying with `serverless.yml`:

```yml
service: myapp

provider:
    name: aws

functions:
    function:
        handler: function.php
        runtime: php-81

    api:
        handler: api.php
        runtime: php-81-fpm
        url: true


plugins:
    - ./vendor/bref/bref
```

This replaces the `layers` variables (**which still work!**). One could migrate to this new simpler syntax like this for example:

```diff
service: myapp

provider:
    name: aws
-    runtime: provided.al2

functions:
    function:
        handler: function.php
-        layers
-            - ${bref:layer.php-81}
+        runtime: php-81

    api:
        handler: api.php
-        layers
-            - ${bref:layer.php-81-fpm}
+        runtime: php-81-fpm
        url: true

plugins:
    - ./vendor/bref/bref
```

This [removes several wtfs for beginners](https://www.osnews.com/story/19266/wtfsm/):

- wtf is "provided.al2"
- wtf are "layers"
- wtf is that `${bref:layer.php-81-fpm}` syntax
- wtf do I need 2 layers for console

Regarding the last one, indeed things get simpler for `console`:

```diff
functions:
    console:
        handler: bin/console
-        layers
-            - ${bref:layer.php-81}
-            - ${bref:layer.console}
+        runtime: php-81-console
```

And also it makes switching to ARM much simpler too because the runtime stays the same, the layer is automatically switched to the ARM layer by the Bref plugin (it detects `architecture: arm64`):

```yml
functions:
    console:
        handler: bin/console
        architecture: arm64
        runtime: php-81 # no need to add the `arm-` prefix
```