### PR TITLE
The Console runtime now always returns the command output

### DIFF
--- a/src/Bref.php
+++ b/src/Bref.php
@@ -104,5 +104,10 @@ class Bref
     {
         self::$containerProvider = null;
         self::$container = null;
+        self::$hooks = [
+            'beforeStartup' => [],
+            'beforeInvoke' => [],
+        ];
+        self::$eventDispatcher = new EventDispatcher;
     }
 }

--- a/src/ConsoleRuntime/CommandFailed.php
+++ b/src/ConsoleRuntime/CommandFailed.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Bref\ConsoleRuntime;
+
+use Exception;
+
+class CommandFailed extends Exception
+{
+}

--- a/src/ConsoleRuntime/Main.php
+++ b/src/ConsoleRuntime/Main.php
@@ -44,7 +44,7 @@ class Main
                 }
 
                 $timeout = max(1, $context->getRemainingTimeInMillis() / 1000 - 1);
-                $command = sprintf('/opt/bin/php %s %s 2>&1', $handlerFile, $cliOptions);
+                $command = sprintf('php %s %s 2>&1', $handlerFile, $cliOptions);
                 $process = Process::fromShellCommandline($command, null, null, null, $timeout);
 
                 $process->run(function ($type, $buffer): void {

--- a/src/ConsoleRuntime/Main.php
+++ b/src/ConsoleRuntime/Main.php
@@ -54,7 +54,7 @@ class Main
                 $exitCode = $process->getExitCode();
 
                 if ($exitCode > 0) {
-                    throw new Exception('The command exited with a non-zero status code: ' . $exitCode);
+                    throw new CommandFailed($process->getOutput());
                 }
 
                 return [

--- a/src/ConsoleRuntime/Main.php
+++ b/src/ConsoleRuntime/Main.php
@@ -52,13 +52,21 @@ class Main
 
                 $exitCode = $process->getExitCode();
 
+                $output = $process->getOutput();
+                // Trim the output to stay under the 6MB limit for AWS Lambda
+                // We only keep 5MB because at this point the difference won't be important
+                // and we'll serialize the output to JSON which will add some overhead
+                $output = substr($output, max(0, strlen($output) - 5 * 1024 * 1024));
+
                 if ($exitCode > 0) {
-                    throw new CommandFailed($process->getOutput());
+                    // This needs to be thrown so that AWS Lambda knows the invocation failed
+                    // (e.g. important for error rates in CloudWatch)
+                    throw new CommandFailed($output);
                 }
 
                 return [
                     'exitCode' => $exitCode, // will always be 0
-                    'output' => $process->getOutput(),
+                    'output' => $output,
                 ];
             });
         }

--- a/src/ConsoleRuntime/Main.php
+++ b/src/ConsoleRuntime/Main.php
@@ -6,7 +6,6 @@ use Bref\Bref;
 use Bref\Context\Context;
 use Bref\LazySecretsLoader;
 use Bref\Runtime\LambdaRuntime;
