### PR TITLE
Add SQS polling information to docs

### DIFF
--- a/docs/laravel/queues.mdx
+++ b/docs/laravel/queues.mdx
@@ -67,3 +67,13 @@ Instead, "Bref for Laravel" makes all the feature of Laravel Queues work out of 
 <Callout>
     The "Bref-Laravel bridge" v1 used to do the opposite. We changed that behavior in Bref v2 in order to make the experience smoother for Laravel users.
 </Callout>
+
+### SQS Polling and Charges
+AWS Lambda maintains a continuous "poller" for SQS messages, which invokes the Lambda function upon receiving messages. This process, while eliminating the need for manual polling, generates continuous SQS requests, incurring charges, [though the first 1M requests of each month are free as part of the AWS free tier](https://aws.amazon.com/sqs/pricing/#:~:text=First%201%20Million%20Requests/Month). 
+
+Reducing Polling Charges
+To mitigate these charges, consider adjusting the `MaximumBatchingWindowInSeconds` in your Lambda configuration. This setting delays message delivery to the Lambda function when batching, aiming to assemble the largest possible batch within the specified timeframe, counted as a single SQS API request.
+
+<Callout>
+    Adjusting `MaximumBatchingWindowInSeconds` can effectively reduce SQS polling charges but may introduce a delay in message processing. This trade-off is essential to consider based on your application's requirements.
+</Callout>

--- a/docs/symfony/messenger.mdx
+++ b/docs/symfony/messenger.mdx
@@ -174,6 +174,16 @@ $messageBus->dispatch(new MyAsyncMessage(), [
 ```
 Everything else is identical to the normal SQS queue.
 
+### Polling and Charges
+AWS Lambda maintains a continuous "poller" for SQS messages, which invokes the Lambda function upon receiving messages. This process, while eliminating the need for manual polling, generates continuous SQS requests, incurring charges, [though the first 1M requests of each month are free as part of the AWS free tier](https://aws.amazon.com/sqs/pricing/#:~:text=First%201%20Million%20Requests/Month). 
+
+Reducing Polling Charges
+To mitigate these charges, consider adjusting the `MaximumBatchingWindowInSeconds` in your Lambda configuration. This setting delays message delivery to the Lambda function when batching, aiming to assemble the largest possible batch within the specified timeframe, counted as a single SQS API request.
+
+<Callout>
+    Adjusting `MaximumBatchingWindowInSeconds` can effectively reduce SQS polling charges but may introduce a delay in message processing. This trade-off is essential to consider based on your application's requirements.
+</Callout>
+
 ## SNS
 
 AWS [SNS](https://aws.amazon.com/sns) is "notification" instead of "queues". Messages may not arrive in the same order as sent, and they might arrive all at once. To use it, create an SNS topic and set it as the DSN:


### PR DESCRIPTION
Updating documentation based on our discussion on https://github.com/brefphp/bref/discussions/1760 in an attempt to be helpful! 

I wonder if this information would be better in a more centralised area of the docs that can provide more detailed information about different parts of the infrastructure layer work. I couldn't see anything like this so for now I've added the information to the Symfony Messenger and Laravel Queue sections.