### PR TITLE
Patch for chalk dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,14 +158,14 @@ class ServerlessPlugin {
             'before:logs:logs': () => {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
-                const chalk = require.main.require('chalk');
+                // const chalk = require.main.require('chalk');
                 utils.log(formatText('View, tail, and search logs from all functions with https://dashboard.bref.sh'));
                 utils.log();
             },
             'before:metrics:metrics': () => {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
-                const chalk = require.main.require('chalk');
+                // const chalk = require.main.require('chalk');
                 utils.log(formatText('View all your application\'s metrics with https://dashboard.bref.sh'));
                 utils.log();
             },

--- a/index.js
+++ b/index.js
@@ -7,6 +7,15 @@ const {warnIfUsingSecretsWithoutTheBrefDependency} = require('./plugin/secrets')
 const fs = require('fs');
 const path = require('path');
 
+function formatText(text) {
+  const grayText = "\x1b[37m"; // Gray text
+  const grayBackground = "\x1b[100m"; // Gray background
+  const reset = "\x1b[0m"; // Reset formatting
+
+  // Combine ANSI escape codes with the text
+  return `${grayBackground}${grayText}${text}${reset}`;
+}
+
 // Disable `sls` promoting the Serverless Console because it's not compatible with PHP, it's tripping users up
 if (!process.env.SLS_NOTIFICATIONS_MODE) {
     process.env.SLS_NOTIFICATIONS_MODE = 'upgrades-only';
@@ -150,14 +159,14 @@ class ServerlessPlugin {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
                 const chalk = require.main.require('chalk');
-                utils.log(chalk.gray('View, tail, and search logs from all functions with https://dashboard.bref.sh'));
+                utils.log(formatText('View, tail, and search logs from all functions with https://dashboard.bref.sh'));
                 utils.log();
             },
             'before:metrics:metrics': () => {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
                 const chalk = require.main.require('chalk');
-                utils.log(chalk.gray('View all your application\'s metrics with https://dashboard.bref.sh'));
+                utils.log(formatText('View all your application\'s metrics with https://dashboard.bref.sh'));
                 utils.log();
             },
         };
@@ -168,9 +177,9 @@ class ServerlessPlugin {
             if (command.startsWith('deploy') && code === 0) {
                 /** @type {typeof import('chalk')} */
                 // @ts-ignore
-                const chalk = require.main.require('chalk');
+                 // const chalk = require.main.require('chalk');  // This will aslways throw an error as chalk is not available here. if we cannot load chalk into the required context
                 utils.log();
-                utils.log(chalk.gray('Want a better experience than the AWS console? Try out https://dashboard.bref.sh'));
+                utils.log( formatText('Want a better experience than the AWS console? Try out https://dashboard.bref.sh'));
             }
         });
     }


### PR DESCRIPTION

The motivation behind these changes is to enhance the Serverless plugin for Bref by improving the terminal output formatting and resolving an error caused by the unavailability of `chalk` as a dependency.

Previously, the plugin relied on `chalk` for terminal text styling. However, recent updates or configurations may have caused `chalk` to become unavailable in certain contexts, resulting in errors such as:

```
✖ Cannot read properties of undefined (reading 'require')
TypeError: Cannot read properties of undefined (reading 'require')
    at process.<anonymous> (REDACTED/vendor/bref/bref/index.js:171:44)
    at process.emit (node:events:514:28)
    at process.processEmit [as emit] (file:///REDACTED/.serverless/releases/4.1.7/package/dist/sf-core.js:63:5538)
```

To address this, the pull request introduces a `formatText` function that utilizes ANSI escape codes for terminal text formatting. This approach ensures consistent and visually appealing text styling, including gray text with a gray background. The `formatText` function replaces the previous usage of `chalk` in lifecycle events (`before:logs:logs`, `before:metrics:metrics`, and deploy success feedback), thereby preventing the aforementioned error and maintaining a reliable user experience across different deployment scenarios.

By standardizing terminal output format and eliminating dependency-related issues with `chalk`, these updates contribute to a more robust and error-free Serverless deployment process within the Bref ecosystem.
