### PR TITLE
Flags should have consitent api

### DIFF
--- a/docs/function/local-development.md
+++ b/docs/function/local-development.md
@@ -83,7 +83,7 @@ $ cat event.json
 {
     "name": "Alex"
 }
-$ vendor/bin/bref-local --path event.json my-function.php
+$ vendor/bin/bref-local -f my-function.php --path event.json 
 Hello Alex
 ```
 

--- a/docs/function/local-development.md
+++ b/docs/function/local-development.md
@@ -71,14 +71,11 @@ Instead, you can use the [`bref/dev-server`](https://github.com/brefphp/dev-serv
 If you do not use `serverless.yml` but something else, like SAM/AWS CDK/Terraform, use the `vendor/bin/bref-local` command instead:
 
 ```bash
-$ vendor/bin/bref-local <handler> <event-data>
-
-# For example
-$ vendor/bin/bref-local my-function.php
+$ vendor/bin/bref-local -f my-function.php
 Hello world
 
 # With JSON event data
-$ vendor/bin/bref-local my-function.php '{"name": "Jane"}'
+$ vendor/bin/bref-local -f my-function.php '{"name": "Jane"}'
 Hello Jane
 
 # With a path to a file containing a JSON event.

--- a/docs/function/local-development.md
+++ b/docs/function/local-development.md
@@ -75,15 +75,15 @@ $ vendor/bin/bref-local -f my-function.php
 Hello world
 
 # With JSON event data
-$ vendor/bin/bref-local -f my-function.php '{"name": "Jane"}'
+$ vendor/bin/bref-local -f my-function.php --data '{"name": "Fred"}'
 Hello Jane
 
-# With a path to a file containing a JSON event.
+# With JSON in a file
 $ cat event.json
 {
     "name": "Alex"
 }
