### PR TITLE
fix: add missing chalk dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,14 +148,10 @@ class ServerlessPlugin {
             'bref:local:run': () => runLocal(this.serverless, options),
             'bref:layers:show': () => listLayers(this.serverless, utils.log),
             'before:logs:logs': () => {
-                /** @type {typeof import('chalk')} */
-                // @ts-ignore
                 utils.log(chalk.gray('View, tail, and search logs from all functions with https://dashboard.bref.sh'));
                 utils.log();
             },
             'before:metrics:metrics': () => {
-                /** @type {typeof import('chalk')} */
-                // @ts-ignore
                 utils.log(chalk.gray('View all your application\'s metrics with https://dashboard.bref.sh'));
                 utils.log();
             },
@@ -165,8 +161,6 @@ class ServerlessPlugin {
             const command = serverless.processedInput.commands[0] || '';
             // On successful deploy
             if (command.startsWith('deploy') && code === 0) {
-                /** @type {typeof import('chalk')} */
-                // @ts-ignore
                 utils.log();
                 utils.log(chalk.gray('Want a better experience than the AWS console? Try out https://dashboard.bref.sh'));
             }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const {runLocal} = require('./plugin/local');
 const {warnIfUsingSecretsWithoutTheBrefDependency} = require('./plugin/secrets');
 const fs = require('fs');
 const path = require('path');
+const chalk = require('chalk');
 
 // Disable `sls` promoting the Serverless Console because it's not compatible with PHP, it's tripping users up
 if (!process.env.SLS_NOTIFICATIONS_MODE) {
@@ -149,14 +150,12 @@ class ServerlessPlugin {
             'before:logs:logs': () => {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
-                const chalk = require.main.require('chalk');
                 utils.log(chalk.gray('View, tail, and search logs from all functions with https://dashboard.bref.sh'));
                 utils.log();
             },
             'before:metrics:metrics': () => {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
-                const chalk = require.main.require('chalk');
                 utils.log(chalk.gray('View all your application\'s metrics with https://dashboard.bref.sh'));
                 utils.log();
             },
@@ -168,7 +167,6 @@ class ServerlessPlugin {
             if (command.startsWith('deploy') && code === 0) {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
-                const chalk = require.main.require('chalk');
                 utils.log();
                 utils.log(chalk.gray('Want a better experience than the AWS console? Try out https://dashboard.bref.sh'));
             }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const {runLocal} = require('./plugin/local');
 const {warnIfUsingSecretsWithoutTheBrefDependency} = require('./plugin/secrets');
 const fs = require('fs');
 const path = require('path');
-const chalk = require('chalk');
 
 // Disable `sls` promoting the Serverless Console because it's not compatible with PHP, it's tripping users up
 if (!process.env.SLS_NOTIFICATIONS_MODE) {
@@ -148,11 +147,11 @@ class ServerlessPlugin {
             'bref:local:run': () => runLocal(this.serverless, options),
             'bref:layers:show': () => listLayers(this.serverless, utils.log),
             'before:logs:logs': () => {
-                utils.log(chalk.gray('View, tail, and search logs from all functions with https://dashboard.bref.sh'));
+                (utils.log.aside ?? utils.log)('View, tail, and search logs from all functions with https://dashboard.bref.sh');
                 utils.log();
             },
             'before:metrics:metrics': () => {
-                utils.log(chalk.gray('View all your application\'s metrics with https://dashboard.bref.sh'));
+                (utils.log.aside ?? utils.log)('View all your application\'s metrics with https://dashboard.bref.sh');
                 utils.log();
             },
         };
@@ -162,7 +161,7 @@ class ServerlessPlugin {
             // On successful deploy
             if (command.startsWith('deploy') && code === 0) {
                 utils.log();
-                utils.log(chalk.gray('Want a better experience than the AWS console? Try out https://dashboard.bref.sh'));
+                (utils.log.aside ?? utils.log)('Want a better experience than the AWS console? Try out https://dashboard.bref.sh');
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "prettier": "^2.8.8"
     },
     "dependencies": {
-        "@headlessui/react": "^1.7.17",
-        "chalk": "^4.1.2"
+        "@headlessui/react": "^1.7.17"
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "prettier": "^2.8.8"
     },
     "dependencies": {
-        "@headlessui/react": "^1.7.17"
+        "@headlessui/react": "^1.7.17",
+        "chalk": "^4.1.2"
     }
 }

--- a/plugin/serverless.ts
+++ b/plugin/serverless.ts
@@ -80,6 +80,7 @@ export type ServerlessUtils = {
 
 export type Logger = ((message?: string) => void) & {
     debug(message?: string): void;
+    aside(message?: string): void; // Requires Serverless Framework v4
     verbose(message?: string): void;
     success(message?: string): void;
     warning(message?: string): void;


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->

`chalk` is no longer a dependency for `serverless` v4. `bref` must install `chalk` on its own to use it.