### PR TITLE
Exclude .git directory from deployment

### DIFF
--- a/template/http/serverless.yml
+++ b/template/http/serverless.yml
@@ -24,3 +24,4 @@ package:
     patterns:
         - '!node_modules/**'
         - '!tests/**'
+        - '!.git/**'


### PR DESCRIPTION
Due to some repository having a big .git file, this change adds the exclusion of the .git directory to the list of patterns in the deployment process. This also ensures that sensitive version control information is not deployed along with the rest of the code, reducing the size of the deployment package.