### PR TITLE
Update advanced-use-cases.mdx to include request size & HTTP support

### DIFF
--- a/docs/use-cases/http/advanced-use-cases.mdx
+++ b/docs/use-cases/http/advanced-use-cases.mdx
@@ -33,6 +33,7 @@ Here is a summary of the differences between the 4 options:
 |---------------------------------|:---------------------:|:-----------------------------:|:--------------------------------:|:----------------:|
 | Pricing (Lambda cost excluded)  | $3.5/million requests |      $1/million requests      |      Free (no extra costs)       | Starts at $22/mo |
 | Custom domain                   |           ✅           |               ✅               | No, but possible with CloudFront |        ✅         |
+| HTTP/HTTPS Support              |           ✅           |          HTTPS Only          |            HTTPS Only             |         ✅       |      
 | Authorizers                     | IAM, Lambda, Cognito  | IAM, Lambda, Cognito, OAuth 2 |               IAM                |  OIDC, Cognito   |
 | CORS                            |           ✅           |               ✅               |                ✅                 |        ❌         |
 | CloudWatch metrics              |           ✅           |               ✅               |                ✅                 |        ✅         |
@@ -41,6 +42,7 @@ Here is a summary of the differences between the 4 options:
 | API key management              |           ✅           |               ❌               |                ❌                 |        ❌         |
 | Request transformation          |           ✅           |               ❌               |                ❌                 |        ❌         |
 | Request/response validation     |           ✅           |               ❌               |                ❌                 |        ❌         |
+| Maximum request/response size   |          6MB          |               6MB              |                6MB               |        1MB       |
 | Maximum HTTP response timeout   |          29s          |              30s              |            15 minutes            |    15 minutes    |
 | Added latency to HTTP responses |         25ms          |             15ms              |               10ms               |                  |
 


### PR DESCRIPTION
I added 2 new rows to the comparison table to include:
- HTTP/HTTPS Support: this is relevant because you won't be able to redirect from http://dashboard.example.com to https://dashboard.example.com
- Maximum request/response size

For ALB it is a bit more complex: 

> The maximum size of the request body that you can send to a Lambda function is 1 MB. For related size limits, see HTTP header limits.
> The maximum size of the response JSON that the Lambda function can send is 1 MB. 

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html

