### PR TITLE
Upgrade nghttp2 to 1.57.0

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -195,7 +195,7 @@ RUN set -xe; \
 #   - OpenSSL
 # Needed by:
 #   - curl
-ENV VERSION_NGHTTP2=1.56.0
+ENV VERSION_NGHTTP2=1.57.0
 ENV NGHTTP2_BUILD_DIR=${BUILD_DIR}/nghttp2
 
 RUN set -xe; \


### PR DESCRIPTION
Fixes [CVE-2023-44487](https://github.com/nghttp2/nghttp2/security/advisories/GHSA-vx74-f528-fxqg).