### PR TITLE
Add 'iam:TagRole' permission to AWS policy

### DIFF
--- a/docs/setup/minimal-aws-policy.mdx
+++ b/docs/setup/minimal-aws-policy.mdx
@@ -66,6 +66,7 @@ Feel free to submit a PR if you have any suggestions for improvements.
                 "iam:DeleteRolePolicy",
                 "iam:DetachRolePolicy",
                 "iam:GetRole",
+                "iam:TagRole",
                 "iam:PassRole",
                 "iam:PutRolePolicy",
                 "iot:CreateTopicRule",


### PR DESCRIPTION
The `serverless deploy` cli command now requires the `iam:TagRole` permissions on the minimum policy for the Deployment to be completed. Without this role, we get the following error

```bash
CREATE_FAILED: IamRoleLambdaExecution (AWS::IAM::Role)
Resource handler returned message: "Encountered a permissions error performing a tagging operation, please add required tag permissions. See https://repost.aws/knowledge-center/cloudformation-tagging-permission-error for how to resolve. Resource handler returned message: "User: arn:aws:iam::XXXXXX:user/lambda_user is not authorized to perform: iam:TagRole on resource: arn:aws:iam::XXXXXX:role/app-dev-ap-south-1-lambdaRole because no identity-based policy allows the iam:TagRole action
```