### PR TITLE
fix: key was missing in kafka record

### DIFF
--- a/src/Event/Kafka/KafkaRecord.php
+++ b/src/Event/Kafka/KafkaRecord.php
@@ -18,7 +18,7 @@ class KafkaRecord
         }
         $this->record = $record;
     }
-    
+
     public function getKey(): string
     {
         return $this->record['key'];

--- a/src/Event/Kafka/KafkaRecord.php
+++ b/src/Event/Kafka/KafkaRecord.php
@@ -18,6 +18,11 @@ class KafkaRecord
         }
         $this->record = $record;
     }
+    
+    public function getKey(): string
+    {
+        return $this->record['key'];
+    }
 
     public function getTopic(): string
     {

--- a/tests/Event/Kafka/KafkaEventTest.php
+++ b/tests/Event/Kafka/KafkaEventTest.php
@@ -19,6 +19,7 @@ final class KafkaEventTest extends TestCase
         self::assertSame(15, $record->getOffset());
         self::assertSame(1545084650987, $record->getTimestamp());
         self::assertSame('Hello, this is a test.', $record->getValue());
+        self::assertSame('SGVsbG8gV29ybGQ=', $record->getKey());
         self::assertSame(
             [
                 'type'           => 'core',

--- a/tests/Event/Kafka/kafka.json
+++ b/tests/Event/Kafka/kafka.json
@@ -9,6 +9,7 @@
                 "offset":15,
                 "timestamp":1545084650987,
                 "timestampType":"CREATE_TIME",
+                "key": "SGVsbG8gV29ybGQ=",
                 "value":"SGVsbG8sIHRoaXMgaXMgYSB0ZXN0Lg==",
                 "headers":[
                     {


### PR DESCRIPTION
Added a getter for missing key property because it was missing.

As per the official SDK for Java: https://github.com/aws/aws-lambda-java-libs/blob/main/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/KafkaEvent.java

<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
