### PR TITLE
Just add a retry before really throwing a FastCgiCommunicationFailed exception.

### DIFF
--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -182,6 +182,10 @@ final class FpmHandler extends HttpHandler
                     $e->getMessage()
                 );
 
+                // Restart PHP-FPM: in some cases PHP-FPM is borked, that's the only way we can recover
+                $this->stop();
+                $this->start();
+
                 throw new FastCgiCommunicationFailed;
             }
         }

--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -171,7 +171,19 @@ final class FpmHandler extends HttpHandler
             $this->stop();
             $this->start();
 
-            throw new FastCgiCommunicationFailed;
+            try {
+                $socketId = $this->client->sendAsyncRequest($this->connection, $request);
+
+                $response = $this->client->readResponse($socketId, $timeoutDelayInMs);
+            } catch (Throwable $e) {
+                printf(
+                    "Error communicating with PHP-FPM to read the HTTP response. Bref will restart PHP-FPM now. Original exception message: %s %s\n",
+                    get_class($e),
+                    $e->getMessage()
+                );
+
+                throw new FastCgiCommunicationFailed;
+            }
         }
 
         $responseHeaders = $this->getResponseHeaders($response);


### PR DESCRIPTION
Hello there!

This PR only to start a discussion to try to find a solution to this kind of random errors:

```
Error communicating with PHP-FPM to read the HTTP response. Bref will restart PHP-FPM now. Original exception message: hollodotme\FastCGI\Exceptions\ReadFailedException Stream got blocked, or terminated.
```

I'm pretty sure something smarter can be achieved but manually testing this for a few minutes now and only got 200 responses and no more 500...
