### PR TITLE
Recommend Serverless Framework v3

### DIFF
--- a/docs/setup.mdx
+++ b/docs/setup.mdx
@@ -26,7 +26,7 @@ To use Bref, you will need an AWS account and the `serverless` CLI. Let's get st
     npm install -g serverless@3
     ```
 
-    Bref is compatible with Serverless Framework v3 and v4. However the Bref documentation is written for v3 as v4 switches to a proprietary license.
+    Bref is compatible with Serverless Framework v3 and v4. Note that Serverless Framework v4 has proven to be very unstable and is no longer open-source. We recommend using v3 for the best experience.
 
     If you don't want to install `serverless` via NPM, you can install it as a standalone binary [by following this documentation](https://github.com/serverless/serverless/blob/v3/docs/install-standalone.md).
 

--- a/docs/upgrading/v2.md
+++ b/docs/upgrading/v2.md
@@ -33,7 +33,7 @@ To check your Serverless Framework version, run:
 serverless --version
 ```
 
-If you need to upgrade, [read the Serverless Framework documentation](https://www.serverless.com/framework/docs/getting-started#upgrade) (short version: run `npm install -g serverless`).
+If you need to upgrade, [read the Serverless Framework documentation](https://www.serverless.com/framework/docs/getting-started#upgrade) (short version: run `npm install -g serverless@3`).
 
 ## PHP runtimes
 


### PR DESCRIPTION
There are just so many issues with v4 that it's impossible to recommend it at the moment.

Lift was supposed to work with v4 but I keep seeing reports that it actually doesn't work (latest is https://github.com/serverless/serverless/issues/12797). Since Lift is key to Bref users, let's recommend using v3 for now.

Note that yes, there are bugfixes merged in v4 regularly, but there are new bugs introduced in the CLI in every release (1 step forward, 2 steps back). So I'm not considering the number of fixes merged, I'm considering the overall stability of the project.