### PR TITLE
Drop Symfony versions that don't support PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=8.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "symfony/process": "^4.2|^5.0|^6.0",
+        "symfony/process": "^4.4|^5.0|^6.0",
         "psr/http-message": "^1.0",
         "hollodotme/fast-cgi-client": "^3.0.1",
         "riverline/multipart-parser": "^2.0.6",
@@ -41,7 +41,7 @@
         "doctrine/coding-standard": "^8.0",
         "phpstan/phpstan": "^1.0",
         "guzzlehttp/guzzle": "^7.5",
-        "symfony/console": "^3.0|^4.0|^5.0|^6.0"
+        "symfony/console": "^4.4|^5.0|^6.0"
     },
     "scripts": {
         "test": [


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
