### PR TITLE
Fix #1520 "Unknown application error occurred Runtime.Unknown"

### DIFF
--- a/src/ConsoleRuntime/Main.php
+++ b/src/ConsoleRuntime/Main.php
@@ -25,7 +25,7 @@ class Main
         $appRoot = getenv('LAMBDA_TASK_ROOT');
         $handlerFile = $appRoot . '/' . getenv('_HANDLER');
         if (! is_file($handlerFile)) {
-            $lambdaRuntime->failInitialization("Handler `$handlerFile` doesn't exist");
+            $lambdaRuntime->failInitialization("Handler `$handlerFile` doesn't exist", 'Runtime.NoSuchHandler');
         }
 
         /** @phpstan-ignore-next-line */

--- a/src/FpmRuntime/Main.php
+++ b/src/FpmRuntime/Main.php
@@ -5,6 +5,7 @@ namespace Bref\FpmRuntime;
 use Bref\Bref;
 use Bref\LazySecretsLoader;
 use Bref\Runtime\LambdaRuntime;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -27,14 +28,14 @@ class Main
         $appRoot = getenv('LAMBDA_TASK_ROOT');
         $handlerFile = $appRoot . '/' . getenv('_HANDLER');
         if (! is_file($handlerFile)) {
-            $lambdaRuntime->failInitialization("Handler `$handlerFile` doesn't exist");
+            $lambdaRuntime->failInitialization("Handler `$handlerFile` doesn't exist", 'Runtime.NoSuchHandler');
         }
 
         $phpFpm = new FpmHandler($handlerFile);
         try {
             $phpFpm->start();
         } catch (Throwable $e) {
-            $lambdaRuntime->failInitialization('Error while starting PHP-FPM', $e);
+            $lambdaRuntime->failInitialization(new RuntimeException('Error while starting PHP-FPM: ' . $e->getMessage(), 0, $e));
         }
 
         /** @phpstan-ignore-next-line */

--- a/src/FunctionRuntime/Main.php
+++ b/src/FunctionRuntime/Main.php
@@ -25,7 +25,7 @@ class Main
         try {
             $handler = $container->get(getenv('_HANDLER'));
         } catch (Throwable $e) {
-            $lambdaRuntime->failInitialization($e->getMessage(), $e);
+            $lambdaRuntime->failInitialization($e, 'Runtime.NoSuchHandler');
         }
 
         $loopMax = getenv('BREF_LOOP_MAX') ?: 1;

--- a/src/FunctionRuntime/Main.php
+++ b/src/FunctionRuntime/Main.php
@@ -25,7 +25,7 @@ class Main
         try {
             $handler = $container->get(getenv('_HANDLER'));
         } catch (Throwable $e) {
-            $lambdaRuntime->failInitialization($e->getMessage());
+            $lambdaRuntime->failInitialization($e->getMessage(), $e);
         }
 
         $loopMax = getenv('BREF_LOOP_MAX') ?: 1;

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -268,6 +268,8 @@ final class LambdaRuntime
             echo "$error\n";
         }
 
