### PR TITLE
[Docs] Update database docs for RDS V2

### DIFF
--- a/docs/environment/database.mdx
+++ b/docs/environment/database.mdx
@@ -15,7 +15,7 @@ Here are some of the database services offered by RDS:
 - [Aurora Serverless MySQL/PostgreSQL](https://aws.amazon.com/rds/aurora/serverless/): similar to Aurora but scales automatically on-demand
 
 <Callout>
-    Aurora Serverless v1 can be configured to scale down to 0 instances when unused (which costs $0), however be careful with this option: the database can take up to 30 seconds to un-pause. Aurora Serverless v2 cannot scale down to 0 instances.
+    Aurora Serverless can be configured to scale down to 0 instances when unused (which costs $0), however be careful with this option: the database can take up to 30 seconds to un-pause.
 </Callout>
 
 All RDS databases can be setup with Lambda in two ways:


### PR DESCRIPTION
RDS Serverless V2 does support pausing now. Update the docs which currently say it doesn't.

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2-auto-pause.html#auto-pause-how-it-works