### PR TITLE
Introduce SqsEventFactory

### DIFF
--- a/src/Event/Sqs/SqsEvent.php
+++ b/src/Event/Sqs/SqsEvent.php
@@ -2,9 +2,7 @@
 
 namespace Bref\Event\Sqs;
 
-use Bref\Event\InvalidLambdaEvent;
 use Bref\Event\LambdaEvent;
-use InvalidArgumentException;
 
 /**
  * Represents a Lambda event when Lambda is invoked by SQS.
@@ -12,13 +10,12 @@ use InvalidArgumentException;
 final class SqsEvent implements LambdaEvent
 {
     private array $event;
+    private array $records;
 
-    public function __construct(mixed $event)
+    public function __construct(array $records, mixed $event)
     {
-        if (! is_array($event) || ! isset($event['Records'])) {
-            throw new InvalidLambdaEvent('SQS', $event);
-        }
         $this->event = $event;
+        $this->records = $records;
     }
 
     /**
@@ -26,13 +23,7 @@ final class SqsEvent implements LambdaEvent
      */
     public function getRecords(): array
     {
-        return array_map(function ($record): SqsRecord {
-            try {
-                return new SqsRecord($record);
-            } catch (InvalidArgumentException) {
-                throw new InvalidLambdaEvent('SQS', $this->event);
-            }
-        }, $this->event['Records']);
+        return $this->records;
     }
 
     public function toArray(): array

--- a/src/Event/Sqs/SqsEventFactory.php
+++ b/src/Event/Sqs/SqsEventFactory.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\Sqs;
+
+use Bref\Event\InvalidLambdaEvent;
+use InvalidArgumentException;
+
+final class SqsEventFactory implements SqsEventFactoryInterface
+{
+    public function createFromPayload(array $payload): SqsEvent
+    {
+        if (! isset($payload['Records'])) {
+            throw new InvalidLambdaEvent('SQS', $payload);
+        }
+
+        return new SqsEvent(array_map([$this, 'createSqsRecord'], $payload['Records']), $payload);
+    }
+
+    private function createSqsRecord(array $payload): SqsRecord
+    {
+        if (! isset($payload['eventSource']) || $payload['eventSource'] !== 'aws:sqs') {
+            throw new InvalidArgumentException;
+        }
+        return new SqsRecord(
+            $payload['messageId'],
+            $payload['body'],
+            $payload['messageAttributes'],
+            (int) $payload['attributes']['ApproximateReceiveCount'],
+            $payload['receiptHandle'],
+            $payload,
+        );
+    }
+}

--- a/src/Event/Sqs/SqsEventFactoryInterface.php
+++ b/src/Event/Sqs/SqsEventFactoryInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Event\Sqs;
+
+interface SqsEventFactoryInterface
+{
+    public function createFromPayload(array $payload): SqsEvent;
+}

