### PR TITLE
Use package patterns in functional fixture

### DIFF
--- a/tests/FpmRuntime/Functional/serverless.yml
+++ b/tests/FpmRuntime/Functional/serverless.yml
@@ -13,9 +13,8 @@ plugins:
     - ./index.js
 
 package:
-    exclude:
-        - '**'
-    include:
+    patterns:
+        - '!**'
         - 'src/**'
         - 'tests/**'
         - 'vendor/**'


### PR DESCRIPTION
- Replace removed package include/exclude syntax with package.patterns in the FPM functional fixture.
- Preserve the existing package contents by excluding everything first, then re-including src, tests, and vendor.
