### PR TITLE
Update laravel sqs documentation

### DIFF
--- a/docs/laravel/queues.mdx
+++ b/docs/laravel/queues.mdx
@@ -62,9 +62,11 @@ That's it! Anytime a job is pushed to Laravel Queues, it will be sent to SQS, an
 <Callout>
     In the example above, we used the default queue connection with the name `sqs`.
 
-    If you need to set up a custom queue connection, you must set the `AWS_SESSION_TOKEN` in the connection configuration as follows:
+    It is best practice to remove the `key` and `secret` keys from the queue.php configuration file.
 
-    `Config::set('queue.connections.<connection-name>.token', env('AWS_SESSION_TOKEN'));`
+    If you need to keep these keys (for example, due to requirements of your local environment), you should also add `'token' => env('AWS_SESSION_TOKEN')`.
+
+    Managing the connection's configuration is your responsibility; however, if the `key` and `secret` keys are provided (even with null values), the token key must also be set.
 </Callout>
 
 ## How it works

--- a/docs/laravel/queues.mdx
+++ b/docs/laravel/queues.mdx
@@ -58,6 +58,15 @@ That's it! Anytime a job is pushed to Laravel Queues, it will be sent to SQS, an
     If you only set the queue name (which is also valid), you need to set the `SQS_PREFIX` environment variable too. For example: `SQS_PREFIX: "https://sqs.${aws:region}.amazonaws.com/${aws:accountId}"`.
 </Callout>
 
+
+<Callout>
+    In the example above, we used the default queue connection with the name `sqs`.
+
+    If you need to set up a custom queue connection, you must set the `AWS_SESSION_TOKEN` in the connection configuration as follows:
+
+    `Config::set('queue.connections.<connection-name>.token', env('AWS_SESSION_TOKEN'));`
+</Callout>
+
 ## How it works
 
 When integrated with AWS Lambda, SQS has a built-in retry mechanism and storage for failed messages. These features work slightly differently than Laravel Queues. The "Bref for Laravel" integration does **not** use these SQS features.


### PR DESCRIPTION
Updated Laravel SQS documentation to achive this: https://github.com/brefphp/laravel-bridge/issues/155 

In the documentation is mentioned how to use SQS with the default connection, but not with a custom one (with a name different than `sqs`).

I've explained how to achieve it.