### PR TITLE
feat: support loading secrets when only present in dotenv

### DIFF
--- a/src/LazySecretsLoader.php
+++ b/src/LazySecretsLoader.php
@@ -19,6 +19,11 @@ final class LazySecretsLoader
 {
     public static function loadSecretEnvironmentVariables(): void
     {
+
+        if (class_exists(Secrets::class)) {
+            Secrets::loadSecretEnvironmentVariables();
+        }
+
         if (! self::areThereSecretsToLoad()) {
             return;
         }
@@ -27,7 +32,6 @@ final class LazySecretsLoader
             throw new Exception('The "bref/secrets-loader" package is required to load SSM parameters via the "bref-ssm:xxx" syntax in environment variables. Please add it to your "require" section in composer.json.');
         }
 
-        Secrets::loadSecretEnvironmentVariables();
     }
 
     /**


### PR DESCRIPTION
Please see the related PR on the secrets loader which adds support for defining secret env values in dotenv.

This change ensures we will always attempt to load secrets if the secret-loader is a dependency, as there may be no secret values (`bref-ssm:...`) in the lambda directly but there may be some in a dotenv file.

We keep the check for un-loaded secret values after the loader has run (if it was present) for cases where the dependency was missing or where the secret loading has somehow failed.