### PR TITLE
SSM doc - Specifying that using SecureString is possible

### DIFF
--- a/docs/environment/variables.mdx
+++ b/docs/environment/variables.mdx
@@ -60,6 +60,8 @@ aws ssm put-parameter --region us-east-1 --name '//my-app\my-parameter' --type S
 
 It is recommended to prefix the parameter name with your application name, for example: `/my-app/my-parameter`.
 
+SSM also allows to store a SecureString parameter, which is encrypted with AWS KMS. To use a SecureString, simply change the `--type` argument to `--type SecureString`. Bref takes care of decrypting the value.
+
 ### Retrieving secrets
 
 You can inject a secret in an environment variable:


### PR DESCRIPTION
Since the example only talks about the `String` parameter type, I did not felt comfortable in storing the secrets as plain text in SSM.  Upon digging in github, I found this [comment on PR #1376](https://github.com/brefphp/bref/pull/1376#issuecomment-1405754051). 

I thought it would be helpful to specify that both SecureString and String are taken into account.

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
