### PR TITLE
Update docker-compose.yml example to include user

### DIFF
--- a/docs/web-apps/local-development.md
+++ b/docs/web-apps/local-development.md
@@ -42,6 +42,7 @@ services:
             - .:/var/task
         environment:
             HANDLER: public/index.php
+        user: nobody
 ```
 
 After running `docker-compose up`, the application will be available at [http://localhost:8000/](http://localhost:8000/).


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
From #1644, the `user` field needs to be in `docker-compose.yml` for it to work with laravel.