### PR TITLE
feat: uncouple secrets loader

### DIFF
--- a/src/LazySecretsLoader.php
+++ b/src/LazySecretsLoader.php
@@ -19,12 +19,16 @@ final class LazySecretsLoader
 {
     public static function loadSecretEnvironmentVariables(): void
     {
-        if (! self::areThereSecretsToLoad()) {
-            return;
+        $hasSecretsLoader = class_exists(Secrets::class);
+
+        if (self::areThereSecretsToLoad()) {
+            if (! $hasSecretsLoader) {
+                throw new Exception('The "bref/secrets-loader" package is required to load SSM parameters via the "bref-ssm:xxx" syntax in environment variables. Please add it to your "require" section in composer.json.');
+            }
         }
 
-        if (! class_exists(Secrets::class)) {
-            throw new Exception('The "bref/secrets-loader" package is required to load SSM parameters via the "bref-ssm:xxx" syntax in environment variables. Please add it to your "require" section in composer.json.');
+        if (! $hasSecretsLoader) {
+            return;
         }
 
         Secrets::loadSecretEnvironmentVariables();


### PR DESCRIPTION
Right now, the logic whether the secrets loader will be used or not is implemented here in the first place. However, I think it should only be used to output a warning. That makes it easier to patch the secrets loader and for example use this proposed change: https://github.com/brefphp/secrets-loader/pull/4
