### PR TITLE
Retry request on WriteFailedException instead of returning 500

### DIFF
--- a/src/FpmRuntime/FpmHandler.php
+++ b/src/FpmRuntime/FpmHandler.php
@@ -12,6 +12,7 @@ use Bref\FpmRuntime\FastCgi\Timeout;
 use Exception;
 use hollodotme\FastCGI\Client;
 use hollodotme\FastCGI\Exceptions\TimedoutException;
+use hollodotme\FastCGI\Exceptions\WriteFailedException;
 use hollodotme\FastCGI\Interfaces\ProvidesRequestData;
 use hollodotme\FastCGI\Interfaces\ProvidesResponseData;
 use hollodotme\FastCGI\SocketConnections\UnixDomainSocket;
@@ -172,17 +173,39 @@ final class FpmHandler extends HttpHandler
             // - the 500 response is the same as if an exception happened in Bref
             throw new Timeout($timeoutDelayInMs, $context->getAwsRequestId());
         } catch (Throwable $e) {
-            printf(
-                "Error communicating with PHP-FPM to read the HTTP response. Bref will restart PHP-FPM now. Original exception message: %s %s\n",
-                get_class($e),
-                $e->getMessage()
-            );
-
             // Restart PHP-FPM: in some cases PHP-FPM is borked, that's the only way we can recover
             $this->stop();
             $this->start();
 
-            throw new FastCgiCommunicationFailed;
+            // On WriteFailedException (broken pipe), the request never reached PHP-FPM so it is
+            // safe to retry once against the freshly restarted FPM process. This avoids returning
+            // a 500 error to the caller for a transient FPM socket failure.
+            // Other exceptions (e.g. ReadFailedException) mean the request may have already been
+            // processed by PHP, so retrying could cause double-execution.
+            if ($e instanceof WriteFailedException) {
+                try {
+                    $socketId = $this->client->sendAsyncRequest($this->connection, $request);
+                    $response = $this->client->readResponse($socketId, $timeoutDelayInMs);
+                } catch (Throwable $retryException) {
+                    printf(
+                        "Error communicating with PHP-FPM to read the HTTP response. Bref will restart PHP-FPM now. Original exception message: %s %s | Retry exception: %s %s\n",
+                        get_class($e),
+                        $e->getMessage(),
+                        get_class($retryException),
+                        $retryException->getMessage()
+                    );
+                    $this->stop();
+                    $this->start();
+                    throw new FastCgiCommunicationFailed;
+                }
+            } else {
+                printf(
+                    "Error communicating with PHP-FPM to read the HTTP response. Bref will restart PHP-FPM now. Original exception message: %s %s\n",
+                    get_class($e),
+                    $e->getMessage()
+                );
+                throw new FastCgiCommunicationFailed;
+            }
         }
 
         $responseHeaders = $this->getResponseHeaders($response);


### PR DESCRIPTION
Related to https://github.com/brefphp/bref/issues/2077

  ## Summary

When PHP-FPM's Unix socket is broken between Lambda invocations (e.g. the FPM worker died while the master is still alive), `sendAsyncRequest` throws a `WriteFailedException` (broken pipe). The current behavior restarts FPM but still throws `FastCgiCommunicationFailed`, returning a 500 to the caller even though FPM was just successfully restarted and is ready to serve.

This PR retries the request once against the freshly restarted FPM process on `WriteFailedException`, turning a guaranteed 500 into a transparent recovery.

  ## Why this is safe

  A `WriteFailedException` means the FastCGI request **failed to write to the socket** — the request never reached PHP-FPM. Since no application code executed, retrying is idempotent.

 Other exceptions (e.g. `ReadFailedException`) are **not** retried because the request may have already been processed by PHP, and retrying could cause double-execution. The existing behavior (log, restart FPM, throw `FastCgiCommunicationFailed`) is preserved for those cases.

  ## Background

   Key findings from production diagnostics for https://github.com/brefphp/bref/issues/2077:

  - **The FPM master is alive** when the broken pipe occurs — `proc_get_status()` shows `running=true`, `signaled=false`, `exitcode=-1`. The master is not crashing.
  - **The FPM worker or socket is dead.** The write fails because the reader end (worker) has closed its end of the Unix socket, likely due to the worker dying between invocations.
  - **The error is transient.** After Bref restarts FPM, the very next request to the same Lambda instance succeeds. The current code already does the right thing (restart FPM) but then discards the recovery by throwing `FastCgiCommunicationFailed`.
  - **The pattern:** Request N completes normally → ~6ms later request N+1 arrives → `WriteFailedException` immediately → Bref restarts FPM → current code throws 500 → next request works fine.

 I still don't know the root cause of the worker death is still under investigation (Lambda freeze/thaw, socket FD corruption, etc.), but regardless of cause, retrying on write failure is a safe mitigation that eliminates unnecessary 500s.

  ## What changed

  In the `catch (Throwable $e)` block of `FpmHandler::handleRequest()`:

  1. FPM is still restarted (`stop()` + `start()`) on all errors — no change
  2. **New:** If the exception is `WriteFailedException`, retry the request once against the fresh FPM
  3. If the retry also fails, log both exceptions and throw `FastCgiCommunicationFailed` as before
  4. For all other exceptions, behavior is unchanged (log + throw)

 We've been running this patch via `cweagans/composer-patches` in production. Broken pipe errors that previously resulted in 500s are now transparently recovered, with no double-execution or other side effects observed.
 
 Happy to hear your thoughts! Thought we will submit a PR since all the retries have been successful.
