### PR TITLE
Add note for deprecated usage of !php/const:

### DIFF
--- a/docs/environment/database-planetscale.md
+++ b/docs/environment/database-planetscale.md
@@ -135,6 +135,8 @@ doctrine:
             # Connect to the database via SSL
             !php/const:PDO::MYSQL_ATTR_SSL_CA: /opt/bref/ssl/cert.pem
 
+            # Note: When using symfony/yaml 6.2 and up it should be: (there is no colon after "const")
+            !php/const PDO::MYSQL_ATTR_SSL_CA: /opt/bref/ssl/cert.pem
 # ...
 ```
 

--- a/docs/environment/database-planetscale.md
+++ b/docs/environment/database-planetscale.md
@@ -133,10 +133,8 @@ doctrine:
         url: '%env(resolve:DATABASE_URL)%'
         options:
             # Connect to the database via SSL
-            !php/const:PDO::MYSQL_ATTR_SSL_CA: /opt/bref/ssl/cert.pem
-
-            # Note: When using symfony/yaml 6.2 and up it should be: (there is no colon after "const")
             !php/const PDO::MYSQL_ATTR_SSL_CA: /opt/bref/ssl/cert.pem
+
 # ...
 ```
 


### PR DESCRIPTION
When linting the yaml files with Symfony yaml 6.2 and higher you will get a deprecation warning when using the original notation. This proposed change makes users aware of this upcoming change.

> Since symfony/yaml 6.2: YAML syntax for key "!php/const:PDO::MYSQL_ATTR_SSL_CA" is deprecated and replaced by "!php/const PDO::MYSQL_ATTR_SSL_CA" 
