### PR TITLE
Allow setting `runtime: php-xx` in `provider.runtime`

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -3,6 +3,7 @@ service: bref-demo
 provider:
     name: aws
     region: us-east-2
+    runtime: php-81
     logs:
         restApi: true
     apiGateway:
@@ -22,7 +23,6 @@ package:
 functions:
     function:
         handler: demo/function.php
-        runtime: php-81
         description: 'Bref function demo'
         environment:
             BREF_LOOP_MAX: 100
@@ -38,7 +38,6 @@ functions:
 
     psr7:
         handler: demo/psr7.php
-        runtime: php-81
         description: 'Bref HTTP demo with a PSR-7 handler'
         timeout: 5 # in seconds (API Gateway has a timeout of 29 seconds)
         events:


### PR DESCRIPTION
Fix #1431
