### PR TITLE
[1.x] Upgrade to cURL 8.1.1

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -226,7 +226,7 @@ RUN set -xe; \
 # #   - libssh2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=7.85.0
+ENV VERSION_CURL=8.1.1
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 
 RUN set -xe; \


### PR DESCRIPTION
The segfaults I was seeing previously were ultimately caused by the nghttp2 library not being linked correctly in Laravel Vapor, and so the cURL upgrade in bref is fine to do, even on OpenSSL 1.1.x for PHP 8.0. It's nice that we can finally get all the security and bug fixes to cURL into all bref runtimes.

---

The difference here between the Bref 2.x (PHP 8.0) build is that openssl is not compiled with TLS 1.3 enabled - I don't feel that it is necessary to backport that adjustment since TLS 1.2 is still considered secure, and the focus for Bref 1.x is now on security and nasty bugs.