### PR TITLE
Add note to about reduced response limit with binary responses

### DIFF
--- a/docs/use-cases/http/binary-requests-responses.mdx
+++ b/docs/use-cases/http/binary-requests-responses.mdx
@@ -24,4 +24,4 @@ provider:
 
 This will make API Gateway support binary file uploads and downloads, and Bref will automatically encode responses to base64 (which is what API Gateway expects for binary responses).
 
-Be aware that the max upload and download size is **6MB**. For larger files, use AWS S3. An example is available in [Serverless Visually Explained](https://serverless-visually-explained.com/).
+Be aware that the max upload and download size is **6MB** and because [base64 encoding adds a ~33% overhead](https://en.wikipedia.org/wiki/Base64) to the response, downloads are limited to ~4.5MB in size. For larger files, use AWS S3. An example is available in [Serverless Visually Explained](https://serverless-visually-explained.com/).


### PR DESCRIPTION
In the documentation it is mentioned that the size limitation of responses is 6MB though through the use of base64 in practice it is reduced to about 4.5MB. This PR adds a note of it.