### PR TITLE
Log error location

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -202,6 +202,7 @@ final class LambdaRuntime
                 $previousErrors[] = [
                     'errorType' => get_class($previousError),
                     'errorMessage' => $previousError->getMessage(),
+                    'errorLocation' => 'File: ' . $previousError->getFile() . ', Line: ' . $previousError->getLine(),
                     'stack' => explode(PHP_EOL, $previousError->getTraceAsString()),
                 ];
             } while ($previousError->getPrevious() !== null);
@@ -230,6 +231,7 @@ final class LambdaRuntime
             $this->postJson($url, [
                 'errorType' => get_class($error),
                 'errorMessage' => $error->getMessage(),
+                'errorLocation' => 'File: ' . $error->getFile() . ', Line: ' . $error->getLine(),
                 'stackTrace' => $stackTraceAsArray,
             ]);
         }

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -190,6 +190,7 @@ final class LambdaRuntime
         $errorFormatted = [
             'errorType' => get_class($error),
             'errorMessage' => $error->getMessage(),
+            'errorLocation' => 'File: ' . $error->getFile() . ', Line: ' . $error->getLine(),
             'stack' => $stackTraceAsArray,
         ];
 

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -190,7 +190,7 @@ final class LambdaRuntime
         $errorFormatted = [
             'errorType' => get_class($error),
             'errorMessage' => $error->getMessage(),
-            'errorLocation' => 'File: ' . $error->getFile() . ', Line: ' . $error->getLine(),
+            'errorLocation' => ['file' => $error->getFile(), 'line' => $error->getLine()],
             'stack' => $stackTraceAsArray,
         ];
 
@@ -202,7 +202,7 @@ final class LambdaRuntime
                 $previousErrors[] = [
                     'errorType' => get_class($previousError),
                     'errorMessage' => $previousError->getMessage(),
-                    'errorLocation' => 'File: ' . $previousError->getFile() . ', Line: ' . $previousError->getLine(),
+                    'errorLocation' => ['file' => $previousError->getFile(), 'line' => $previousError->getLine()],
                     'stack' => explode(PHP_EOL, $previousError->getTraceAsString()),
                 ];
             } while ($previousError->getPrevious() !== null);
@@ -231,7 +231,7 @@ final class LambdaRuntime
             $this->postJson($url, [
                 'errorType' => get_class($error),
                 'errorMessage' => $error->getMessage(),
-                'errorLocation' => 'File: ' . $error->getFile() . ', Line: ' . $error->getLine(),
+                'errorLocation' => ['file' => $error->getFile(), 'line' => $error->getLine()],
                 'stackTrace' => $stackTraceAsArray,
             ]);
         }

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -450,7 +450,7 @@ ERROR;
         ], array_keys($invocationResult));
         $this->assertEquals($errorClass, $invocationResult['errorType']);
         $this->assertEquals($errorMessage, $invocationResult['errorMessage']);
-        if ($errorClass === RuntimeException::class) {
+        if (! empty($errorLocation)) {
             $this->assertEquals($errorLocation, $invocationResult['errorLocation']);
         }
         $this->assertIsArray($invocationResult['stackTrace']);
@@ -482,7 +482,7 @@ ERROR;
         ], array_keys($invocationResult));
         $this->assertEquals($errorClass, $invocationResult['errorType']);
         $this->assertStringContainsString($errorMessage, $invocationResult['errorMessage']);
-        if ($errorClass === RuntimeException::class) {
+        if (! empty($errorLocation)) {
             $this->assertSame($errorLocation, $invocationResult['errorLocation']);
         }
         $this->assertIsArray($invocationResult['stack']);

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -99,8 +99,8 @@ class LambdaRuntimeTest extends TestCase
         $originalException = new Exception('The original exception.');
         $previousException = new RuntimeException('The previous exception.', 0, $originalException);
         $currentException = new RuntimeException(
-            'This is an exception', 
-            0, 
+            'This is an exception',
+            0,
             $previousException
         );
         $this->runtime->processNextEvent(function () use ($currentException) {
@@ -120,16 +120,16 @@ class LambdaRuntimeTest extends TestCase
                 'errorMessage' => 'The previous exception.',
                 'errorLocation' => [
                     'file' => $previousException->getFile(),
-                    'line' => $previousException->getLine()
-                ]
+                    'line' => $previousException->getLine(),
+                ],
             ],
             [
                 'errorClass' => 'Exception',
                 'errorMessage' => 'The original exception.',
                 'errorLocation' => [
                     'file' => $originalException->getFile(),
-                    'line' => $originalException->getLine()
-                ]
+                    'line' => $originalException->getLine(),
+                ],
             ],
         ]);
     }