+        echo "The function failed to start. AWS Lambda will restart the process, do not be surprised if you see the error message twice.\n";
+
         $url = "http://$this->apiUrl/2018-06-01/runtime/init/error";
         $this->postJson($url, $data, [
             "Lambda-Runtime-Function-Error-Type: $lambdaInitializationReason",

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -237,10 +237,9 @@ final class LambdaRuntime
     /**
      * Abort the lambda and signal to the runtime API that we failed to initialize this instance.
      *
-     * @param 'Runtime.NoSuchHandler'|'Runtime.UnknownReason' $lambdaInitializationReason
-     *
      * @see https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html#runtimes-api-initerror
      *
+     * @phpstan-param 'Runtime.NoSuchHandler'|'Runtime.UnknownReason' $lambdaInitializationReason
      * @phpstan-return never-returns
      */
     public function failInitialization(
@@ -287,9 +286,8 @@ final class LambdaRuntime
 
     /**
      * @param string[] $headers
-     *
-     * @throws ResponseTooBig
      * @throws Exception
+     * @throws ResponseTooBig
      */
     private function postJson(string $url, mixed $data, array $headers = []): void
     {
@@ -313,7 +311,7 @@ final class LambdaRuntime
         curl_setopt($this->curlHandleResult, CURLOPT_HTTPHEADER, [
             'Content-Type: application/json',
             'Content-Length: ' . strlen($jsonData),
-            ...$headers
+            ...$headers,
         ]);
 
         $body = curl_exec($this->curlHandleResult);


### PR DESCRIPTION
I finally found the source of the issue 🎉

When failing to get the handler (in the function runtime), the Lambda would fail but would only consider the exception message. It would completely ignore the rest of the exception (stack trace & class name).

In the case of Laravel (which is the most common report for this bug), we would get the following log:

```
App\TestHandler
START
Unknown application error occurred
Runtime.Unknown
END Duration: 108.02 ms Memory Used: 36 MB
```

As you can see, the name of the handler class is logged, but that's it. What happens is that Laravel throws an `EntryNotFoundException`: the exception message is only the class name…

So the exception message gets logged, but it's not useful, and it looks like the exception wasn't logged at all.

With this PR, the exception message + class name + stack trace will correctly be logged.

On top of that, I refactored how "initialization failures" are reported to have even better logs from Lambda.

Additionally, specifically for this Laravel exception, I will probably catch + rethrow this exception with a clearer message (but this change will go in the Laravel bridge).

## Before

Lambda logs:

```
App\TestHandler
App\TestHandler
START
Unknown application error occurred
Runtime.Unknown
END Duration: 108.02 ms Memory Used: 36 MB
```

Lambda invocation result:

```json
{
    "errorMessage": "App\\TestHandler ",
    "errorType": "Internal",
    "stackTrace": []
}
```

## After

Lambda logs:

```c
Fatal error: Illuminate\Container\EntryNotFoundException: App\TestHandler in /var/task/vendor/laravel/framework/src/Illuminate/Container/Container.php:723
{"message":"App\\TestHandler","type":"Illuminate\\Container\\EntryNotFoundException","stackTrace":["#0 \/var\/task\/vendor\/bref\/laravel-bridge\/src\/HandlerResolver.php(46): Illuminate\\Container\\Container->get('App\\\\TestHandler...')","#1 \/var\/task\/vendor\/bref\/bref\/src\/FunctionRuntime\/Main.php(26): Bref\\LaravelBridge\\HandlerResolver->get('App\\\\TestHandler...')","#2 \/opt\/bref\/bootstrap.php(17): Bref\\FunctionRuntime\\Main::run()","#3 {main}"]}
The function failed to start. AWS Lambda will restart the process, do not be surprised if you see the error message twice.
Fatal error: Illuminate\Container\EntryNotFoundException: App\TestHandler in /var/task/vendor/laravel/framework/src/Illuminate/Container/Container.php:723
{"message":"App\\TestHandler","type":"Illuminate\\Container\\EntryNotFoundException","stackTrace":["#0 \/var\/task\/vendor\/bref\/laravel-bridge\/src\/HandlerResolver.php(46): Illuminate\\Container\\Container->get('App\\\\TestHandler...')","#1 \/var\/task\/vendor\/bref\/bref\/src\/FunctionRuntime\/Main.php(26): Bref\\LaravelBridge\\HandlerResolver->get('App\\\\TestHandler...')","#2 \/opt\/bref\/bootstrap.php(17): Bref\\FunctionRuntime\\Main::run()","#3 {main}"]}
The function failed to start. AWS Lambda will restart the process, do not be surprised if you see the error message twice.
START
Unknown application error occurred
Runtime.NoSuchHandler
END Duration: 114.13 ms Memory Used: 36 MB
```

The exception is logged twice because AWS Lambda performs a retry (in the same function, it simply restarts the Bref process).

Lambda invocation result:

```json
{
    "errorMessage": "App\\TestHandler App\\TestHandler",
    "errorType": "Illuminate\\Container\\EntryNotFoundException",
    "stackTrace": [
        "#0 /var/task/vendor/bref/laravel-bridge/src/HandlerResolver.php(46): Illuminate\\Container\\Container->get('App\\\\TestHandler...')",
        "#1 /var/task/vendor/bref/bref/src/FunctionRuntime/Main.php(26): Bref\\LaravelBridge\\HandlerResolver->get('App\\\\TestHandler...')",
        "#2 /opt/bref/bootstrap.php(17): Bref\\FunctionRuntime\\Main::run()",
        "#3 {main}"
    ]
}
```

Here's a preview with the JSON logs in the [Bref Dashboard](https://dashboard.bref.sh/):

<img width="1656" alt="image" src="https://github.com/brefphp/bref/assets/720328/4c49ce1d-8532-4f20-ab53-602c2b71aad5">
