### PR TITLE
[Serverless Plugin] Prevent errors when combined with unlayered functions

### DIFF
--- a/plugin/run-console.js
+++ b/plugin/run-console.js
@@ -18,7 +18,7 @@ function getConsoleFunction(serverless, region) {
     const functions = serverless.service.functions;
     const consoleFunctions = [];
     for (const [functionName, functionDetails] of Object.entries(functions)) {
-        if (functionDetails.layers.includes(consoleLayerArn)) {
+        if (functionDetails.layers && functionDetails.layers.includes(consoleLayerArn)) {
             consoleFunctions.push(functionName);
         }
     }

--- a/plugin/run-console.js
+++ b/plugin/run-console.js
@@ -18,7 +18,7 @@ function getConsoleFunction(serverless, region) {
     const functions = serverless.service.functions;
     const consoleFunctions = [];
     for (const [functionName, functionDetails] of Object.entries(functions)) {
-        if (functionDetails.layers && functionDetails.layers.includes(consoleLayerArn)) {
+        if (functionDetails.layers?.includes(consoleLayerArn)) {
             consoleFunctions.push(functionName);
         }
     }


### PR DESCRIPTION
When `serverless.yml` contains functions that do not have layers, the following error will occur when trying to invoke `serverless bref:cli ...`:

```
Error:
TypeError: Cannot read properties of undefined (reading 'includes')
    at getConsoleFunction (vendor/bref/bref/plugin/run-console.js:21:36)
    at runConsole (vendor/bref/bref/plugin/run-console.js:7:44)
    at bref:cli:run (vendor/bref/bref/index.js:129:35)
    at PluginManager.runHooks (node_modules/serverless/lib/classes/plugin-manager.js:530:
15)
    at PluginManager.invoke (node_modules/serverless/lib/classes/plugin-manager.js:564:20
)
    at async PluginManager.run (node_modules/serverless/lib/classes/plugin-manager.js:604
:7)
    at async Serverless.run (node_modules/serverless/lib/serverless.js:179:5)
    at async node_modules/serverless/scripts/serverless.js:812:9
```

This PR prevents said error by ignoring functions that have undefined `runtime` configuration.