### PR TITLE
[1.x] curl 8.6.0

### DIFF
--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -226,7 +226,7 @@ RUN set -xe; \
 # #   - libssh2
 # # Needed by:
 # #   - php
-ENV VERSION_CURL=8.5.0
+ENV VERSION_CURL=8.6.0
 ENV CURL_BUILD_DIR=${BUILD_DIR}/curl
 
 RUN set -xe; \

--- a/runtime/base/base.Dockerfile
+++ b/runtime/base/base.Dockerfile
@@ -262,7 +262,8 @@ RUN set -xe; \
     --with-gnu-ld \
     --with-ssl \
     --with-libssh2 \
-    --with-nghttp2
+    --with-nghttp2 \
+    --without-libpsl
 
 
 RUN set -xe; \


### PR DESCRIPTION
Prior to cURL 8.6.0, configure would silently skip when libpsl was missing, compiling without support for public suffix lists. Probably it's not a good idea to start making arguably breaking changes in Bref v1 at this point, and so I've added in the configure flag to continue to ignore the fact that libpsl is missing. For Bref v2 (https://github.com/brefphp/aws-lambda-layers/pull/157), I'll try and get that library included.