@@ -450,7 +450,7 @@ ERROR;
         ], array_keys($invocationResult));
         $this->assertEquals($errorClass, $invocationResult['errorType']);
         $this->assertEquals($errorMessage, $invocationResult['errorMessage']);
-        if ($errorClass instanceof RuntimeException) {
+        if ($errorClass === RuntimeException::class) {
             $this->assertEquals($errorLocation, $invocationResult['errorLocation']);
         }
         $this->assertIsArray($invocationResult['stackTrace']);
@@ -482,7 +482,7 @@ ERROR;
         ], array_keys($invocationResult));
         $this->assertEquals($errorClass, $invocationResult['errorType']);
         $this->assertStringContainsString($errorMessage, $invocationResult['errorMessage']);
-        if ($errorClass instanceof RuntimeException) {
+        if ($errorClass === RuntimeException::class) {
             $this->assertSame($errorLocation, $invocationResult['errorLocation']);
         }
         $this->assertIsArray($invocationResult['stack']);

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -413,6 +413,7 @@ ERROR;
         $this->assertSame([
             'errorType',
             'errorMessage',
+            'errorLocation',
             'stackTrace',
         ], array_keys($invocationResult));
         $this->assertEquals($errorClass, $invocationResult['errorType']);
@@ -441,6 +442,7 @@ ERROR;
         $this->assertSame([
             'errorType',
             'errorMessage',
+            'errorLocation',
             'stack',
         ], array_keys($invocationResult));
         $this->assertEquals($errorClass, $invocationResult['errorType']);
@@ -461,6 +463,7 @@ ERROR;
             $this->assertSame([
                 'errorType',
                 'errorMessage',
+                'errorLocation',
                 'stack',
             ], array_keys($error));
             $this->assertEquals($previousErrors[$index]['errorClass'], $error['errorType']);

--- a/tests/Runtime/LambdaRuntimeTest.php
+++ b/tests/Runtime/LambdaRuntimeTest.php
@@ -82,7 +82,7 @@ class LambdaRuntimeTest extends TestCase
             throw $exception;
         });
 
-        $errorLocation = 'File: ' . $exception->getFile() . ', Line: ' . $exception->getLine();
+        $errorLocation = ['file' => $exception->getFile(), 'line' => $exception->getLine()];
         $this->assertFalse($output);
         $this->assertInvocationErrorResult(
             'RuntimeException',
@@ -107,7 +107,7 @@ class LambdaRuntimeTest extends TestCase
             throw $currentException;
         });
 
-        $errorLocation = 'File: ' . $currentException->getFile() . ', Line: ' . $currentException->getLine();
+        $errorLocation = ['file' => $currentException->getFile(), 'line' => $currentException->getLine()];
         $this->assertInvocationErrorResult(
             'RuntimeException',
             'This is an exception',
@@ -118,12 +118,18 @@ class LambdaRuntimeTest extends TestCase
             [
                 'errorClass' => 'RuntimeException',
                 'errorMessage' => 'The previous exception.',
-                'errorLocation' => 'File: ' . $previousException->getFile() . ', Line: ' . $previousException->getLine()
+                'errorLocation' => [
+                    'file' => $previousException->getFile(),
+                    'line' => $previousException->getLine()
+                ]
             ],
             [
                 'errorClass' => 'Exception',
                 'errorMessage' => 'The original exception.',
-                'errorLocation' => 'File: ' . $originalException->getFile() . ', Line: ' . $originalException->getLine()
+                'errorLocation' => [
+                    'file' => $originalException->getFile(),
+                    'line' => $originalException->getLine()
+                ]
             ],
         ]);
     }
@@ -423,7 +429,7 @@ ERROR;
         $this->assertEquals($result, json_decode($eventResponse->getBody()->__toString(), true, 512, JSON_THROW_ON_ERROR));
     }
 
-    private function assertInvocationErrorResult(string $errorClass, string $errorMessage, string $errorLocation = '')
+    private function assertInvocationErrorResult(string $errorClass, string $errorMessage, array $errorLocation = [])
     {
         $requests = Server::received();
         $this->assertCount(2, $requests);
@@ -450,7 +456,7 @@ ERROR;
         $this->assertIsArray($invocationResult['stackTrace']);
     }
 
-    private function assertErrorInLogs(string $errorClass, string $errorMessage, string $errorLocation = ''): void
+    private function assertErrorInLogs(string $errorClass, string $errorMessage, array $errorLocation = []): void
     {
         // Decode the logs from stdout
         $stdout = $this->getActualOutput();


### PR DESCRIPTION
resolves #1619 

So that we can see the context of an error in Cloudwatch logs, I have added an `errorLocation` key to the `errorFormatted` data structure. This means that the file and line number where the exception is thrown is logged.