### PR TITLE
Colons in URIs are not supported with the function runtime

### DIFF
--- a/tests/Event/Http/CommonHttpTest.php
+++ b/tests/Event/Http/CommonHttpTest.php
@@ -520,6 +520,15 @@ Year,Make,Model
         $this->assertBasicAuthPassword('secret');
     }
 
+    /**
+     * @dataProvider provide API Gateway versions
+     */
+    public function test colon in uri(int $version)
+    {
+        $this->fromFixture(__DIR__ . "/Fixture/ag-v$version-colon-in-uri.json");
+        $this->assertPath('/tags/john:81');
+    }
+
     abstract protected function fromFixture(string $file): void;
 
     abstract protected function assertBody(string $expected): void;

--- a/tests/Event/Http/Fixture/ag-v1-colon-in-uri.json
+++ b/tests/Event/Http/Fixture/ag-v1-colon-in-uri.json
@@ -1,0 +1,52 @@
+{
+    "version": "1.0",
+    "resource": "/tags/john:81",
+    "path": "/tags/john:81",
+    "httpMethod": "GET",
+    "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Cache-Control": "no-cache",
+        "Host": "example.org",
+        "User-Agent": "PostmanRuntime/7.20.1",
+        "X-Amzn-Trace-Id": "Root=1-ffffffff-ffffffffffffffffffffffff",
+        "X-Forwarded-For": "1.1.1.1",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https"
+    },
+    "queryStringParameters": null,
+    "pathParameters": null,
+    "stageVariables": null,
+    "requestContext": {
+        "resourceId": "xxxxxx",
+        "resourcePath": "/tags/john:81",
+        "httpMethod": "PUT",
+        "extendedRequestId": "XXXXXX-xxxxxxxx=",
+        "requestTime": "24/Nov/2019:18:55:08 +0000",
+        "path": "/tags/john:81",
+        "accountId": "123400000000",
+        "protocol": "HTTP/1.1",
+        "stage": "dev",
+        "domainPrefix": "dev",
+        "requestTimeEpoch": 1574621708700,
+        "requestId": "ffffffff-ffff-4fff-ffff-ffffffffffff",
+        "identity": {
+            "cognitoIdentityPoolId": null,
+            "accountId": null,
+            "cognitoIdentityId": null,
+            "caller": null,
+            "sourceIp": "1.1.1.1",
+            "principalOrgId": null,
+            "accessKey": null,
+            "cognitoAuthenticationType": null,
+            "cognitoAuthenticationProvider": null,
+            "userArn": null,
+            "userAgent": "PostmanRuntime/7.20.1",
+            "user": null
+        },
+        "domainName": "example.org",
+        "apiId": "xxxxxxxxxx"
+    },
+    "body": "",
+    "isBase64Encoded": false
+}

--- a/tests/Event/Http/Fixture/ag-v2-colon-in-uri.json
+++ b/tests/Event/Http/Fixture/ag-v2-colon-in-uri.json
@@ -1,0 +1,39 @@
+{
+    "version": "2.0",
+    "routeKey": "ANY /path",
+    "rawPath": "/tags/john:81",
+    "rawQueryString": "",
+    "cookies": [],
+    "headers": {
+        "accept": "*/*",
+        "accept-encoding": "gzip, deflate",
+        "cache-control": "no-cache",
+        "host": "example.org",
+        "user-agent": "PostmanRuntime/7.20.1",
+        "x-amzn-trace-id": "Root=1-ffffffff-ffffffffffffffffffffffff",
+        "x-forwarded-for": "1.1.1.1",
+        "x-forwarded-port": "443",
+        "x-forwarded-proto": "https"
+    },
+    "queryStringParameters": null,
+    "requestContext": {
+        "accountId": "123400000000",
+        "apiId": "xxxxxxxxxx",
+        "domainName": "example.org",
+        "domainPrefix": "0000000000",
+        "http": {
+            "method": "GET",
+            "path": "/tags/john:81",
+            "protocol": "HTTP/1.1",
+            "sourceIp": "1.1.1.1",
+            "userAgent": "PostmanRuntime/7.20.1"
+        },
+        "requestId": "JTHoQgr2oAMEPMg=",
+        "routeId": "47matwk",
+        "routeKey": "ANY /path",
+        "stage": "$default",
+        "time": "24/Nov/2019:18:55:08 +0000",
+        "timeEpoch": 1574621708700
+    },
+    "isBase64Encoded": false
+}


### PR DESCRIPTION
For example `/tags/john:81`.

I'm opening this PR with a test case to reproduce. I don't have a fix yet.

@Nyholm the root of the exception is in https://github.com/Nyholm/psr7, specifically here:

https://github.com/Nyholm/psr7/blob/229484fc939a76a6579e331b55d86a77fb8e2863/src/Uri.php#L54-L56

This is caused by PHP not supporting these URIs in `parse_url`: https://3v4l.org/jpiQo

https://github.com/php/php-src/issues/12703

Any idea whether https://github.com/Nyholm/psr7 could have a workaround to support these URIs? Should I open a bug there? (do you want to address this?)