### PR TITLE
Enable faster deployments by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,12 @@ class ServerlessPlugin {
             throw new serverless.classes.Error('Bref requires Serverless Framework v3, but an older v2 version is running.\nPlease upgrade to Serverless Framework v3.');
         }
 
+        // Automatically enable faster deployments (unless a value is already set)
+        // https://www.serverless.com/framework/docs/providers/aws/guide/deploying#deployment-method
+        if (! serverless.service.provider.deploymentMethod) {
+            serverless.service.provider.deploymentMethod = 'direct';
+        }
+
         const filename = path.resolve(__dirname, 'layers.json');
         const layers = JSON.parse(fs.readFileSync(filename).toString());
 


### PR DESCRIPTION
I set this manually in every project:

```yaml
provider:
  name: aws
  deploymentMethod: direct
```

Why not have Bref set it by default?

This PR enable the following feature by default: https://www.serverless.com/framework/docs/providers/aws/guide/deploying#deployment-method (unless the user set it explicitly in `serverless.yml`)

That makes full deployments 2 times faster or more.

See https://github.com/serverless/serverless/issues/10815 for some numbers.

---

TL/DR about the underlying issue: Serverless Framework v3 deploys with CloudFormation *changesets* enabled to show a nice progress count while the deployment progresses.

But changesets, unfortunately, make the deployment MUCH longer for no apparent reason. That's unfortunate. We introduced an option in `serverless.yml` to opt-out of these slower deployments, with the goal of making this the default for Serverless Framework v4.

The idea here is to enable this option by default with Bref. The only downside is that we lose the interactive progress, specifically the number of resources deployed in real time 🤷 