### PR TITLE
Update usage examples to a current version of PHP

### DIFF
--- a/docs/runtimes/http.md
+++ b/docs/runtimes/http.md
@@ -35,7 +35,7 @@ functions:
     app:
         handler: index.php
         layers:
-            - ${bref:layer.php-74-fpm}
+            - ${bref:layer.php-82-fpm}
         events:
             - httpApi: '*'
 ```
@@ -56,13 +56,13 @@ functions:
 
 ## Runtime
 
-For web apps, the runtime (aka layer) to use is the **FPM** runtime (`php-74-fpm`):
+For web apps, the runtime (aka layer) to use is the **FPM** runtime (`php-82-fpm`):
 
 ```yaml
 functions:
     app:
         layers:
-            - ${bref:layer.php-74-fpm}
+            - ${bref:layer.php-82-fpm}
 ```
 
 To learn more check out [the runtimes documentation](/docs/runtimes/README.md).


### PR DESCRIPTION
The usage examples showed using the PHP 7.4 PHP-FPM layer, but 7.4 has been unsupported since Nov 2022