### PR TITLE
Add test cases for query arrays without brackets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=8.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "crwlr/query-string": "^1.0.1",
+        "crwlr/query-string": "^1.0.3",
         "hollodotme/fast-cgi-client": "^3.0.1",
         "nyholm/psr7": "^1.4.1",
         "psr/container": "^1.0|^2.0",

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -107,9 +107,10 @@ abstract class CommonHttpTest extends TestCase implements HttpRequestProxyTest
             'shapes' => ['a' => ['square', 'triangle']],
             'myvar' => 'abc',
             'foo.bar' => ['baz'],
+            'array' => ['one', 'two'],
         ]);
-        $this->assertQueryString('foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz');
-        $this->assertUri('/path?foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz');
+        $this->assertQueryString('foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz&array%5B0%5D=one&array%5B1%5D=two');
+        $this->assertUri('/path?foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz&array%5B0%5D=one&array%5B1%5D=two');
     }
 
     /**

--- a/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v1-query-string-multivalue.json
@@ -23,7 +23,8 @@
         "colors[][]": ["red", "blue"],
         "shapes[a][]": ["square", "triangle"],
         "myvar": ["abc"],
-        "foo.bar[]": ["baz"]
+        "foo.bar[]": ["baz"],
+        "array": ["one", "two"]
     },
     "pathParameters": null,
     "stageVariables": null,

--- a/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
+++ b/tests/Event/Http/Fixture/ag-v2-query-string-multivalue.json
@@ -2,7 +2,7 @@
     "version": "2.0",
     "routeKey": "ANY /path",
     "rawPath": "/path",
-    "rawQueryString": "foo[]=bar&foo[]=baz&cards[]=birthday&colors[][]=red&colors[][]=blue&shapes[a][]=square&shapes[a][]=triangle&myvar=abc&foo.bar[]=baz",
+    "rawQueryString": "foo[]=bar&foo[]=baz&cards[]=birthday&colors[][]=red&colors[][]=blue&shapes[a][]=square&shapes[a][]=triangle&myvar=abc&foo.bar[]=baz&array=one&array=two",
     "headers": {
         "Accept": "*/*",
         "Accept-Encoding": "gzip, deflate",


### PR DESCRIPTION
Support for getting array structure from duplicate query string keys without array syntax (brackets) was added in crwlr/query-string (v1.0.2) as requested in the discussion of this PR
https://github.com/brefphp/bref/pull/1437.

Example:
foo=bar&foo=baz
becomes
['foo' => ['bar', 'baz']]

Add test case to make sure this actually works (and keeps working) in bref.