### PR TITLE
Fix typo missing end quote

### DIFF
--- a/docs/runtimes/README.md
+++ b/docs/runtimes/README.md
@@ -265,7 +265,7 @@ We consider this to be beneficial both to the Bref project (by getting more user
 
 The data sent in the ping is completely anonymous. It does not contain any identifiable data about anything (the project, users, etc.).
 
-**The only data it contains is:** "A Bref invocation happened with the layer XYZ" (where XYZ is the name of the Bref layer, like "function", "fpm" or "console).
+**The only data it contains is:** "A Bref invocation happened with the layer XYZ" (where XYZ is the name of the Bref layer, like "function", "fpm" or "console").
 
 Anyone can inspect the code and the data sent by checking the [`Bref\Runtime\LambdaRuntime::ping()` function](https://github.com/brefphp/bref/blob/master/src/Runtime/LambdaRuntime.php#L374).
 


### PR DESCRIPTION
Add missing end quote to '"console'.
