### PR TITLE
Add hook system to make the Bref runtime more extensible

### DIFF
--- a/src/Bref.php
+++ b/src/Bref.php
@@ -11,6 +11,10 @@ class Bref
 {
     private static ?Closure $containerProvider = null;
     private static ?ContainerInterface $container = null;
+    private static array $hooks = [
+        'beforeStartup' => [],
+        'beforeInvoke' => [],
+    ];
 
     /**
      * Configure the container that provides Lambda handlers.
@@ -20,6 +24,42 @@ class Bref
     public static function setContainer(Closure $containerProvider): void
     {
         self::$containerProvider = $containerProvider;
+    }
+
+    /**
+     * Register a hook to be executed before the runtime starts.
+     *
+     * Warning: hooks are low-level extension points to be used by framework
+     * integrations. For user code, it is not recommended to use them. Use your
+     * framework's extension points instead.
+     */
+    public static function beforeStartup(Closure $hook): void
+    {
+        self::$hooks['beforeStartup'][] = $hook;
+    }
+
+    /**
+     * Register a hook to be executed before any Lambda invocation.
+     *
+     * Warning: hooks are low-level extension points to be used by framework
+     * integrations. For user code, it is not recommended to use them. Use your
+     * framework's extension points instead.
+     */
+    public static function beforeInvoke(Closure $hook): void
+    {
+        self::$hooks['beforeInvoke'][] = $hook;
+    }
+
+    /**
+     * @param 'beforeStartup'|'beforeInvoke' $hookName
+     *
+     * @internal Used by the Bref runtime
+     */
+    public static function triggerHooks(string $hookName): void
+    {
+        foreach (self::$hooks[$hookName] as $hook) {
+            $hook();
+        }
     }
 
     /**

--- a/src/ConsoleRuntime/Main.php
+++ b/src/ConsoleRuntime/Main.php
@@ -2,6 +2,7 @@
 
 namespace Bref\ConsoleRuntime;
 
+use Bref\Bref;
 use Bref\Context\Context;
 use Bref\Runtime\LambdaRuntime;
 use Bref\Secrets\Secrets;
@@ -13,6 +14,8 @@ class Main
     public static function run(): void
     {
         Secrets::decryptSecretEnvironmentVariables();
+
+        Bref::triggerHooks('beforeStartup');
 
         $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable('console');
 

--- a/src/FunctionRuntime/Main.php
+++ b/src/FunctionRuntime/Main.php
@@ -13,6 +13,8 @@ class Main
     {
         Secrets::decryptSecretEnvironmentVariables();
 
+        Bref::triggerHooks('beforeStartup');
+
         $lambdaRuntime = LambdaRuntime::fromEnvironmentVariable('function');
 
         $container = Bref::getContainer();

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -2,6 +2,7 @@
 
 namespace Bref\Runtime;
 
+use Bref\Bref;
 use Bref\Context\Context;
 use Bref\Context\ContextBuilder;
 use Bref\Event\Handler;
@@ -79,7 +80,7 @@ final class LambdaRuntime
     {
         [$event, $context] = $this->waitNextInvocation();
 
-        $this->hook();
+        Bref::triggerHooks('beforeInvoke');
 
         $this->ping();
 
@@ -302,16 +303,6 @@ final class LambdaRuntime
         if ($this->curlHandleResult !== null) {
             curl_close($this->curlHandleResult);
             $this->curlHandleResult = null;
-        }
-    }
-
-    private function hook(): void
-    {
-        /**
-         * This is completely experimental, do not use
-         */
-        if (isset($_SERVER['BREF_HOOK_BEFORE_INVOKE'])) {
-            system($_SERVER['BREF_HOOK_BEFORE_INVOKE']);
         }
     }
 

--- a/tests/BrefTest.php
+++ b/tests/BrefTest.php
@@ -10,8 +10,6 @@ class BrefTest extends TestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
-
         Bref::reset();
     }
 
@@ -31,5 +29,35 @@ class BrefTest extends TestCase
         });
 
         $this->assertSame($container, Bref::getContainer());
+    }
+
+    public function test hooks(): void
+    {
+        $beforeStartup1 = false;
+        $beforeStartup2 = false;
+        $beforeInvoke = false;
+
+        // Check that we can set multiple handlers
+        Bref::beforeStartup(function () use (&$beforeStartup1) {
+            return $beforeStartup1 = true;
+        });
+        Bref::beforeStartup(function () use (&$beforeStartup2) {
+            return $beforeStartup2 = true;
+        });
+        Bref::beforeInvoke(function () use (&$beforeInvoke) {
+            return $beforeInvoke = true;
+        });
+
+        $this->assertFalse($beforeStartup1);
+        $this->assertFalse($beforeStartup2);
+        $this->assertFalse($beforeInvoke);
+
+        Bref::triggerHooks('beforeStartup');
+        $this->assertTrue($beforeStartup1);
+        $this->assertTrue($beforeStartup2);
+        $this->assertFalse($beforeInvoke);
+
+        Bref::triggerHooks('beforeInvoke');
+        $this->assertTrue($beforeInvoke);
     }
 }

--- a/tests/ConsoleRuntime/MainTest.php
+++ b/tests/ConsoleRuntime/MainTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test\ConsoleRuntime;
+
+use Bref\Bref;
+use Bref\ConsoleRuntime\Main;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class MainTest extends TestCase
+{
+    public function test startup hook is called()
+    {
+        Bref::beforeStartup(function () {
+            throw new Exception('This should be called');
+        });
+
+        $this->expectExceptionMessage('This should be called');
+        Main::run();
+    }
+}

--- a/tests/FunctionRuntime/MainTest.php
+++ b/tests/FunctionRuntime/MainTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test\FunctionRuntime;
+
+use Bref\Bref;
+use Bref\FunctionRuntime\Main;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class MainTest extends TestCase
+{
+    public function test startup hook is called()
+    {
+        Bref::beforeStartup(function () {
+            throw new Exception('This should be called');
+        });
+
+        $this->expectExceptionMessage('This should be called');
+        Main::run();
+    }
+}


### PR DESCRIPTION
This new "hook system" allows 3rd party packages or user code to register hooks on:

- startup (i.e. cold start), before anything else runs
- before Lambda invocations

So far, I have seen that being (legitimately) useful twice for low-level integrations:

- Laravel bridge, to run `php artisan make:config` (or run other caching commands) on cold starts -> that could also be useful for Symfony
- for Bref Live (currently at the prototype stage) that lets users edit code live on Lambda (not published yet)

My initial approach was to try and add environment variables to register shell commands to execute, but that is unnecessarily expensive and harder to set up (because environment variables must be set in `serverless.yml`). With this new system, packages can register hooks automatically, just like with `Bref::setContainer()`.

The targets for this new hook system are not end users (at least from what I can see). This is targeted at packages providing framework integrations or enhancing Bref on a low level.

Adding new extension points is something I don't want to do lightly, as it's the best way to cement/add crust to a system, leading to it being very hard to refactor and maintain down the road. However here it seems like a very good solution for framework integrations, and it is very little invasive. So the balance seems ok.

I'll keep this PR open at first to do some implementation tests.

Note: there is no public documentation for this, this is intentional.