### PR TITLE
Cite bref/api-gateway-websocket-client in the websockets docs page

### DIFF
--- a/docs/use-cases/websockets.mdx
+++ b/docs/use-cases/websockets.mdx
@@ -38,6 +38,8 @@ class MyHandler extends WebsocketHandler
 }
 ```
 
+To send a message to a client connected you can use [bref/api-gateway-websocket-client library](https://github.com/brefphp/api-gateway-websocket-client) to make an http request to the endpoint provided by AWS.
+
 Learn more about using WebSockets in `serverless.yml` [in the Serverless Framework documentation](https://www.serverless.com/framework/docs/providers/aws/events/websocket/).
 
 <Callout>


### PR DESCRIPTION
bref/api-gateway-websocket-client is not cited in either the websockets documentation or the Serverless Visually Explained websockets documentation (and there the namespace is also not updated)