### PR TITLE
docs: mention Relay in the extra extensions list

### DIFF
--- a/docs/environment/php.mdx
+++ b/docs/environment/php.mdx
@@ -114,7 +114,7 @@ extension=soap
 
 Due to space limitations in AWS Lambda, Bref runtimes cannot include every possible PHP extensions. These additional PHP extensions can be included as separate AWS Lambda layers.
 
-All extra PHP extensions are found in [brefphp/extra-php-extensions](https://github.com/brefphp/extra-php-extensions).
+All extra PHP extensions are found in [brefphp/extra-php-extensions](https://github.com/brefphp/extra-php-extensions). These include [Relay](https://relay.so) — a high-performance drop-in replacement for the `redis` extension that keeps a copy of your Redis data in shared memory.
 
 Contributions to add more PHP extensions are welcomed.
 


### PR DESCRIPTION
## What

Adds a one-line mention of [Relay](https://relay.so) to the **Extra extensions** section of `docs/environment/php.mdx` (https://bref.sh/docs/environment/php#extra-extensions), so readers know the high-performance Redis client is available as a Bref layer.

## Why draft

Depends on the Relay layer actually being built & published from extra-php-extensions — see brefphp/extra-php-extensions#665, which enables and modernizes that layer (it was previously pinned to an old version and never built). Ready to merge once the layer ships.