### PR TITLE
Add testimonials to the website (remove link to course)

### DIFF
--- a/website/template/enterprise.twig
+++ b/website/template/enterprise.twig
@@ -88,7 +88,15 @@
                             <svg class="h-5 w-5 flex-shrink-0 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                 <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
                             </svg>
-                            <span class="text-sm text-gray-600">Use AWS Lambda runtimes hosted in <em>your</em> AWS account (optional)</span>
+                            <span class="text-sm text-gray-600">Use AWS Lambda runtimes hosted in <em>your</em> AWS account (opt-in)</span>
+                        </li>
+
+                        <li class="flex space-x-3">
+                            <!-- Heroicon name: mini/check -->
+                            <svg class="h-5 w-5 flex-shrink-0 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
+                            </svg>
+                            <span class="text-sm text-gray-600">Open-source gold sponsor 💙</span>
                         </li>
 
                         <li class="flex space-x-3">
@@ -151,7 +159,15 @@
                             <svg class="h-5 w-5 flex-shrink-0 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                 <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
                             </svg>
-                            <span class="text-sm text-gray-600">Use AWS Lambda runtimes hosted in <em>your</em> AWS account (optional)</span>
+                            <span class="text-sm text-gray-600">Use AWS Lambda runtimes hosted in <em>your</em> AWS account (opt-in)</span>
+                        </li>
+
+                        <li class="flex space-x-3">
+                            <!-- Heroicon name: mini/check -->
+                            <svg class="h-5 w-5 flex-shrink-0 text-green-500" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
+                            </svg>
+                            <span class="text-sm text-gray-600">Open-source premium sponsor 💙</span>
                         </li>
 
                         <li class="flex space-x-3">
@@ -160,7 +176,7 @@
                                 <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clip-rule="evenodd" />
                             </svg>
                             <span class="text-sm text-gray-600">
-                                Tailor-made AWS Lambda runtimes optimized for your project
+                                Tailor-made AWS Lambda runtimes optimized for your project (opt-in)
                             </span>
                         </li>
 

--- a/website/template/home.twig
+++ b/website/template/home.twig
@@ -181,10 +181,16 @@
                 They sponsor the open-source project
             </h2>
             <div class="md:flex mb-10 border-t border-gray-300 pt-8">
-                <h3 class="mb-6 block w-56 font-bold text-gray-800 text-left">Premium sponsors</h3>
+                <div class="mb-6 w-56 text-left">
+                    <h3 class="font-bold text-gray-800">Premium sponsors</h3>
+                    <p class="mt-6 row-span-full text-xs text-gray-600">
+                        * one-time sponsor
+                    </p>
+                </div>
                 <div class="flex-grow grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-16">
                     <a class="flex justify-center items-center" href="https://aws.amazon.com" title="AWS">
                         <img class="h-12" src="/img/aws.svg" alt="AWS">
+                        <span class="self-start text-black">*</span>
                     </a>
                     <a class="flex justify-center items-start" href="https://craftcms.com/?ref=bref.sh" title="Craft CMS">
                         <img class="w-40" src="/img/logo-craft-cms.png" alt="Craft CMS">
@@ -194,6 +200,9 @@
                     </a>
                     <a class="flex justify-center items-center" href="https://www.mybuilder.com/?ref=bref.sh" title="MyBuilder">
                         <img class="h-7" src="/img/logo-mybuilder.svg" alt="MyBuilder">
+                    </a>
+                    <a class="flex justify-center items-center" href="https://www.shippypro.com/?ref=bref.sh" title="ShippyPro">
+                        <img class="w-36" src="/img/logo-shippypro.png" alt="ShippyPro">
                     </a>
                     <a class="-mt-3 flex justify-center" href="https://null.tc/?ref=bref" title="Serverless consulting company">
                         <img class="h-12" src="/img/logo-null.png" alt="Null">
@@ -217,9 +226,6 @@
                     </a>
                     <a class="flex justify-center items-center" href="https://ecomail.cz/?ref=bref.sh" title="Ecomail.cz">
                         <img class="w-24" src="/img/logo-ecomail.png" alt="Ecomail.cz">
-                    </a>
-                    <a class="flex justify-center items-center" href="https://www.shippypro.com/?ref=bref.sh" title="ShippyPro">
-                        <img class="w-36" src="/img/logo-shippypro.png" alt="ShippyPro">
                     </a>
                 </div>
             </div>

--- a/website/template/home.twig
+++ b/website/template/home.twig
@@ -136,33 +136,42 @@
         </div>
     </section>
 
