### PR TITLE
Move the default Symfony template from Flex to this repository

### DIFF
--- a/bref
+++ b/bref
@@ -17,7 +17,7 @@ telemetry();
 switch ($argv[1] ?? '') {
     case 'init':
         require_once __DIR__ . '/src/Cli/init.php';
-        init();
+        init($argv[2] ?? null);
         break;
     case 'cli':
         cliWarning();

--- a/docs/symfony/getting-started.mdx
+++ b/docs/symfony/getting-started.mdx
@@ -21,17 +21,17 @@ Next, in an existing Symfony project, install Bref and the [Symfony Bridge packa
 composer require bref/bref bref/symfony-bridge --update-with-dependencies
 ```
 
-If you are using [Symfony Flex](https://flex.symfony.com/), it will automatically run the [bref/symfony-bridge recipe](https://github.com/symfony/recipes-contrib/tree/master/bref/symfony-bridge/0.1) which will perform the following tasks:
+Next, create a `serverless.yml` configuration file at the root of your project by running:
 
-- Create a `serverless.yml` configuration file optimized for Symfony.
-- Add the `.serverless` folder to the `.gitignore` file.
+```bash
+vendor/bin/bref init symfony
+```
 
-Otherwise, you can create the `serverless.yml` file manually at the root of the project. Take a look at the [default configuration](https://github.com/symfony/recipes-contrib/blob/master/bref/symfony-bridge/0.1/serverless.yaml) provided by the recipe.
+(you can preview that file [here](https://github.com/brefphp/bref/blob/master/template/http/serverless.yml))
 
 You still have a few modifications to do on the application to make it compatible with AWS Lambda.
 
-Since [the filesystem is readonly](/docs/environment/storage.md) except for `/tmp` we need to customize where the cache and logs are stored in
-the `src/Kernel.php` file. This is automatically done by the bridge, you just need to use the `BrefKernel` class instead of the default `BaseKernel`:
+Since [the filesystem is readonly](/docs/environment/storage.md) except for `/tmp` we need to customize where the cache and logs are stored in the `src/Kernel.php` file. This is automatically done by the bridge, you just need to use the `BrefKernel` class instead of the default `BaseKernel`:
 
 ```diff filename="src/Kernel.php"
 namespace App;

--- a/docs/use-cases/websites.mdx
+++ b/docs/use-cases/websites.mdx
@@ -87,10 +87,6 @@ serverless plugin install -n serverless-lift
                     # add here any file or directory that needs to be served from S3
         ```
 
-        <Callout>
-            If you are not using Flex, update `serverless.yml` to exclude assets from the deployment ([see the recipe](https://github.com/symfony/recipes-contrib/blob/master/bref/symfony-bridge/0.1/serverless.yaml#L35))
-        </Callout>
-
         Because this construct sets the `X-Forwarded-Host` header by default, you should add it in your `trusted_headers` config, otherwise Symfony might generate wrong URLs.
 
         ```yml filename="config/packages/framework.yaml" /, 'x-forwarded-host'/

--- a/template/symfony/serverless.yml
+++ b/template/symfony/serverless.yml
@@ -1,0 +1,47 @@
+# Read the documentation at https://bref.sh/docs/symfony/getting-started
+service: symfony
+
+# Set your team ID if you are using Bref Cloud
+#bref:
+#    team: my-team-id
+
+provider:
+    name: aws
+    # The AWS region in which to deploy (us-east-1 is the default)
+    region: us-east-1
+    environment:
+        # Symfony environment variables
+        APP_ENV: prod
+
+plugins:
+    - ./vendor/bref/bref
+
+functions:
+
+    # This function runs the Symfony website/API
+    web:
+        handler: public/index.php
+        runtime: php-82-fpm
+        timeout: 28 # in seconds (API Gateway has a timeout of 29 seconds)
+        events:
+            - httpApi: '*'
+
+    # This function let us run console commands in Lambda
+    console:
+        handler: bin/console
+        runtime: php-82-console
+        timeout: 120 # in seconds
+
+package:
+    patterns:
+        # Excluded files and folders for deployment
+        - '!assets/**'
+        - '!node_modules/**'
+        - '!public/build/**'
+        - '!tests/**'
+        - '!var/**'
+        # If you want to include files and folders that are part of excluded folders,
+        # add them at the end
+        - 'var/cache/prod/**'
+        - 'public/build/entrypoints.json'
+        - 'public/build/manifest.json'


### PR DESCRIPTION
Currently the `serverless.yml` file for Symfony application is created by Flex based on this recipe: https://github.com/symfony/recipes-contrib/tree/main/bref/symfony-bridge/0.1

The recipe lives in a 3rd party repository we don't control, and currently we can't merge changes to it. This is a pain and makes no sense.

Let's get back control over this and move the template in Bref.

See https://github.com/symfony/recipes-contrib/pull/1769