### PR TITLE
Enable file path to data on bref-local with CDK

### DIFF
--- a/docs/function/local-development.md
+++ b/docs/function/local-development.md
@@ -80,6 +80,14 @@ Hello world
 # With JSON event data
 $ vendor/bin/bref-local my-function.php '{"name": "Jane"}'
 Hello Jane
+
+# With a path to a file containing a JSON event.
+$cat event.json
+{
+    "name": "Alex"
+}
+$ vendor/bin/bref-local --path event.json my-function.php
+Hello Alex
 ```
 
 If you want to run your function in Docker:

--- a/docs/function/local-development.md
+++ b/docs/function/local-development.md
@@ -82,7 +82,7 @@ $ vendor/bin/bref-local my-function.php '{"name": "Jane"}'
 Hello Jane
 
 # With a path to a file containing a JSON event.
-$cat event.json
+$ cat event.json
 {
     "name": "Alex"
 }

--- a/src/bref-local
+++ b/src/bref-local
@@ -18,10 +18,14 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 
 $handler = $argv[1] ?? '';
 $data = $argv[2] ?? null;
-$opts = getopt("f::");
+$opts = getopt('', ['path:']);
 
-if (isset($opts['f']) && file_exists($opts['f'])) {
-    $data = file_get_contents($opts['f']);
+if (isset($opts['path'])) {
+    if (! file_exists($opts['path'])) {
+        throw new Exception('The file ' . $opts['path'] . ' could not be found.');
+    }
+
+    $data = file_get_contents($opts['path']);
 }
 
 try {

--- a/src/bref-local
+++ b/src/bref-local
@@ -25,6 +25,7 @@ if (isset($opts['path'])) {
         throw new Exception('The file ' . $opts['path'] . ' could not be found.');
     }
 
+    $handler = $argv[array_key_last($argv)];
     $data = file_get_contents($opts['path']);
 }
 

--- a/src/bref-local
+++ b/src/bref-local
@@ -18,12 +18,10 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 
 $handler = $argv[1] ?? '';
 $data = $argv[2] ?? null;
+$opts = getopt("f::");
 
-if ($data === '--file') {
-    if ($argv[3] === null) {
-        throw new Exception('A file path to a valid JSON file must be passed when invoking the `--file` flag.');
-    }
-    $data = $argv[3];
+if (isset($opts['f']) && file_exists($opts['f'])) {
+    $data = file_get_contents($opts['f']);
 }
 
 try {

--- a/src/bref-local
+++ b/src/bref-local
@@ -19,6 +19,13 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 $handler = $argv[1] ?? '';
 $data = $argv[2] ?? null;
 
+if ($data === '--file') {
+    if ($argv[3] === null) {
+        throw new Exception('A file path to a valid JSON file must be passed when invoking the `--file` flag.');
+    }
+    $data = $argv[3];
+}
+
 try {
     $handler = Bref::getContainer()->get($handler);
 } catch (NotFoundExceptionInterface $e) {


### PR DESCRIPTION
This change provides command line access to the `--path` flag where an application is built on AWS CDK rather than Serverless framework. This enables the passing of a path to a JSON file when running `vendor/bin/bref--local` instead of passing data as a string.

If you agree with the premise of this change, I will also update the relevant documentation and include in the PR.