-$ vendor/bin/bref-local -f my-function.php --path event.json 
+$ vendor/bin/bref-local -f my-function.php --path event.json
 Hello Alex
 ```
 

--- a/src/bref-local
+++ b/src/bref-local
@@ -20,12 +20,6 @@ $opts = getopt('f:', ['path:', 'data:']);
 $handler = $opts['f'] ?? null;
 $data = $opts['data'] ?? null;
 
-// Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`
-if (empty($opts)) {
-    $handler = $argv[1] ?? '';
-    $data = $argv[2] ?? null;
-}
-
 if (isset($opts['path'])) {
     if (! file_exists($opts['path'])) {
         throw new Exception('The file ' . $opts['path'] . ' could not be found.');
@@ -44,6 +38,12 @@ if (isset($opts['f'])) {
     }
 
     $handler = $opts['f'];
+}
+
+// Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`
+if (empty($opts)) {
+    $handler = $argv[1] ?? '';
+    $data = $argv[2] ?? null;
 }
 
 try {

--- a/src/bref-local
+++ b/src/bref-local
@@ -30,6 +30,10 @@ if (isset($opts['path'])) {
 }
 
 if (isset($opts['f'])) {
+    if (! file_exists($opts['f'])) {
+        throw new Exception('Handler file ' . $opts['f'] . ' could not be found.');
+    }
+
     $handler = $opts['f'];
 }
 

--- a/src/bref-local
+++ b/src/bref-local
@@ -16,16 +16,15 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     require_once __DIR__ . '/../../../autoload.php';
 }
 
-$handler = $argv[1] ?? '';
-$data = $argv[2] ?? null;
-$opts = getopt('f:', ['path:']);
+$opts = getopt('f:', ['path:', 'data:']);
+$data = $opts['data'] ?? null;
+$handler = $opts['f'] ?? null;
 
 if (isset($opts['path'])) {
     if (! file_exists($opts['path'])) {
         throw new Exception('The file ' . $opts['path'] . ' could not be found.');
     }
 
-    $handler = $argv[array_key_last($argv)];
     $data = file_get_contents($opts['path']);
 }
 
@@ -34,8 +33,8 @@ if (isset($opts['f'])) {
         throw new Exception('Handler file ' . $opts['f'] . ' could not be found.');
     }
 
-    if (! isset($opts['path'])) {
-        $data = $argv[3] ?? null;
+    if (! isset($opts['path']) && isset($opts['data'])) {
+        $data = $opts['data'];
     }
 
     $handler = $opts['f'];

--- a/src/bref-local
+++ b/src/bref-local
@@ -20,24 +20,18 @@ $opts = getopt('f:', ['path:', 'data:']);
 $handler = $opts['f'] ?? null;
 $data = $opts['data'] ?? null;
 
-if (isset($opts['f'])) {
-    if (! file_exists($opts['f'])) {
-        throw new Exception('Handler file ' . $opts['f'] . ' could not be found.');
-    }
-
-    if (! isset($opts['path']) && isset($opts['data'])) {
-        $data = $opts['data'];
-    }
-
-    $handler = $opts['f'];
+if ($handler !== null && ! is_file($opts['f'])) {
+    throw new Exception('Handler file ' . $handler . ' could not be found.');
 }
 
 if (isset($opts['path'])) {
-    if (! file_exists($opts['path'])) {
+    if (! is_file($opts['path'])) {
         throw new Exception('The file ' . $opts['path'] . ' could not be found.');
     }
 
     $data = file_get_contents($opts['path']);
+} elseif (isset($opts['data'])) {
+    $data = $opts['data'];
 }
 
 // Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`

--- a/src/bref-local
+++ b/src/bref-local
@@ -29,6 +29,10 @@ if (isset($opts['path'])) {
     $data = file_get_contents($opts['path']);
 }
 
+if (isset($opts['f'])) {
+    $handler = $opts['f'];
+}
+
 try {
     $handler = Bref::getContainer()->get($handler);
 } catch (NotFoundExceptionInterface $e) {

--- a/src/bref-local
+++ b/src/bref-local
@@ -18,7 +18,7 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 
 $handler = $argv[1] ?? '';
 $data = $argv[2] ?? null;
-$opts = getopt('', ['path:']);
+$opts = getopt('f:', ['path:']);
 
 if (isset($opts['path'])) {
     if (! file_exists($opts['path'])) {

--- a/src/bref-local
+++ b/src/bref-local
@@ -17,7 +17,7 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 }
 
 $opts = getopt('f:', ['path:', 'data:']);
-$handler = $opts['f'] ?? '';
+$handler = $opts['f'] ?? null;
 $data = $opts['data'] ?? null;
 
 // Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`

--- a/src/bref-local
+++ b/src/bref-local
@@ -20,14 +20,6 @@ $opts = getopt('f:', ['path:', 'data:']);
 $handler = $opts['f'] ?? null;
 $data = $opts['data'] ?? null;
 
-if (isset($opts['path'])) {
-    if (! file_exists($opts['path'])) {
-        throw new Exception('The file ' . $opts['path'] . ' could not be found.');
-    }
-
-    $data = file_get_contents($opts['path']);
-}
-
 if (isset($opts['f'])) {
     if (! file_exists($opts['f'])) {
         throw new Exception('Handler file ' . $opts['f'] . ' could not be found.');
@@ -38,6 +30,14 @@ if (isset($opts['f'])) {
     }
 
     $handler = $opts['f'];
+}
+
+if (isset($opts['path'])) {
+    if (! file_exists($opts['path'])) {
+        throw new Exception('The file ' . $opts['path'] . ' could not be found.');
+    }
+
+    $data = file_get_contents($opts['path']);
 }
 
 // Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`

--- a/src/bref-local
+++ b/src/bref-local
@@ -20,6 +20,12 @@ $opts = getopt('f:', ['path:', 'data:']);
 $data = $opts['data'] ?? null;
 $handler = $opts['f'] ?? null;
 
+// Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`
+if (empty($opts)) {
+    $handler = $argv[1] ?? '';
+    $data = $argv[2] ?? null;
+}
+
 if (isset($opts['path'])) {
     if (! file_exists($opts['path'])) {
         throw new Exception('The file ' . $opts['path'] . ' could not be found.');

--- a/src/bref-local
+++ b/src/bref-local
@@ -17,8 +17,8 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
 }
 
 $opts = getopt('f:', ['path:', 'data:']);
+$handler = $opts['f'] ?? '';
 $data = $opts['data'] ?? null;
-$handler = $opts['f'] ?? null;
 
 // Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`
 if (empty($opts)) {

--- a/src/bref-local
+++ b/src/bref-local
@@ -20,7 +20,7 @@ $opts = getopt('f:', ['path:', 'data:']);
 $handler = $opts['f'] ?? null;
 $data = $opts['data'] ?? null;
 
-if ($handler !== null && ! is_file($opts['f'])) {
+if ($handler !== null && ! is_file($handler)) {
     throw new Exception('Handler file ' . $handler . ' could not be found.');
 }
 

--- a/src/bref-local
+++ b/src/bref-local
@@ -30,8 +30,6 @@ if (isset($opts['path'])) {
     }
 
     $data = file_get_contents($opts['path']);
-} elseif (isset($opts['data'])) {
-    $data = $opts['data'];
 }
 
 // Retains backward compatibilty with `./vendor/bin/bref-local <handler> <event-data>`

--- a/src/bref-local
+++ b/src/bref-local
@@ -34,6 +34,10 @@ if (isset($opts['f'])) {
         throw new Exception('Handler file ' . $opts['f'] . ' could not be found.');
     }
 
+    if (! isset($opts['path'])) {
+        $data = $argv[3] ?? null;
+    }
+
     $handler = $opts['f'];
 }
 


### PR DESCRIPTION
PR closes #1628 and is a follow on from the initial implementation of the `--path` flag merged in #1627 

Provides a suite of CLI flags for local invocation of Bref event driven functions when _not_ utilising Serverless framework. This makes the API for invoking event driven Bref functions consistent with running local functions using `serverless bref:local`

## Available flags

| Flag   | Description                                       |
| ------ | ------------------------------------------------- |
| -f     | The handler file                                  |
| --path | A path to a valid JSON file containing event data |
| --data | A JSON string containing event data               |

## Backward compatability

Backward compatibility with the current way to invoke bref-local
has been maintained so calling via `vendor/bin/bref-local <handler> <event-data>` will continue to work. Essentially, flags are 100% opt in.

## Ordering of flags

The order of flags is now irrelevant and any combination of either `-f && --path` or `-f && --data` will be accepted as valid invocations.

## Tested commands

I have tested invoking functions using `bref-local` in the following combinations.

### Backward compatible commands

✅ `$ vendor/bin/bref-local index.php ` `-> Hello World`

✅ `$ vendor/bin/bref-local index.php '{"name": "Fred"}' ` `-> Hello Fred`

### Flag based commands

✅ `$ vendor/bin/bref-local -f index.php` `-> Hello World`

✅ `$ vendor/bin/bref-local -f index.php --path event.json` `-> Hello Fred `

✅ `$ vendor/bin/bref-local -f index.php --data '{"name": "Alex"}'` `-> Hello Alex`

✅ `$ vendor/bin/bref-local --path event.json -f index.php` `-> Hello Fred`

✅ `$ vendor/bin/bref-local --data '{"name": "Alex"}' -f index.php` `-> Hello Alex`
