### PR TITLE
Fix #1369 and #1714 Support large amount of logs

### DIFF
--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -15,7 +15,7 @@ use hollodotme\FastCGI\Exceptions\TimedoutException;
 use hollodotme\FastCGI\Interfaces\ProvidesRequestData;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
-use Symfony\Component\Process\Process;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -47,7 +47,8 @@ final class FpmHandler extends HttpHandler
     private UnixDomainSocket $connection;
     private string $handler;
     private string $configFile;
-    private ?Process $fpm = null;
+    /** @var resource|null */
+    private $fpm;
 
     public function __construct(string $handler, string $configFile = self::CONFIG)
     {
@@ -76,13 +77,12 @@ final class FpmHandler extends HttpHandler
          * --nodaemonize: we want to keep control of the process
          * --force-stderr: force logs to be sent to stderr, which will allow us to send them to CloudWatch
          */
-        $this->fpm = new Process(['php-fpm', '--nodaemonize', '--force-stderr', '--fpm-config', $this->configFile]);
+        $resource = @proc_open(['php-fpm', '--nodaemonize', '--force-stderr', '--fpm-config', $this->configFile], [], $pipes);
 
-        $this->fpm->setTimeout(null);
-        $this->fpm->start(function ($type, $output): void {
-            // Send any PHP-FPM log to CloudWatch
-            echo $output;
-        });
+        if (! is_resource($resource)) {
+            throw new RuntimeException('PHP-FPM failed to start');
+        }
+        $this->fpm = $resource;
 
         $this->client = new Client;
         $this->connection = new UnixDomainSocket(self::SOCKET, 1000, 900000);
@@ -95,12 +95,11 @@ final class FpmHandler extends HttpHandler
      */
     public function stop(): void
     {
-        if ($this->fpm && $this->fpm->isRunning()) {
+        if ($this->isFpmRunning()) {
             // Give it less than a second to stop (500ms should be plenty enough time)
             // this is for the case where the script timed out: we reserve 1 second before the end
             // of the Lambda timeout, so we must kill everything and restart FPM in 1 second.
-            // Note: Symfony will first try sending SIGTERM (15) and then SIGKILL (9)
-            $this->fpm->stop(0.5);
+            $this->stopFpm(0.5);
             if ($this->isReady()) {
                 throw new Exception('PHP-FPM cannot be stopped');
             }
@@ -192,7 +191,7 @@ final class FpmHandler extends HttpHandler
      */
     private function ensureStillRunning(): void
     {
-        if (! $this->fpm || ! $this->fpm->isRunning()) {
+        if (! $this->isFpmRunning()) {
             throw new Exception('PHP-FPM has stopped for an unknown reason');
         }
     }
@@ -215,7 +214,7 @@ final class FpmHandler extends HttpHandler
             }
 
             // If the process has crashed we can stop immediately
-            if (! $this->fpm->isRunning()) {
+            if (! $this->isFpmRunning()) {
                 throw new Exception('PHP-FPM failed to start: ' . PHP_EOL . $this->fpm->getOutput() . PHP_EOL . $this->fpm->getErrorOutput());
             }
         }
@@ -336,5 +335,36 @@ final class FpmHandler extends HttpHandler
     private function getResponseHeaders(ProvidesResponseData $response): array
     {
         return array_change_key_case($response->getHeaders(), CASE_LOWER);
+    }
+
+    public function stopFpm(float $timeout): void
+    {
+        if (! $this->fpm) {
+            return;
+        }
+
+        $timeoutMicro = microtime(true) + $timeout;
+        if ($this->isFpmRunning()) {
+            $pid = proc_get_status($this->fpm)['pid'];
+            // SIGTERM
+            @posix_kill($pid, 15);
+            do {
+                usleep(1000);
+            } while ($this->isFpmRunning() && microtime(true) < $timeoutMicro);
+
+            if ($this->isFpmRunning()) {
+                // SIGKILL
+                @posix_kill($pid, 9);
+                usleep(1000);
+            }
+        }
+
+        proc_close($this->fpm);
+        $this->fpm = null;
+    }
+
+    private function isFpmRunning(): bool
+    {
+        return $this->fpm && proc_get_status($this->fpm)['running'];
     }
 }

--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -215,7 +215,8 @@ final class FpmHandler extends HttpHandler
 
             // If the process has crashed we can stop immediately
             if (! $this->isFpmRunning()) {
-                throw new Exception('PHP-FPM failed to start: ' . PHP_EOL . $this->fpm->getOutput() . PHP_EOL . $this->fpm->getErrorOutput());
+                // The output of FPM is in the stderr of the Lambda process
+                throw new Exception('PHP-FPM failed to start');
             }
         }
     }

--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -351,8 +351,10 @@ final class FpmHandler extends HttpHandler
             @posix_kill($pid, 15);
             do {
                 usleep(1000);
+                // @phpstan-ignore-next-line
             } while ($this->isFpmRunning() && microtime(true) < $timeoutMicro);
 
+            // @phpstan-ignore-next-line
             if ($this->isFpmRunning()) {
                 // SIGKILL
                 @posix_kill($pid, 9);

--- a/tests/FpmRuntime/FpmHandlerTest.php
+++ b/tests/FpmRuntime/FpmHandlerTest.php
@@ -1255,8 +1255,8 @@ Year,Make,Model
             $this->fail('No exception was thrown');
         } catch (Timeout $e) {
             $this->markTestSkipped('We can no longer test this since proc_open skips output buffering, we cannot capture the logs');
-            $logs = ob_get_contents();
-            self::assertStringContainsString('This is a log message', $logs);
+//            $logs = ob_get_contents();
+//            self::assertStringContainsString('This is a log message', $logs);
         }
     }
 

