### PR TITLE
POC: Adding specific sns and sqs exception when aws configration is invalid

### DIFF
--- a/src/Event/Sns/SnsRecord.php
+++ b/src/Event/Sns/SnsRecord.php
@@ -4,6 +4,7 @@ namespace Bref\Event\Sns;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
+use LogicException;
 
 /**
  * Represents a SNS message record.
@@ -18,9 +19,18 @@ class SnsRecord
 
     public function __construct(mixed $record)
     {
-        if (! is_array($record) || ! isset($record['EventSource']) || $record['EventSource'] !== 'aws:sns') {
+        if (! is_array($record) || ! isset($record['EventSource'])) {
             throw new InvalidArgumentException;
         }
+
+        if ($record['EventSource'] === 'aws:sqs') {
+            throw new LogicException('Unexpected record type "sqs". Check your AWS infrastructure.');
+        }
+
+        if ($record['EventSource'] !== 'aws:sns') {
+            throw new InvalidArgumentException;
+        }
+
         $this->record = $record;
     }
 

--- a/src/Event/Sqs/SqsRecord.php
+++ b/src/Event/Sqs/SqsRecord.php
@@ -3,6 +3,7 @@
 namespace Bref\Event\Sqs;
 
 use InvalidArgumentException;
+use LogicException;
 
 /**
  * @final
@@ -13,9 +14,18 @@ class SqsRecord
 
     public function __construct(mixed $record)
     {
-        if (! is_array($record) || ! isset($record['eventSource']) || $record['eventSource'] !== 'aws:sqs') {
+        if (! is_array($record) || ! isset($record['eventSource'])) {
             throw new InvalidArgumentException;
         }
+
+        if ($record['eventSource'] === 'aws:sns') {
+            throw new LogicException('Unexpected record type "sns". Check your AWS infrastructure.');
+        }
+
+        if ($record['eventSource'] !== 'aws:sqs') {
+            throw new InvalidArgumentException;
+        }
+
         $this->record = $record;
     }
 


### PR DESCRIPTION
This would help developers with configurations like SNS->Lambda when they use the wrong consumer.