### PR TITLE
Fix #1593 `WebsocketEvent` `getRegion()` not returning correct region for custom domains

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,4 +15,7 @@
       <directory>./tests/Sam</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <env name="AWS_REGION" value="eu-west-1" force="true" />
+  </php>
 </phpunit>

--- a/src/Event/ApiGateway/WebsocketEvent.php
+++ b/src/Event/ApiGateway/WebsocketEvent.php
@@ -105,7 +105,6 @@ class WebsocketEvent implements LambdaEvent
 
     public function getRegion(): string
     {
-        [, , $region] = explode('.', $this->getDomainName(), 4);
-        return $region;
+        return getenv('AWS_REGION');
     }
 }


### PR DESCRIPTION
Fixes https://github.com/brefphp/bref/issues/1593 using the `AWS_REGION` env variable set in the lambda runtime. 