-use Exception;
 use Symfony\Component\Process\Process;
 
 /**

--- a/tests/ConsoleRuntime/MainTest.php
+++ b/tests/ConsoleRuntime/MainTest.php
@@ -3,12 +3,21 @@
 namespace Bref\Test\ConsoleRuntime;
 
 use Bref\Bref;
+use Bref\ConsoleRuntime\CommandFailed;
 use Bref\ConsoleRuntime\Main;
+use Bref\Test\RuntimeTestCase;
 use Exception;
-use PHPUnit\Framework\TestCase;
 
-class MainTest extends TestCase
+class MainTest extends RuntimeTestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('LAMBDA_TASK_ROOT=' . __DIR__);
+        putenv('_HANDLER=console.php');
+    }
+
     public function test startup hook is called()
     {
         Bref::beforeStartup(function () {
@@ -17,5 +26,34 @@ class MainTest extends TestCase
 
         $this->expectExceptionMessage('This should be called');
         Main::run();
+    }
+
+    public function test happy path()
+    {
+        $this->givenAnEvent('');
+
+        try {
+            Main::run();
+        } catch (Exception) {
+            // Needed because `run()` is an infinite loop and will fail eventually
+        }
+
+        $this->assertInvocationResult([
+            'exitCode' => 0,
+            'output' => "Hello world!\n",
+        ]);
+    }
+
+    public function test failure()
+    {
+        $this->givenAnEvent('fail');
+
+        try {
+            Main::run();
+        } catch (Exception) {
+            // Needed because `run()` is an infinite loop and will fail eventually
+        }
+
+        $this->assertInvocationErrorResult(CommandFailed::class, "Hello world!\nFailure\n");
     }
 }

--- a/tests/ConsoleRuntime/MainTest.php
+++ b/tests/ConsoleRuntime/MainTest.php
@@ -34,7 +34,7 @@ class MainTest extends RuntimeTestCase
 
         try {
             Main::run();
-        } catch (Exception) {
+        } catch (\Throwable) {
             // Needed because `run()` is an infinite loop and will fail eventually
         }
 
@@ -50,7 +50,7 @@ class MainTest extends RuntimeTestCase
 
         try {
             Main::run();
-        } catch (Exception) {
+        } catch (\Throwable) {
             // Needed because `run()` is an infinite loop and will fail eventually
         }
 

--- a/tests/ConsoleRuntime/console.php
+++ b/tests/ConsoleRuntime/console.php
@@ -1,5 +1,11 @@
 <?php declare(strict_types=1);
 
+if (isset($argv[1]) && $argv[1] === 'flood') {
+    // Print 7MB of data to go over the 6MB limit
+    echo str_repeat('x', 7 * 1024 * 1024);
+    exit(0);
+}
+
 echo "Hello world!\n";
 
 if (isset($argv[1]) && $argv[1] === 'fail') {

--- a/tests/ConsoleRuntime/console.php
+++ b/tests/ConsoleRuntime/console.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+echo "Hello world!\n";
+
+if (isset($argv[1]) && $argv[1] === 'fail') {
+    echo "Failure\n";
+    exit(1);
+}

--- a/tests/RuntimeTestCase.php
+++ b/tests/RuntimeTestCase.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace Bref\Test;
+
+use Bref\Bref;
+use GuzzleHttp\Psr7\Response;
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The Lambda Runtime HTTP API is mocked using a fake HTTP server.
+ */
+abstract class RuntimeTestCase extends TestCase
+{
+    protected function setUp(): void
+    {
+        Bref::reset();
+        ob_start();
+        Server::start();
+        putenv('AWS_LAMBDA_RUNTIME_API=localhost:8126');
+    }
+
+    protected function tearDown(): void
+    {
+        Server::stop();
+        ob_end_clean();
+    }
+
+    protected function givenAnEvent(mixed $event): void
+    {
+        Server::enqueue([
+            new Response( // lambda event
+                200,
+                [
+                    'lambda-runtime-aws-request-id' => '1',
+                    'lambda-runtime-invoked-function-arn' => 'test-function-name',
+                ],
+                json_encode($event, JSON_THROW_ON_ERROR)
+            ),
+            new Response(200), // lambda response accepted
+        ]);
+    }
+
+    protected function assertInvocationResult(mixed $result): void
+    {
+        $requests = Server::received();
+        $this->assertCount(2, $requests);
+
+        [$eventRequest, $eventResponse] = $requests;
+        $this->assertSame('GET', $eventRequest->getMethod());
+        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/next', $eventRequest->getUri()->__toString());
+        $this->assertSame('POST', $eventResponse->getMethod());
+        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/1/response', $eventResponse->getUri()->__toString());
+        $this->assertEquals($result, json_decode($eventResponse->getBody()->__toString(), true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    protected function assertInvocationErrorResult(string $errorClass, string $errorMessage): void
+    {
+        $requests = Server::received();
+        $this->assertCount(2, $requests);
+
+        [$eventRequest, $eventResponse] = $requests;
+        $this->assertSame('GET', $eventRequest->getMethod());
+        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/next', $eventRequest->getUri()->__toString());
+        $this->assertSame('POST', $eventResponse->getMethod());
+        $this->assertSame('http://localhost:8126/2018-06-01/runtime/invocation/1/error', $eventResponse->getUri()->__toString());
+
+        // Check the content of the result of the lambda
+        $invocationResult = json_decode($eventResponse->getBody()->__toString(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame([
+            'errorType',
+            'errorMessage',
+            'stackTrace',
+        ], array_keys($invocationResult));
+        $this->assertEquals($errorClass, $invocationResult['errorType']);
+        $this->assertEquals($errorMessage, $invocationResult['errorMessage']);
+        $this->assertIsArray($invocationResult['stackTrace']);
+    }
+
+    protected function assertErrorInLogs(string $errorClass, string $errorMessage): void
+    {
+        // Decode the logs from stdout
+        $stdout = $this->getActualOutput();
+
+        [$requestId, $message, $json] = explode("\t", $stdout);
+
+        $this->assertSame('Invoke Error', $message);
+
+        // Check the request ID matches a UUID
+        $this->assertNotEmpty($requestId);
+
+        try {
+            $invocationResult = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            $this->fail("Could not decode JSON from logs ({$e->getMessage()}): $json");
+        }
+        unset($invocationResult['previous']);
+        $this->assertSame([
+            'errorType',
+            'errorMessage',
+            'stack',
+        ], array_keys($invocationResult));
+        $this->assertEquals($errorClass, $invocationResult['errorType']);
+        $this->assertStringContainsString($errorMessage, $invocationResult['errorMessage']);
+        $this->assertIsArray($invocationResult['stack']);
+    }
+
+    protected function assertPreviousErrorsInLogs(array $previousErrors): void
+    {
+        // Decode the logs from stdout
+        $stdout = $this->getActualOutput();
+
+        [, , $json] = explode("\t", $stdout);
+
+        ['previous' => $previous] = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertCount(count($previousErrors), $previous);
+        foreach ($previous as $index => $error) {
+            $this->assertSame([
+                'errorType',
+                'errorMessage',
+                'stack',
+            ], array_keys($error));
+            $this->assertEquals($previousErrors[$index]['errorClass'], $error['errorType']);
+            $this->assertEquals($previousErrors[$index]['errorMessage'], $error['errorMessage']);
+            $this->assertIsArray($error['stack']);
+        }
+    }
+}

--- a/tests/server.js
+++ b/tests/server.js
@@ -201,7 +201,7 @@ var GuzzleServer = function(port, log) {
                 that.responses = JSON.parse(request.body);
                 for (var i = 0; i < that.responses.length; i++) {
                     if (that.responses[i].body) {
-                        that.responses[i].body = new Buffer(that.responses[i].body, 'base64');
+                        that.responses[i].body = Buffer.from(that.responses[i].body, 'base64');
                     }
                 }
                 if (that.log) {


### PR DESCRIPTION
Before this change, it would only return the output in case of success (not in case of errors). The output could be retrieved via logs. It can now always be retrieved via the invocation result.

This should make it easier to build tooling around this: no need to use CloudWatch to retrieve the command output now.