### PR TITLE
[1.x] Bump to cURL 8.4.0

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -226,7 +226,7 @@ RUN set -xe; \
 # #   - libssh2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.3.0
+ENV VERSION_CURL=8.4.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 
 RUN set -xe; \


### PR DESCRIPTION
Fixes [CVE-2023-38545](https://curl.se/docs/CVE-2023-38545.html) and [CVE-2023-38546](https://curl.se/docs/CVE-2023-38546.html).