### PR TITLE
feat: Allow configurable timeout via environment variable

### DIFF
--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -197,8 +197,9 @@ final class FpmHandler extends HttpHandler
     }
 
     /**
-     * @throws Exception
      * @see https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html#runtimes-lifecycle-ib
+     *
+     * @throws Exception
      */
     private function waitUntilReady(): void
     {


### PR DESCRIPTION
- The timeout value (in microseconds) is now configurable using the `BREF_FPM_READY_TIMEOUT` environment variable.
- If the `BREF_FPM_READY_TIMEOUT` variable is not set, the default timeout is 5 seconds (5000000 microseconds).

ref: #1917
