### PR TITLE
Require `riverline/multipart-parser` 2.1.2 to fix security issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "psr/container": "^1.0|^2.0",
         "psr/http-message": "^1.0|^2.0",
         "psr/http-server-handler": "^1.0",
-        "riverline/multipart-parser": "^2.0.6",
+        "riverline/multipart-parser": "^2.1.2",
         "symfony/process": "^4.4|^5.0|^6.0|^7.0"
     },
     "require-dev": {


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
