### PR TITLE
Make CLI messages Bref-specific

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -3,8 +3,8 @@ service: bref-demo
 provider:
     name: aws
     region: us-east-2
-    logs:
-        restApi: true
+    logRetentionInDays: 7
+    versionFunctions: false
     apiGateway:
         binaryMediaTypes:
             - '*/*'


### PR DESCRIPTION
The `serverless` CLI prints CLI messages about the Serverless Console (formerly Serverless Dashboard). This product doesn't work with PHP, I've heard people trying to set it up and being confused. Here's an example:

<img width="1046" alt="Screen-001205" src="https://github.com/brefphp/bref/assets/720328/2ea5995b-a8e2-4770-a87c-2a0d46fa7ade">

Instead, I replaced it with a message about the [Bref Dashboard](https://dashboard.bref.sh/):

<img width="912" alt="Screen-001204" src="https://github.com/brefphp/bref/assets/720328/f5a72afc-ddef-4f66-8145-f877b942ad4c">

I also added it in two commands that I think are particularly relevant to the Dashboard:

<img width="1158" alt="Screen-001203" src="https://github.com/brefphp/bref/assets/720328/b3eff6fe-1fc1-4e7b-9c56-03afbfab16bd">


<img width="735" alt="Screen-001202" src="https://github.com/brefphp/bref/assets/720328/cb4416ae-31db-4410-8138-450be95f0f7a">
