### PR TITLE
Fix against serverless v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
                     node-version: 18
             # serverless is required by some tests
             -   name: Install serverless
-                run: npm i -g serverless
+                run: npm i -g serverless@3
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:

--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -23,7 +23,7 @@ To use Bref, you will need an AWS account and the `serverless` CLI. Let's get st
     Bref relies on the [Serverless framework](https://serverless.com/) and AWS access keys to deploy applications. You will need to install the `serverless` CLI ([more details here](https://serverless.com/framework/docs/providers/aws/guide/quick-start/)):
 
     ```bash
-    npm install -g serverless
+    npm install -g serverless@3
     ```
 
     Bref is compatible with Serverless Framework v3 (current version).


### PR DESCRIPTION
Serverless Framework has started releasing a beta version as a stable version on NPM.

This breaks all the existing systems and tutorials out there because it requires a license key now. To fix the CI, and to make life easier for newcomers, I'm updating the instructions to install v3.