### PR TITLE
[Doc] Trust all remote proxies

### DIFF
--- a/docs/symfony/getting-started.mdx
+++ b/docs/symfony/getting-started.mdx
@@ -165,7 +165,7 @@ Add the following lines to `config/packages/framework.yaml`:
 ```yml filename="config/packages/framework.yaml" {2-5}
 framework:
   # trust the remote address because API Gateway has no fixed IP or CIDR range that we can target
-  trusted_proxies: '127.0.0.1'
+  trusted_proxies: '127.0.0.1, 0.0.0.0/0'
   # trust "X-Forwarded-*" headers coming from API Gateway
   trusted_headers: [ 'x-forwarded-for', 'x-forwarded-proto', 'x-forwarded-port' ]
 ```

--- a/docs/use-cases/websites.mdx
+++ b/docs/use-cases/websites.mdx
@@ -94,6 +94,7 @@ serverless plugin install -n serverless-lift
         Because this construct sets the `X-Forwarded-Host` header by default, you should add it in your `trusted_headers` config, otherwise Symfony might generate wrong URLs.
 
         ```yml filename="config/packages/framework.yaml" /, 'x-forwarded-host'/
+           trusted_proxies: '127.0.0.1, 0.0.0.0/0'
            trusted_headers: [ 'x-forwarded-for', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-host' ]
         ```
 


### PR DESCRIPTION
Using Lift and a custom domain, you need to trust all proxies in order to make it work properly. 

This is because Symfony will never see Cloudfront URL because we are using the end client IP here: https://github.com/brefphp/bref/blob/master/src/Event/Http/Psr7Bridge.php#L44

If we set this the `127.0.0.1` instead, it would work for Symfony with `trusted_proxies: 127.0.0.1`. But that will obviously not work for other users expecing this to be the end client IP. 

We **could** specify `$_SERVER['REMOTE_ADDR']` to be either the proxy or `127.0.0.1`. If so, you would configure `trusted_proxies: 127.0.0.1, REMOTE_ADDR`. See [Symfony Request](https://github.com/symfony/symfony/blob/v7.1.5/src/Symfony/Component/HttpFoundation/Request.php#L528-L540)

The `$_SERVER['REMOTE_ADDR']` is currently undefined. 

-------------

I am not 100% this suggestion is safe, so we should probably use `$_SERVER['REMOTE_ADDR']`, but that also feels wrong. I would be happy to get some input. 