--- a/src/Event/Sqs/SqsHandler.php
+++ b/src/Event/Sqs/SqsHandler.php
@@ -10,6 +10,16 @@ use Bref\Event\Handler;
  */
 abstract class SqsHandler implements Handler
 {
+    private SqsEventFactoryInterface $eventFactory;
+
+    public function __construct(?SqsEventFactoryInterface $eventFactory = null)
+    {
+        if (! $eventFactory) {
+            $eventFactory = new SqsEventFactory;
+        }
+        $this->eventFactory = $eventFactory;
+    }
+
     /** @var SqsRecord[] */
     private array $failedRecords = [];
 
@@ -21,7 +31,7 @@ abstract class SqsHandler implements Handler
         // Reset the failed records to clear the internal state when using BREF_LOOP_MAX
         $this->failedRecords = [];
 
-        $this->handleSqs(new SqsEvent($event), $context);
+        $this->handleSqs($this->eventFactory->createFromPayload($event), $context);
 
         if (count($this->failedRecords) === 0) {
             return [];

--- a/src/Event/Sqs/SqsRecord.php
+++ b/src/Event/Sqs/SqsRecord.php
@@ -2,23 +2,34 @@
 
 namespace Bref\Event\Sqs;
 
-use InvalidArgumentException;
-
 final class SqsRecord
 {
+    private string $messageId;
+    private string $body;
+    private array $messageAttributes;
+    private int $approximateReceiveCount;
+    private string $receiptHandle;
     private array $record;
 
-    public function __construct(mixed $record)
-    {
-        if (! is_array($record) || ! isset($record['eventSource']) || $record['eventSource'] !== 'aws:sqs') {
-            throw new InvalidArgumentException;
-        }
-        $this->record = $record;
+    public function __construct(
+        string $messageId,
+        string $body,
+        array $messageAttributes,
+        int $approximateReceiveCount,
+        string $receiptHandle,
+        array $rawRecord,
+    ) {
+        $this->messageId = $messageId;
+        $this->body = $body;
+        $this->messageAttributes = $messageAttributes;
+        $this->approximateReceiveCount = $approximateReceiveCount;
+        $this->receiptHandle = $receiptHandle;
+        $this->record = $rawRecord;
     }
 
     public function getMessageId(): string
     {
-        return $this->record['messageId'];
+        return $this->messageId;
     }
 
     /**
@@ -27,7 +38,7 @@ final class SqsRecord
      */
     public function getBody(): string
     {
-        return $this->record['body'];
+        return $this->body;
     }
 
     /**
@@ -35,7 +46,7 @@ final class SqsRecord
      */
     public function getMessageAttributes(): array
     {
-        return $this->record['messageAttributes'];
+        return $this->messageAttributes;
     }
 
     /**
@@ -43,7 +54,7 @@ final class SqsRecord
      */
     public function getApproximateReceiveCount(): int
     {
-        return (int) $this->record['attributes']['ApproximateReceiveCount'];
+        return $this->approximateReceiveCount;
     }
 
     /**
@@ -51,7 +62,7 @@ final class SqsRecord
      */
     public function getReceiptHandle(): string
     {
-        return $this->record['receiptHandle'];
+        return $this->receiptHandle;
     }
 
     /**

--- a/tests/Event/Sqs/SqsEventTest.php
+++ b/tests/Event/Sqs/SqsEventTest.php
@@ -3,47 +3,11 @@
 namespace Bref\Test\Event\Sqs;
 
 use Bref\Context\ContextBuilder;
-use Bref\Event\InvalidLambdaEvent;
-use Bref\Event\Sqs\SqsEvent;
 use Bref\Test\Fixture\SqsFakeHandler;
 use PHPUnit\Framework\TestCase;
 
 class SqsEventTest extends TestCase
 {
-    public function test canonical case()
-    {
-        $event = json_decode(file_get_contents(__DIR__ . '/sqs.json'), true);
-        $event = new SqsEvent($event);
-
-        $record = $event->getRecords()[0];
-        $this->assertSame('059f36b4-87a3-44ab-83d2-661975830a7d', $record->getMessageId());
-        $this->assertSame('Test message.', $record->getBody());
-        $this->assertSame([
-            'Foobar' => [
-                'stringValue' => 'my value',
-                'stringListValues' => [],
-                'binaryListValues' => [],
-                'dataType' => 'String',
-            ],
-        ], $record->getMessageAttributes());
-        $this->assertSame(1, $record->getApproximateReceiveCount());
-        $this->assertSame('AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...', $record->getReceiptHandle());
-
-        $record = $event->getRecords()[1];
-        $this->assertSame('2e1424d4-f796-459a-8184-9c92662be6da', $record->getMessageId());
-        $this->assertSame('Test message.', $record->getBody());
-        $this->assertSame([], $record->getMessageAttributes());
-        $this->assertSame(4, $record->getApproximateReceiveCount());
-        $this->assertSame('AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...', $record->getReceiptHandle());
-    }
-
-    public function test invalid event()
-    {
-        $this->expectException(InvalidLambdaEvent::class);
-        $this->expectExceptionMessage('This handler expected to be invoked with a SQS event. Instead, the handler was invoked with invalid event data');
-        new SqsEvent([]);
-    }
-
     public function test partial failure()
     {
         $event = json_decode(file_get_contents(__DIR__ . '/handler.json'), true);

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -12,6 +12,7 @@ use Bref\Event\S3\S3Handler;
 use Bref\Event\Sns\SnsEvent;
 use Bref\Event\Sns\SnsHandler;
 use Bref\Event\Sqs\SqsEvent;
+use Bref\Event\Sqs\SqsEventFactory;
 use Bref\Event\Sqs\SqsHandler;
 use Bref\Runtime\LambdaRuntime;
 use Bref\Test\Server;
@@ -231,7 +232,7 @@ ERROR;
 
         $this->runtime->processNextEvent($handler);
 
-        $this->assertEquals(new SqsEvent($eventData), $handler->event);
+        $this->assertEquals((new SqsEventFactory)->createFromPayload($eventData), $handler->event);
     }
 
     public function test SNS event handler()


### PR DESCRIPTION
@mnapoli , You asked on [Twitter](https://twitter.com/matthieunapoli/status/1622258374837420032), if there is an elegant way, to mock the Event classes, but keep the final.
data structures normally do not have to be mocked, since they are just data structures. If the construction of them is too complex, it should get encapsulated in a factory.

I prepared and example, which also showcases, that the test responsibility moved too the FactoryTest and leaves the EventTest small.

In Tests, you can easily have a helper, for these Events. We at work have for example a trait for tests which is called like `ProvidesFakeEvents` and this has then methods like `createRandomValidEvent()`.
Here a code example:
```php
<?php declare(strict_types=1);

namespace Bref\Test\Traits;

use Bref\Event\Sqs\SqsEvent;
use Bref\Event\Sqs\SqsEventFactory;

trait ProvidesFakeEvents
{
    protected function getValidSqsEvent(): SqsEvent
    {
        $rawEvent = json_decode(file_get_contents(dirname(__DIR__) . '/Event/Sqs/sqs.json'), true);

        return (new SqsEventFactory())->createFromPayload($rawEvent);
    }
}

```
It is absolutely fine to use such a factory for static data in you test helpers, since it is also covered by unit tests.

Happy to hear you opinion on this.


