### PR TITLE
Support malformed multipart body

### DIFF
--- a/src/Event/Http/Psr7Bridge.php
+++ b/src/Event/Http/Psr7Bridge.php
@@ -111,7 +111,7 @@ final class Psr7Bridge
 
         // Parse the body as multipart/form-data
         $document = new Part("Content-type: $contentType\r\n\r\n" . $event->getBody());
-        if (!$document->isMultiPart()) {
+        if (! $document->isMultiPart()) {
             return [[], null];
         }
         $files = [];

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -554,7 +554,7 @@ Year,Make,Model
 
     abstract protected function assertHasMultiHeader(bool $expected): void;
 
-    abstract protected function assertParsedBody(array|null $expected): void;
+    abstract protected function assertParsedBody(array | null $expected): void;
 
     abstract protected function assertSourceIp(string $expected): void;
 

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -360,6 +360,24 @@ Content-Disposition: form-data; name=\"delete[categories][]\"\r
     /**
      * @dataProvider provide API Gateway versions
      */
+    public function test POST request with malformed multipart form data(int $version)
+    {
+        $this->fromFixture(__DIR__ . "/Fixture/ag-v$version-body-form-multipart-arrays-malformed.json");
+
+        $this->assertContentType('multipart/form-data; boundary=testBoundary');
+        $body = "--testBoundary\r
+Content-Disposition: form-data; name=\"key0[key1][key2][\"\r
+\r
+123\r
+--testBoundary--\r
+";
+        $this->assertBody($body);
+        $this->assertParsedBody(['key0' => ['key1' => ['key2' => '123']]]);
+    }
+
+    /**
+     * @dataProvider provide API Gateway versions
+     */
     public function test POST request with multipart file uploads(int $version)
     {
         $this->fromFixture(__DIR__ . "/Fixture/ag-v$version-body-form-multipart-files.json");

--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -401,7 +401,7 @@ Year,Make,Model
 --testBoundary--\r
 ";
         $this->assertBody($body);
-        $this->assertParsedBody([]);
+        $this->assertParsedBody(null);
         $this->assertUploadedFile(
             'foo',
             'lorem.txt',
@@ -554,7 +554,7 @@ Year,Make,Model
 
     abstract protected function assertHasMultiHeader(bool $expected): void;
 
-    abstract protected function assertParsedBody(array $expected): void;
+    abstract protected function assertParsedBody(array|null $expected): void;
 
     abstract protected function assertSourceIp(string $expected): void;
 

--- a/tests/Event/Http/Fixture/ag-v1-body-form-multipart-arrays-malformed.json
+++ b/tests/Event/Http/Fixture/ag-v1-body-form-multipart-arrays-malformed.json
@@ -1,0 +1,53 @@
+{
+    "version": "1.0",
+    "resource": "/path",
+    "path": "/path",
+    "httpMethod": "POST",
+    "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Cache-Control": "no-cache",
+        "Content-Type": "multipart/form-data; boundary=testBoundary",
+        "Host": "example.org",
+        "User-Agent": "PostmanRuntime/7.20.1",
+        "X-Amzn-Trace-Id": "Root=1-ffffffff-ffffffffffffffffffffffff",
+        "X-Forwarded-For": "1.1.1.1",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "queryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "xxxxxx",
+        "resourcePath": "/path",
+        "httpMethod": "PUT",
+        "extendedRequestId": "XXXXXX-xxxxxxxx=",
+        "requestTime": "24/Nov/2019:18:55:08 +0000",
+        "path": "/path",
+        "accountId": "123400000000",
+        "protocol": "HTTP/1.1",
+        "stage": "dev",
+        "domainPrefix": "dev",
+        "requestTimeEpoch": 1574621708700,
+        "requestId": "ffffffff-ffff-4fff-ffff-ffffffffffff",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "1.1.1.1",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "PostmanRuntime/7.20.1",
+            "user": null
+        },
+        "domainName": "example.org",
+        "apiId": "xxxxxxxxxx"
+    },
+    "body": "--testBoundary\r\nContent-Disposition: form-data; name=\"key0[key1][key2][\"\r\n\r\n123\r\n--testBoundary--\r\n",
+    "isBase64Encoded": false
+}

--- a/tests/Event/Http/Fixture/ag-v2-body-form-multipart-arrays-malformed.json
+++ b/tests/Event/Http/Fixture/ag-v2-body-form-multipart-arrays-malformed.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0",
+    "routeKey": "ANY /path",
+    "rawPath": "/path",
+    "rawQueryString": "",
+    "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Cache-Control": "no-cache",
+        "Content-Type": "multipart/form-data; boundary=testBoundary",
+        "Host": "example.org",
+        "User-Agent": "PostmanRuntime/7.20.1",
+        "X-Amzn-Trace-Id": "Root=1-ffffffff-ffffffffffffffffffffffff",
+        "X-Forwarded-For": "1.1.1.1",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "queryStringParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "accountId": "123400000000",
+        "apiId": "xxxxxxxxxx",
+        "domainName": "example.org",
+        "domainPrefix": "0000000000",
+        "http": {
+            "method": "POST",
+            "path": "/path",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "1.1.1.1",
+            "userAgent": "PostmanRuntime/7.20.1"
+        },
+        "requestId": "JTHoQgr2oAMEPMg=",
+        "routeId": "47matwk",
+        "routeKey": "ANY /path",
+        "stage": "$default",
+        "time": "24/Nov/2019:18:55:08 +0000",
+        "timeEpoch": 1574621708700
+    },
+    "body": "--testBoundary\r\nContent-Disposition: form-data; name=\"key0[key1][key2][\"\r\n\r\n123\r\n--testBoundary--\r\n",
+    "isBase64Encoded": false
+}

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -112,7 +112,7 @@ class HttpRequestEventTest extends CommonHttpTest
         $this->assertEquals($expected, $this->event->getSourceIp());
     }
 
-    protected function assertParsedBody(array $expected): void
+    protected function assertParsedBody(array|null $expected): void
     {
         // Not applicable here since the class doesn't parse the body
     }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -112,7 +112,7 @@ class HttpRequestEventTest extends CommonHttpTest
         $this->assertEquals($expected, $this->event->getSourceIp());
     }
 
-    protected function assertParsedBody(array|null $expected): void
+    protected function assertParsedBody(array | null $expected): void
     {
         // Not applicable here since the class doesn't parse the body
     }

--- a/tests/Event/Http/Psr7BridgeTest.php
+++ b/tests/Event/Http/Psr7BridgeTest.php
@@ -123,7 +123,7 @@ class Psr7BridgeTest extends CommonHttpTest
         // Not applicable here
     }
 
-    protected function assertParsedBody(array|null $expected): void
+    protected function assertParsedBody(array | null $expected): void
     {
         $this->assertEquals($expected, $this->request->getParsedBody());
     }

--- a/tests/Event/Http/Psr7BridgeTest.php
+++ b/tests/Event/Http/Psr7BridgeTest.php
@@ -123,7 +123,7 @@ class Psr7BridgeTest extends CommonHttpTest
         // Not applicable here
     }
 
-    protected function assertParsedBody(array $expected): void
+    protected function assertParsedBody(array|null $expected): void
     {
         $this->assertEquals($expected, $this->request->getParsedBody());
     }


### PR DESCRIPTION
For example body containing broken array keys like `key0[key1][key2][`.

We use `parse_str` to ensure keys are parsed just like native PHP would.