-    <section id="course" class="py-8 md:py-12 bg-blue-800 text-white text-sm md:text-base">
-        <div class="container mx-auto max-w-4xl px-4 md:flex items-end lg:items-center">
-            <div class="flex-grow md:pr-12">
-                <h2 class="mb-6 text-2xl md:text-3xl font-bref text-blue-100">
-                    The advanced serverless course
-                </h2>
-                <p class="mb-4">
-                    <a class="text-blue-200 hover:text-white underline" href="https://serverless-visually-explained.com/?ref=bref-home"
-                       title="Learn how to create serverless applications on AWS">
-                        Serverless Visually Explained</a>
-                    is a hands-on course that teaches developers how to create serverless applications.
-                </p>
-                <p class="mb-4">
-                    Written by Bref's creator, this interactive course focuses on use cases:
-                    APIs, websites, workers, micro-services…
-                </p>
-                <p class="mb-4 md:mb-0">
-                    Learn more at
-                    <a class="text-blue-200 hover:text-white underline" href="https://serverless-visually-explained.com/?ref=bref-home"
-                       title="Serverless course for developers">
-                        serverless-visually-explained.com</a>.
-                </p>
+    <section id="course" class="py-12 bg-blue-800 text-white">
+        <div class="container mx-auto max-w-2xl lg:max-w-4xl px-4">
+            <h2 class="mb-12 text-2xl md:text-3xl xl:text-4xl font-bref text-blue-100">
+                <a href="/docs/news/02-bref-2.0.html" class="text-blue-100 hover:text-blue-100">
+                    <span class="underline">10 billion</span> requests and jobs served using Bref every month
+                </a>
+            </h2>
+            <div class="mx-auto grid max-w-2xl grid-cols-1 lg:mx-0 lg:max-w-none lg:grid-cols-2">
+                <div class="pb-10 lg:pb-0 lg:pr-8">
+                    <figure class="flex flex-auto flex-col justify-between">
+                        <blockquote class="lg:leading-8 text-white">
+                            <p>“Bref is excellent. We've been running a Laravel/PHP app with it since 2020 and it's currently handing over 160 million requests per month without a hiccup.”</p>
+                        </blockquote>
+                        <figcaption class="mt-6">
+                            <div class="font-semibold text-white">Neil Morgan</div>
+                            <div class="mt-1 text-gray-400">
+                                <a href="https://www.bcast.fm/" class="text-current hover:text-white">bcast.fm</a>
+                            </div>
+                        </figcaption>
+                    </figure>
+                </div>
+                <div class="border-t border-white/10 pt-10 lg:border-l lg:border-t-0 lg:pl-8 lg:pt-0">
+                    <figure class="flex flex-auto flex-col justify-between">
+                        <blockquote class="lg:leading-8 text-white">
+                            <p>“Bref has been a boon for running our customer's applications. We've had a Laravel API on Bref for the last 12 months serve over 25M requests with an average response time of 50ms.”</p>
+                        </blockquote>
+                        <figcaption class="mt-6">
+                            <div class="font-semibold text-white">Paul Giberson</div>
+                            <div class="mt-1 text-gray-400">
+                                Chief Software Architect,
+                                <a href="https://twitter.com/HalasLabs/status/1638650910971932672" class="text-current hover:text-white">Halas Labs</a>
+                            </div>
+                        </figcaption>
+                    </figure>
+                </div>
             </div>
-            <a href="https://serverless-visually-explained.com/?ref=bref-home"
-               title="Serverless course for developers"
-               class="w-full max-w-xs mx-auto md:w-96 lg:w-full block rounded overflow-hidden shadow-lg">
-                <img src="/img/serverless-visually-explained.png" alt="Serverless Visually Explained"></a>
         </div>
     </section>
 


### PR DESCRIPTION
I am not earning much through the serverless course (unfortunately), so I was thinking about replacing its section with a few testimonials.

The goal is to show new visitors that Bref is used at scale and is a reliable tool.

### Before

<img width="1001" alt="Screen-001103" src="https://github.com/brefphp/bref/assets/720328/9b2622af-3dd7-4197-847f-b7efbe628818">

### After

<img width="1117" alt="Screen-001102" src="https://github.com/brefphp/bref/assets/720328/589d2d46-eb81-467b-8238-fc5c5168bb81">

### More testimonials?

I am always looking for more testimonials. You can send me one via email (https://github.com/mnapoli/), on Slack, in a Twitter DM, on LinkedIn, etc.