### PR TITLE
docs: Remove unnecessary extra PHP extension

### DIFF
--- a/docs/deploy/docker.mdx
+++ b/docs/deploy/docker.mdx
@@ -70,7 +70,6 @@ You can enable additional PHP extensions by pulling them from [Bref Extra Extens
 ```dockerfile filename="Dockerfile" {3-4}
 FROM bref/php-84:3
 
-COPY --from=bref/extra-redis-php-84:3 /opt /opt
 COPY --from=bref/extra-gmp-php-84:3 /opt /opt
 
 COPY . /var/task


### PR DESCRIPTION
Version 3 does not exist in `bref/extra-redis-php`.
When I checked the upgrade guide, it stated that the Redis extension was internal, so I thought it was a documentation error.