--- a/tests/FpmRuntime/FpmHandlerTest.php
+++ b/tests/FpmRuntime/FpmHandlerTest.php
@@ -1254,6 +1254,7 @@ Year,Make,Model
             ], new Context('abc', time(), 'abc', 'abc'));
             $this->fail('No exception was thrown');
         } catch (Timeout $e) {
+            $this->markTestSkipped('We can no longer test this since proc_open skips output buffering, we cannot capture the logs');
             $logs = ob_get_contents();
             self::assertStringContainsString('This is a log message', $logs);
         }
@@ -1283,6 +1284,16 @@ Year,Make,Model
             'warmer' => true,
         ], $this->fakeContext);
         self::assertEquals(['Lambda is warm'], $result);
+    }
+
+    /**
+     * @see https://github.com/brefphp/bref/issues/1369
+     */
+    public function test large logs()
+    {
+        $response = $this->get('large-logs.php');
+
+        self::assertSame('Hello, world!', $response['body']);
     }
 
     private function assertGlobalVariables(array $event, array $expectedGlobalVariables): void

--- a/tests/FpmRuntime/fixtures/large-logs.php
+++ b/tests/FpmRuntime/fixtures/large-logs.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+$stderr = fopen('php://stderr', 'wb');
+$bytes = 512*512;
+fwrite($stderr, str_repeat('x', $bytes));
+
+echo 'Hello, world!';

--- a/tests/FpmRuntime/fixtures/large-logs.php
+++ b/tests/FpmRuntime/fixtures/large-logs.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 
 $stderr = fopen('php://stderr', 'wb');
-$bytes = 512*512;
+$bytes = 512 * 512;
 fwrite($stderr, str_repeat('x', $bytes));
 
 echo 'Hello, world!';

--- a/tests/FpmRuntime/fixtures/php-fpm.conf
+++ b/tests/FpmRuntime/fixtures/php-fpm.conf
@@ -3,6 +3,9 @@ error_log = /dev/null
 ; Log above warning because PHP-FPM logs useless notices
 ;log_level = 'warning'
 
+; New PHP 7.3 option that includes the maximum length when writing to stderr
+log_limit = 8192
+
 [default]
 pm = static
 ; We only need one child because a lambda can process only one request at a time
@@ -13,8 +16,7 @@ clear_env = yes
 ; Forward stderr of PHP processes to stderr of PHP-FPM (so that it can be sent to cloudwatch)
 catch_workers_output = yes
 ; New PHP 7.3 option that disables a verbose log prefix
-; Disabled for now until we switch to PHP 7.3
-;decorate_workers_output = no
+decorate_workers_output = no
 ; Limit the number of core dump logs to 1 to avoid filling up the /tmp disk
 ; See https://github.com/brefphp/bref/issues/275
 rlimit_core = 1


### PR DESCRIPTION
Fix #1369, Fix #1714

We get rid of symfony/process where we had to forward all the FPM output to PHP. Instead we use `proc_open` and directly stream output to stdout/stderr.