### PR TITLE
Fix splitting of `Cookie` headers

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -185,7 +185,7 @@ final class HttpRequestEvent implements LambdaEvent
             // Multiple "Cookie" headers are not authorized
             // https://stackoverflow.com/questions/16305814/are-multiple-cookie-headers-allowed-in-an-http-request
             $cookieHeader = $this->headers['cookie'][0];
-            $cookieParts = explode('; ', $cookieHeader);
+            $cookieParts = array_map('trim', explode(';', $cookieHeader));
         }
 
         $cookies = [];

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -155,6 +155,18 @@ class HttpRequestEventTest extends CommonHttpTest
         new HttpRequestEvent(null);
     }
 
+    public function test cookies without a space after the semicolon()
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'Cookie' => 'a=1;b=2; c=3',
+            ],
+        ]);
+
+        $this->assertSame(['a' => '1', 'b' => '2', 'c' => '3'], $event->getCookies());
+    }
+
     /**
      * @dataProvider provide query strings
      */


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
