### PR TITLE
Update copyright year in footer

### DIFF
--- a/website/template/footer.twig
+++ b/website/template/footer.twig
@@ -1,7 +1,7 @@
 <section class="mt-24 py-12 bg-gray-800 text-gray-400 text-center text-sm font-light">
     <div class="container mx-auto px-4">
         <p>
-            &copy; 2022 Matthieu Napoli -
+            &copy; 2019-{{ 'now'|date('Y') }} Matthieu Napoli -
             <a href="https://github.com/brefphp/bref" class="text-blue-400">GitHub</a> -
             <a href="https://twitter.com/brefphp" class="text-blue-400">Twitter</a>
         </p>


### PR DESCRIPTION
update copyright years in footer

<!--
Use copyright range.
See https://www.copyrightlaws.com/copyright-symbol-notice-year/#:~:text=What%20About%20Blogs%20and%20Websites?
The first year should be year of first publication of the content, which is 2019
The second should be the year of latest content change.
See amazon or ebay..., they use the same approach.
-->
