### PR TITLE
Fixed typo on the v2 upgrade guide

### DIFF
--- a/docs/upgrading/v2.md
+++ b/docs/upgrading/v2.md
@@ -81,7 +81,7 @@ The following commands of `vendor/bin/bref` have changed:
 
   Read [the Local Development documentation](../function/local-development.md) to learn more. You will also find alternatives if you don't use the `serverless` CLI.
 
-- `vendor/bin/bref layers` is replaced by the simpler `serverless layers`.
+- `vendor/bin/bref layers` is replaced by the simpler `serverless bref:layers`.
 
   Layer versions are also available at [runtimes.bref.sh](https://runtimes.bref.sh/) if you don't use the `serverless` CLI.
 


### PR DESCRIPTION
As the title