### PR TITLE
[1.x] Bump libxml to 2.11.6

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -275,7 +275,7 @@ RUN set -xe; \
 #   - zlib
 # Needed by:
 #   - php
-ENV VERSION_XML2=2.11.5
+ENV VERSION_XML2=2.11.6
 ENV XML2_BUILD_DIR=${BUILD_DIR}/xml2
 
 RUN set -xe; \


### PR DESCRIPTION
2.12.x is not compatible with any current PHP versions, and will only be compatible with newer PHP versions once the next PHP patch releases are out, so I guess we stick on 2.11.x, maybe 2.11.6 will be the last such release. Maybe it's also time to start to talk about making bref v1 EOL, too.