### PR TITLE
Move `final` to an annotation so that event classes can be mocked in tests

### DIFF
--- a/src/Event/ApiGateway/WebsocketEvent.php
+++ b/src/Event/ApiGateway/WebsocketEvent.php
@@ -7,8 +7,10 @@ use Bref\Event\LambdaEvent;
 
 /**
  * Represents a Lambda event when Lambda is invoked by ApiGateway websocket route.
+ *
+ * @final
  */
-final class WebsocketEvent implements LambdaEvent
+class WebsocketEvent implements LambdaEvent
 {
     private array $event;
     private string $routeKey;

--- a/src/Event/DynamoDb/DynamoDbEvent.php
+++ b/src/Event/DynamoDb/DynamoDbEvent.php
@@ -8,8 +8,10 @@ use InvalidArgumentException;
 
 /**
  * Represents a Lambda event when Lambda is invoked by DynamoDB Streams.
+ *
+ * @final
  */
-final class DynamoDbEvent implements LambdaEvent
+class DynamoDbEvent implements LambdaEvent
 {
     private array $event;
 

--- a/src/Event/DynamoDb/DynamoDbRecord.php
+++ b/src/Event/DynamoDb/DynamoDbRecord.php
@@ -4,7 +4,10 @@ namespace Bref\Event\DynamoDb;
 
 use InvalidArgumentException;
 
-final class DynamoDbRecord
+/**
+ * @final
+ */
+class DynamoDbRecord
 {
     private array $record;
 

--- a/src/Event/EventBridge/EventBridgeEvent.php
+++ b/src/Event/EventBridge/EventBridgeEvent.php
@@ -8,8 +8,10 @@ use DateTimeImmutable;
 
 /**
  * Represents a Lambda event when Lambda is invoked by EventBridge.
+ *
+ * @final
  */
-final class EventBridgeEvent implements LambdaEvent
+class EventBridgeEvent implements LambdaEvent
 {
     private array $event;
 

--- a/src/Event/Kafka/KafkaEvent.php
+++ b/src/Event/Kafka/KafkaEvent.php
@@ -6,7 +6,10 @@ use Bref\Event;
 use Bref\Event\InvalidLambdaEvent;
 use InvalidArgumentException;
 
-final class KafkaEvent implements Event\LambdaEvent
+/**
+ * @final
+ */
+class KafkaEvent implements Event\LambdaEvent
 {
     private array $event;
 

--- a/src/Event/Kafka/KafkaHandler.php
+++ b/src/Event/Kafka/KafkaHandler.php
@@ -10,7 +10,7 @@ abstract class KafkaHandler implements Handler
     abstract public function handleKafka(KafkaEvent $event, Context $context): void;
 
     /** {@inheritDoc} */
-    final public function handle($event, Context $context)
+    public function handle($event, Context $context)
     {
         $this->handleKafka(new KafkaEvent($event), $context);
     }

--- a/src/Event/Kafka/KafkaRecord.php
+++ b/src/Event/Kafka/KafkaRecord.php
@@ -4,7 +4,10 @@ namespace Bref\Event\Kafka;
 
 use InvalidArgumentException;
 
-final class KafkaRecord
+/**
+ * @final
+ */
+class KafkaRecord
 {
     private array $record;
 

--- a/src/Event/Kinesis/KinesisEvent.php
+++ b/src/Event/Kinesis/KinesisEvent.php
@@ -6,7 +6,10 @@ use Bref\Event\InvalidLambdaEvent;
 use Bref\Event\LambdaEvent;
 use InvalidArgumentException;
 
-final class KinesisEvent implements LambdaEvent
+/**
+ * @final
+ */
+class KinesisEvent implements LambdaEvent
 {
     private array $event;
 

--- a/src/Event/Kinesis/KinesisRecord.php
+++ b/src/Event/Kinesis/KinesisRecord.php
@@ -5,7 +5,10 @@ namespace Bref\Event\Kinesis;
 use DateTimeImmutable;
 use InvalidArgumentException;
 
-final class KinesisRecord
+/**
+ * @final
+ */
+class KinesisRecord
 {
     private array $record;
 

--- a/src/Event/S3/S3Event.php
+++ b/src/Event/S3/S3Event.php
@@ -10,8 +10,10 @@ use InvalidArgumentException;
  * Represents an event when Lambda is invoked by S3.
  *
  * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
+ *
+ * @final
  */
-final class S3Event implements LambdaEvent
+class S3Event implements LambdaEvent
 {
     private array $event;
 

--- a/src/Event/S3/S3Record.php
+++ b/src/Event/S3/S3Record.php
@@ -7,8 +7,10 @@ use InvalidArgumentException;
 
 /**
  * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
+ *
+ * @final
  */
-final class S3Record
+class S3Record
 {
     private array $record;
 

--- a/src/Event/Sns/SnsEvent.php
+++ b/src/Event/Sns/SnsEvent.php
@@ -8,8 +8,10 @@ use InvalidArgumentException;
 
 /**
  * Represents a Lambda event when Lambda is invoked by SNS.
+ *
+ * @final
  */
-final class SnsEvent implements LambdaEvent
+class SnsEvent implements LambdaEvent
 {
     private array $event;
 

--- a/src/Event/Sns/SnsRecord.php
+++ b/src/Event/Sns/SnsRecord.php
@@ -9,8 +9,10 @@ use InvalidArgumentException;
  * Represents a SNS message record.
  *
  * For more information about each field, see https://docs.aws.amazon.com/sns/latest/api/API_Publish.html
+ *
+ * @final
  */
-final class SnsRecord
+class SnsRecord
 {
     private array $record;
 

--- a/src/Event/Sqs/SqsEvent.php
+++ b/src/Event/Sqs/SqsEvent.php
@@ -8,8 +8,10 @@ use InvalidArgumentException;
 
 /**
  * Represents a Lambda event when Lambda is invoked by SQS.
+ *
+ * @final
  */
-final class SqsEvent implements LambdaEvent
+class SqsEvent implements LambdaEvent
 {
     private array $event;
 

--- a/src/Event/Sqs/SqsRecord.php
+++ b/src/Event/Sqs/SqsRecord.php
@@ -4,7 +4,10 @@ namespace Bref\Event\Sqs;
 
 use InvalidArgumentException;
 
-final class SqsRecord
+/**
+ * @final
+ */
+class SqsRecord
 {
     private array $record;
 


### PR DESCRIPTION
Fix #1396 

PHPStan will honor the `@final` annotation for users that use it.