### PR TITLE
Support empty user or password in basic auth

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -6,6 +6,7 @@ use Bref\Event\InvalidLambdaEvent;
 use Bref\Event\LambdaEvent;
 use Crwlr\QueryString\Query;
 
+use function str_contains;
 use function str_starts_with;
 
 /**
@@ -106,9 +107,9 @@ final class HttpRequestEvent implements LambdaEvent
             return [null, null];
         }
 
-        $auth = base64_decode(trim(explode(' ', $authorizationHeader)[1]));
+        $auth = base64_decode(trim(explode(' ', $authorizationHeader)[1]), true);
 
-        if (! $auth || ! strpos($auth, ':')) {
+        if ($auth === false || ! str_contains($auth, ':')) {
             return [null, null];
         }
 

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -145,6 +145,43 @@ class HttpRequestEventTest extends CommonHttpTest
         $this->assertEquals($expected, $pass);
     }
 
+    public function test basic auth with an empty username()
+    {
+        // `:password` is valid per RFC 7617: the username can be empty
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'Authorization' => 'Basic ' . base64_encode(':password'),
+            ],
+        ]);
+
+        $this->assertSame(['', 'password'], $event->getBasicAuthCredentials());
+    }
+
+    public function test basic auth with an empty password()
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'Authorization' => 'Basic ' . base64_encode('user:'),
+            ],
+        ]);
+
+        $this->assertSame(['user', ''], $event->getBasicAuthCredentials());
+    }
+
+    public function test basic auth without a colon is rejected()
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'Authorization' => 'Basic ' . base64_encode('foobar'),
+            ],
+        ]);
+
+        $this->assertSame([null, null], $event->getBasicAuthCredentials());
+    }
+
     public function test empty invocation will have friendly error message()
     {
         $message = "This handler expected to be invoked with a API Gateway or ALB event (check that you are using the correct Bref runtime: https://bref.sh/docs/runtimes/#bref-runtimes).\nInstead, the handler was invoked with invalid event data: null";


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
