### PR TITLE
Laravel docs: clarify persistent connections apply to MySQL too

### DIFF
--- a/docs/frameworks/laravel.md
+++ b/docs/frameworks/laravel.md
@@ -327,17 +327,9 @@ Keep the following details in mind:
 - Octane keeps Laravel booted in a long-running process, [beware of memory leaks](https://laravel.com/docs/10.x/octane#managing-memory-leaks).
 - `BREF_LOOP_MAX` specifies the number of HTTP requests handled before the PHP process is restarted (and the memory is cleared).
 
-### Persistent database sessions
+### Persistent database connections
 
-If you're using PostgreSQL 9.6 or newer, you can take advantage of persistent database sessions.
-
-First set [`idle_in_transaction_session_timeout`](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT) either in your RDS database's parameter group, or on a specific database itself.
-
-```sql
-ALTER DATABASE SET idle_in_transaction_session_timeout = '10000' -- 10 seconds in ms
-```
-
-Lastly, set the `OCTANE_PERSIST_DATABASE_SESSIONS` environment variable.
+You can keep database connections persistent across requests to make your application even faster. To do so, set the `OCTANE_PERSIST_DATABASE_SESSIONS` environment variable:
 
 ```yml
 functions:
@@ -348,6 +340,12 @@ functions:
           BREF_LOOP_MAX: 250
           OCTANE_PERSIST_DATABASE_SESSIONS: 1
         # ...
+```
+
+Note that if you are using PostgreSQL (9.6 or newer), you need to set [`idle_in_transaction_session_timeout`](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT) either in your RDS database's parameter group, or on a specific database itself.
+
+```sql
+ALTER DATABASE SET idle_in_transaction_session_timeout = '10000' -- 10 seconds in ms
 ```
 
 ## Caching


### PR DESCRIPTION
It wasn't clear whether persistent connections applied to PostgreSQL only or not.

cc @tillkruss, @georgeboot 