### PR TITLE
Add CLI telemetry

### DIFF
--- a/bref
+++ b/bref
@@ -26,4 +26,56 @@ $app->add(new Local());
 $app->add(new Dashboard());
 $app->add(new Layers());
 
+telemetry();
+
 $app->run();
+
+/**
+ * Bref telemetry to estimate the number of users and which commands are most used.
+ *
+ * The data sent is anonymous, and sent over UDP.
+ * Unlike TCP, UDP does not check that the message correctly arrived to the server.
+ * It doesn't even establish a connection: the data is sent over the network and the code moves on to the next line.
+ * That means that UDP is extremely fast (150 micro-seconds) and will not impact the CLI.
+ * It can be disabled by setting the `SLS_TELEMETRY_DISABLED` environment variable to `1`.
+ *
+ * About UDP: https://en.wikipedia.org/wiki/User_Datagram_Protocol
+ */
+function telemetry() {
+    global $argv;
+    // Respect the serverless framework env variable
+    if ($_SERVER['SLS_TELEMETRY_DISABLED'] ?? false) {
+        return;
+    }
+    // Support cases where the sockets extension is not installed
+    if (! function_exists('socket_create')) {
+        return;
+    }
+
+    // Read `~/.serverlessrc` if it exists
+    $userConfigPath = $_SERVER['HOME'] . '/.serverlessrc';
+    if (file_exists($userConfigPath)) {
+        $userConfig = json_decode(file_get_contents($userConfigPath), true, 512, JSON_THROW_ON_ERROR);
+    } else {
+        $userConfig = [];
+    }
+
+    // Check if we are running in CI
+    $ci = $_SERVER['CI'] || $_SERVER['CONTINUOUS_INTEGRATION'] || $_SERVER['BUILD_NUMBER'] || $_SERVER['CI_APP_ID'] || $_SERVER['CI_NAME'] || $_SERVER['RUN_ID'] || $_SERVER['BUILD_ID'];
+
+    $message = json_encode([
+        'cli' => 'vendor/bin/bref',
+        'v' => 1, // Bref version
+        'c' => $argv[1] ?? '',
+        'ci' => $ci,
+        // anonymous user ID created by the Serverless Framework
+        'uid' => $userConfig['frameworkId'] ?? '',
+    ], JSON_THROW_ON_ERROR);
+
+    $sock = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+    // This IP address is the Bref server.
+    // If this server is down or unreachable, there should be no difference in overhead
+    // or execution time.
+    socket_sendto($sock, $message, strlen($message), 0, '108.128.197.71', 8888);
+    socket_close($sock);
+}


### PR DESCRIPTION
I finally managed to implement telemetry for the CLI (`serverless` and `vendor/bin/bref`) with no performance impact (this is something that I think is important, telemetry is great to improve the product but often it has some visible impact).

It uses the same technique as the "Bref ping" telemetry in the layers, i.e. data is sent over UDP. UDP is not as reliable as TCP, so some data might be lost, but telemetry is about getting a sense of the usage.

If you are interested, here was the original PR to add basic telemetry in layers: https://github.com/brefphp/bref/pull/674

This was extremely useful over the last few years to discuss with AWS and other companies. We can now know that [Bref runs 10 billion invocations per month](https://twitter.com/matthieunapoli/status/1603032544424894464). Knowing how many users are using Bref, and which features are most used, will be useful to plan the next features in the CLI. (especially since I'm considering the idea of building a new CLI specialized for Bref users, with new features)

I am opening this PR against Bref v1 because I want to know which percentage of users stay on Bref v1 and which upgrade to v2 over time.