### PR TITLE
Missing next link on Local development documentation page

### DIFF
--- a/docs/web-apps/local-development.md
+++ b/docs/web-apps/local-development.md
@@ -4,6 +4,9 @@ current_menu: web-local-development
 previous:
     link: /docs/web-apps/cron.html
     title: Cron commands
+next:
+    link: /docs/web-apps/docker.html
+    title: Docker
 ---
 
 It is possible to run **web applications** locally.


### PR DESCRIPTION
As the title
