### PR TITLE
Fix PHP 8.5 deprecations

### DIFF
--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -336,7 +336,6 @@ final class LambdaRuntime
     private function closeCurlHandleNext(): void
     {
         if ($this->curlHandleNext !== null) {
-            curl_close($this->curlHandleNext);
             $this->curlHandleNext = null;
         }
     }
@@ -344,7 +343,6 @@ final class LambdaRuntime
     private function closeCurlHandleResult(): void
     {
         if ($this->curlHandleResult !== null) {
-            curl_close($this->curlHandleResult);
             $this->curlHandleResult = null;
         }
     }


### PR DESCRIPTION
Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0.

Thanks @ondrejmirtes 