### PR TITLE
Facilitate testing handlers by adding `Context::fake()`

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -23,6 +23,19 @@ final class Context implements JsonSerializable
     }
 
     /**
+     * Test helper to create a fake context in one line.
+     */
+    public static function fake(): self
+    {
+        return new self(
+            'fake-aws-request-id',
+            time() + 1000 * 60 * 5, // 5 minutes from now (in milliseconds)
+            'fake-invoked-function-arn',
+            'fake-trace-id'
+        );
+    }
+
+    /**
      * Returns the identifier of the invocation request.
      */
     public function getAwsRequestId(): string

--- a/src/bref-local
+++ b/src/bref-local
@@ -35,12 +35,11 @@ try {
 ini_set('display_errors', '1');
 error_reporting(E_ALL);
 
-$requestId = '8f507cfc-example-4697-b07a-ac58fc914c95';
 $startTime = logStart();
 
 try {
     $invoker = new Invoker;
-    $result = $invoker->invoke($handler, $event, new Context($requestId, 0, '', ''));
+    $result = $invoker->invoke($handler, $event, Context::fake());
 } catch (Throwable $e) {
     echo get_class($e) . ': ' . $e->getMessage() . PHP_EOL;
     echo 'Stack trace:' . PHP_EOL;

--- a/tests/Event/Http/Psr7BridgeTest.php
+++ b/tests/Event/Http/Psr7BridgeTest.php
@@ -35,8 +35,7 @@ class Psr7BridgeTest extends CommonHttpTest
     protected function fromFixture(string $file): void
     {
         $event = new HttpRequestEvent(json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR));
-        $context = new Context('', 0, '', '');
-        $this->request = Psr7Bridge::convertRequest($event, $context);
+        $this->request = Psr7Bridge::convertRequest($event, Context::fake());
     }
 
     protected function assertBody(string $expected): void

--- a/tests/Event/Sqs/SqsEventTest.php
+++ b/tests/Event/Sqs/SqsEventTest.php
@@ -2,7 +2,7 @@
 
 namespace Bref\Test\Event\Sqs;
 
-use Bref\Context\ContextBuilder;
+use Bref\Context\Context;
 use Bref\Event\InvalidLambdaEvent;
 use Bref\Event\Sqs\SqsEvent;
 use Bref\Test\Fixture\SqsFakeHandler;
@@ -47,7 +47,7 @@ class SqsEventTest extends TestCase
     public function test partial failure()
     {
         $event = json_decode(file_get_contents(__DIR__ . '/handler.json'), true);
-        $result = (new SqsFakeHandler)->handle($event, (new ContextBuilder)->buildContext());
+        $result = (new SqsFakeHandler)->handle($event, Context::fake());
 
         self::assertSame($result, [
             'batchItemFailures' => [


### PR DESCRIPTION
This is an alternative approach to solve #1396, but just fo the `Context` class. It implies adding `::fake()` to facilitate creating instances.