### PR TITLE
Add ability to get queue name from sqs event

### DIFF
--- a/src/Event/Sqs/SqsRecord.php
+++ b/src/Event/Sqs/SqsRecord.php
@@ -59,10 +59,7 @@ class SqsRecord
 
     /**
      * Returns the name of the SQS queue that contains the message.
-     * 
-     * Queue naming constraints:
-     * 
-     * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html
+     * Queue naming constraints: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html
      */
     public function getQueueName(): string
     {

--- a/src/Event/Sqs/SqsRecord.php
+++ b/src/Event/Sqs/SqsRecord.php
@@ -58,6 +58,20 @@ class SqsRecord
     }
 
     /**
+     * Returns the name of the SQS queue that contains the message.
+     * 
+     * Queue naming constraints:
+     * 
+     * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html
+     */
+    public function getQueueName(): string
+    {
+        $parts = explode(':', $this->record['eventSourceARN']);
+
+        return $parts[count($parts) - 1];
+    }
+
+    /**
      * Returns the record original data as an array.
      *
      * Use this method if you want to access data that is not returned by a method in this class.

--- a/tests/Event/Sqs/SqsRecordTest.php
+++ b/tests/Event/Sqs/SqsRecordTest.php
@@ -7,9 +7,10 @@ use PHPUnit\Framework\TestCase;
 
 class SqsRecordTest extends TestCase
 {
-    public function test_it_can_get_queue_name_from_sqs_event() {
+    public function test_it_can_get_queue_name_from_sqs_event()
+    {
         $event = json_decode(file_get_contents(__DIR__ . '/sqs.json'), true);
-        
+
         $sqsRecord = new SqsRecord($event['Records'][0]);
 
         $this->assertSame($sqsRecord->getQueueName(), 'my-queue');

--- a/tests/Event/Sqs/SqsRecordTest.php
+++ b/tests/Event/Sqs/SqsRecordTest.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test\Event\Sqs;
+
+use Bref\Event\Sqs\SqsRecord;
+use PHPUnit\Framework\TestCase;
+
+class SqsRecordTest extends TestCase
+{
+    public function test_it_can_get_queue_name_from_sqs_event() {
+        $event = json_decode(file_get_contents(__DIR__ . '/sqs.json'), true);
+        
+        $sqsRecord = new SqsRecord($event['Records'][0]);
+
+        $this->assertSame($sqsRecord->getQueueName(), 'my-queue');
+    }
+}


### PR DESCRIPTION
- Adds ability to get the queue name from a given sqs event

## Why is this needed?
- This way we can easily get the queue name from the sqs event, example usage:
- brefphp/laravel-bridge/pull/139