### PR TITLE
[1.x] Bumped nghttp2 to 1.56.0

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -195,7 +195,7 @@ RUN set -xe; \
 #   - OpenSSL
 # Needed by:
 #   - curl
-ENV VERSION_NGHTTP2=1.55.1
+ENV VERSION_NGHTTP2=1.56.0
 ENV NGHTTP2_BUILD_DIR=${BUILD_DIR}/nghttp2
 
 RUN set -xe; \


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
