### PR TITLE
Improve error message when missing Bref runtimes

### DIFF
--- a/src/Event/InvalidLambdaEvent.php
+++ b/src/Event/InvalidLambdaEvent.php
@@ -14,6 +14,6 @@ final class InvalidLambdaEvent extends Exception
             $eventData = print_r($event, true);
         }
 
-        parent::__construct("This handler expected to be invoked with a $expectedEventType event. Instead, the handler was invoked with invalid event data: $eventData");
+        parent::__construct("This handler expected to be invoked with a $expectedEventType event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data: $eventData");
     }
 }

--- a/tests/Event/EventBridge/EventBridgeEventTest.php
+++ b/tests/Event/EventBridge/EventBridgeEventTest.php
@@ -44,7 +44,7 @@ class EventBridgeEventTest extends TestCase
     public function test invalid event()
     {
         $this->expectException(InvalidLambdaEvent::class);
-        $this->expectExceptionMessage('This handler expected to be invoked with a EventBridge event. Instead, the handler was invoked with invalid event data');
+        $this->expectExceptionMessage("This handler expected to be invoked with a EventBridge event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data");
         new EventBridgeEvent([]);
     }
 }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -144,7 +144,7 @@ class HttpRequestEventTest extends CommonHttpTest
 
     public function test empty invocation will have friendly error message()
     {
-        $message = 'This handler expected to be invoked with a API Gateway or ALB event. Instead, the handler was invoked with invalid event data: null';
+        $message = "This handler expected to be invoked with a API Gateway or ALB event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data: null";
 
         $this->expectException(InvalidLambdaEvent::class);
         $this->expectExceptionMessage($message);

--- a/tests/Event/Kafka/KafkaEventTest.php
+++ b/tests/Event/Kafka/KafkaEventTest.php
@@ -31,7 +31,7 @@ final class KafkaEventTest extends TestCase
     public function test invalid event()
     {
         $this->expectException(InvalidLambdaEvent::class);
-        $this->expectExceptionMessage('This handler expected to be invoked with a Kafka event. Instead, the handler was invoked with invalid event data');
+        $this->expectExceptionMessage("This handler expected to be invoked with a Kafka event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data");
         new KafkaEvent([]);
     }
 }

--- a/tests/Event/S3/S3EventTest.php
+++ b/tests/Event/S3/S3EventTest.php
@@ -34,7 +34,7 @@ class S3EventTest extends TestCase
     public function test invalid event()
     {
         $this->expectException(InvalidLambdaEvent::class);
-        $this->expectExceptionMessage('This handler expected to be invoked with a S3 event. Instead, the handler was invoked with invalid event data');
+        $this->expectExceptionMessage("This handler expected to be invoked with a S3 event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data");
         new S3Event([]);
     }
 

--- a/tests/Event/Sns/SnsEventTest.php
+++ b/tests/Event/Sns/SnsEventTest.php
@@ -36,7 +36,7 @@ class SnsEventTest extends TestCase
     public function test invalid event()
     {
         $this->expectException(InvalidLambdaEvent::class);
-        $this->expectExceptionMessage('This handler expected to be invoked with a SNS event. Instead, the handler was invoked with invalid event data');
+        $this->expectExceptionMessage("This handler expected to be invoked with a SNS event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data");
         new SnsEvent([]);
     }
 }

--- a/tests/Event/Sqs/SqsEventTest.php
+++ b/tests/Event/Sqs/SqsEventTest.php
@@ -38,7 +38,7 @@ class SqsEventTest extends TestCase
     public function test invalid event()
     {
         $this->expectException(InvalidLambdaEvent::class);
-        $this->expectExceptionMessage('This handler expected to be invoked with a SQS event. Instead, the handler was invoked with invalid event data');
+        $this->expectExceptionMessage("This handler expected to be invoked with a SQS event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data");
         new SqsEvent([]);
     }
 }


### PR DESCRIPTION
Mixing function invocations with FPM runtimes is very common:

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/720328/227314645-361fd233-3a69-4c3e-a713-965c34dc0b91.png">

Hopefully this little tweak will helps users troubleshoot it.