### PR TITLE
Fix Docker docs to always include a version number

### DIFF
--- a/docs/environment/php.md
+++ b/docs/environment/php.md
@@ -142,7 +142,7 @@ To create your custom layer, you will need to:
 To compile the extension, Bref provides the `bref/build-php-*` Docker images. Here is an example with Blackfire:
 
 ```dockerfile
-FROM bref/build-php-80
+FROM bref/build-php-80:2
 
 RUN curl -A "Docker" -o /tmp/blackfire.so -L -s "https://packages.blackfire.io/binaries/blackfire-php/1.42.0/blackfire-php-linux_amd64-php-74.so"
 

--- a/docs/web-apps/docker.md
+++ b/docs/web-apps/docker.md
@@ -23,7 +23,7 @@ out-of-the-box base images that are package for the Lambda environment.
 Here is an example of a Docker image
 
 ```Dockerfile
-FROM bref/php-80-fpm
+FROM bref/php-80-fpm:2
 
 COPY . /var/task
 
@@ -41,12 +41,10 @@ You may also enable PHP extensions by pulling them from
 [Bref Extensions](https://github.com/brefphp/extra-php-extensions)
 
 ```Dockerfile
-FROM bref/php-80-fpm
+FROM bref/php-80-fpm:2
 
-COPY --from=bref/extra-redis-php-80:0.10 /opt/bref-extra /opt/bref-extra
-
-COPY --from=bref/extra-gmp-php-80:0.10 /opt/bref-extra /opt/bref-extra
-COPY --from=bref/extra-gmp-php-80:0.10 /opt/bref/ /opt/bref
+COPY --from=bref/extra-redis-php-80:1 /opt /opt
+COPY --from=bref/extra-gmp-php-80:1 /opt /opt
 
 COPY . /var/task
 


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
