### PR TITLE
Upgrade guzzle in dev-deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "dms/phpunit-arraysubset-asserts": "^0.2.0",
         "doctrine/coding-standard": "^8.0",
         "phpstan/phpstan": "^1.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^7.5",
         "symfony/console": "^3.0|^4.0|^5.0|^6.0"
     },
     "scripts": {

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -107,7 +107,7 @@ class LambdaRuntimeTest extends TestCase
             new Response( // lambda event
                 404, // 404 instead of 200
                 [
-                    'lambda-runtime-aws-request-id' => 1,
+                    'lambda-runtime-aws-request-id' => '1',
                 ],
                 '{ "Hello": "world!"}'
             ),
@@ -139,7 +139,7 @@ class LambdaRuntimeTest extends TestCase
             new Response( // lambda event
                 200,
                 [
-                    'lambda-runtime-aws-request-id' => 1,
+                    'lambda-runtime-aws-request-id' => '1',
                 ]
             ),
         ]);
@@ -154,7 +154,7 @@ class LambdaRuntimeTest extends TestCase
             new Response( // lambda event
                 200,
                 [
-                    'lambda-runtime-aws-request-id' => 1,
+                    'lambda-runtime-aws-request-id' => '1',
                 ],
                 '{ "Hello": "world!"}'
             ),


### PR DESCRIPTION
Guzzle 6 is EOL (well, at my discretion - the security policy says support for 2 years after release of v7, which means it has been EOL since June 2022, though I have not yet officially marked it as EOL in the supported versions table).