### PR TITLE
Fix capitalization of `Set-Cookie` headers

### DIFF
--- a/src/Event/Http/HttpResponse.php
+++ b/src/Event/Http/HttpResponse.php
@@ -101,7 +101,7 @@ final class HttpResponse
      */
     private function capitalizeHeaderName(string $name): string
     {
-        $name = str_replace('-', ' ', $name);
+        $name = str_replace('-', ' ', strtolower($name));
         $name = ucwords($name);
         return str_replace(' ', '-', $name);
     }

--- a/tests/Event/Http/HttpResponseTest.php
+++ b/tests/Event/Http/HttpResponseTest.php
@@ -144,6 +144,21 @@ class HttpResponseTest extends TestCase
         ], $response->toApiGatewayFormatV2());
     }
 
+    public function test cookies are detected regardless of the header case()
+    {
+        $response = new HttpResponse('', [
+            'SET-COOKIE' => ['foo', 'bar'],
+        ]);
+
+        self::assertEquals([
+            'cookies' => ['foo', 'bar'],
+            'isBase64Encoded' => false,
+            'statusCode' => 200,
+            'headers' => new stdClass,
+            'body' => '',
+        ], $response->toApiGatewayFormatV2());
+    }
+
     public function test response with multiple cookies()
     {
         $response = new HttpResponse('', [


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
