### PR TITLE
(Docs) Added information on the deployment docs for reducing deployment size when using aws/google SDKs

### DIFF
--- a/docs/deploy.mdx
+++ b/docs/deploy.mdx
@@ -36,6 +36,10 @@ Instead, let's remove development dependencies and optimize Composer's autoloade
 composer install --prefer-dist --optimize-autoloader --no-dev
 ```
 
+<Callout>
+    Using [aws/aws-sdk-php](https://github.com/aws/aws-sdk-php/tree/master/src/Script/Composer) or [google/apiclient](https://github.com/googleapis/google-api-php-client#cleaning-up-unused-services)? See the links for reducing deployment size by removing unused services
+</Callout>
+
 Now is also the best time to configure your project for production, as well as build any file cache if necessary.
 
 Once your project is ready, you can deploy via the following command:


### PR DESCRIPTION
My codebase was sitting just on the edge of maximum deployment size & every now and then staging deployments would complain after our patching routine because google or AWS added new services that increased the deployment size.

Our solution have for years been just to extend the never ending exclude list with new services. But this time i got quite annoying by it and with a few searches i found some nifty composer scripts that can be used to automatically cleanup unused services in both the Google and AWS SDKs!

AWS SDK was heavily inspired by https://github.com/aws/aws-sdk-php/pull/2456 - so the syntax is much the same.

This change adds a small callout segment in the deployment which just highlights this as these packages are often found in serverless deployments.