### PR TITLE
Fix bref console bootstrap if using old versions of symfony/process

### DIFF
--- a/runtime/layers/console/bootstrap
+++ b/runtime/layers/console/bootstrap
@@ -58,7 +58,11 @@ while (true) {
 
         $timeout = max(1, $context->getRemainingTimeInMillis() / 1000 - 1);
         $command = sprintf('/opt/bin/php %s %s 2>&1', $handlerFile, $cliOptions);
-        $process = Process::fromShellCommandline($command, null, ['LAMBDA_INVOCATION_CONTEXT' => json_encode($context)], null, $timeout);
+        if (\method_exists(Process::class, 'fromShellCommandline')) {
+            $process = Process::fromShellCommandline($command, null, ['LAMBDA_INVOCATION_CONTEXT' => json_encode($context)], null, $timeout);
+        } else {
+            $process = new Process($command, null, ['LAMBDA_INVOCATION_CONTEXT' => json_encode($context)], null, $timeout);
+        }
 
         $process->run(function ($type, $buffer) {
             echo $buffer;


### PR DESCRIPTION
If you're using "symfony/process" older than ^4.2 method "fromShellCommandline" doesn't exists.

![Captura de pantalla 2023-03-09 a las 13 26 52](https://user-images.githubusercontent.com/13980708/224022838-82dac36e-e5d6-4a17-a82f-d055df02da55.png)

I checked that most of the php libraries, like "knp-snappy" or Symfony itself checks if method exists.
![Captura de pantalla 2023-03-09 a las 13 28 40](https://user-images.githubusercontent.com/13980708/224023304-77fcd5c0-8793-4014-966e-89dfef309eaa.png)
![Captura de pantalla 2023-03-09 a las 13 30 37](https://user-images.githubusercontent.com/13980708/224023726-acc5a264-2363-4ca6-9648-e8f79df94417.png)
