### PR TITLE
Detect bref/secrets-loader installed as dependency of another package

### DIFF
--- a/plugin/secrets.js
+++ b/plugin/secrets.js
@@ -27,7 +27,7 @@ function warnIfUsingSecretsWithoutTheBrefDependency(serverless, log) {
             return;
         }
 
-        log.warning(`The following environment variables use the "bref-ssm:" prefix, but the "bref/secrets-loader" dependency is not installed via "composer.json".`);
+        log.warning(`The following environment variables use the "bref-ssm:" prefix, but the "bref/secrets-loader" dependency is not installed.`);
         allVariables.forEach(variable => log.warning(`    ${variable}`));
         log.warning(`The "bref/secrets-loader" dependency is required to use the "bref-ssm:" prefix. Install it by running:`);
         log.warning(`    composer require bref/secrets-loader`);

--- a/plugin/secrets.js
+++ b/plugin/secrets.js
@@ -18,11 +18,11 @@ function warnIfUsingSecretsWithoutTheBrefDependency(serverless, log) {
 
     if (allVariables.length > 0) {
         // Check if the bref/secrets-loader dependency is installed in composer.json
-        if (! fs.existsSync('composer.json')) {
+        if (! fs.existsSync('composer.lock')) {
             return;
         }
-        const composerJson = JSON.parse(fs.readFileSync('composer.json', 'utf8'));
-        const dependencies = Object.keys(composerJson.require || {});
+        const composerLock = JSON.parse(fs.readFileSync('composer.lock', 'utf8'));
+        const dependencies = composerLock.packages.map(v => v.name) || {};
         if (dependencies.includes('bref/secrets-loader')) {
             return;
         }


### PR DESCRIPTION
If you require `bref/secrets-loader` in another package as dependency you get this warning on serverless cli
![Captura de pantalla 2023-10-22 a las 13 54 20](https://github.com/brefphp/bref/assets/13980708/a7b292c5-e845-4075-8611-4a5742b6744a)

With this simple change we detect if `bref/secrets-loader` is really installed, as direct dependency or as a dependency of another package.

