### PR TITLE
Preserve falsy request headers like `0`

### DIFF
--- a/src/Event/Http/Psr7Bridge.php
+++ b/src/Event/Http/Psr7Bridge.php
@@ -48,7 +48,7 @@ final class Psr7Bridge
             'REQUEST_URI' => $event->getUri(),
             'PHP_AUTH_USER' => $user,
             'PHP_AUTH_PW' => $password,
-        ]);
+        ], fn ($value) => $value !== null);
 
         foreach ($headers as $name => $values) {
             $server['HTTP_' . strtoupper(str_replace('-', '_', (string) $name))] = $values[0];

--- a/tests/Event/Http/Psr7BridgeTest.php
+++ b/tests/Event/Http/Psr7BridgeTest.php
@@ -32,6 +32,23 @@ class Psr7BridgeTest extends CommonHttpTest
         ], $response->toApiGatewayFormat());
     }
 
+    public function test falsy server params are not dropped()
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'Content-Length' => '0',
+                'Authorization' => 'Basic ' . base64_encode('user:'),
+            ],
+        ]);
+        $request = Psr7Bridge::convertRequest($event, Context::fake());
+
+        $serverParams = $request->getServerParams();
+        self::assertSame('0', $serverParams['CONTENT_LENGTH']);
+        self::assertSame('user', $serverParams['PHP_AUTH_USER']);
+        self::assertSame('', $serverParams['PHP_AUTH_PW']);
+    }
+
     protected function fromFixture(string $file): void
     {
         $event = new HttpRequestEvent(json_decode(file_get_contents($file), true, 512, JSON_THROW_ON_ERROR));


### PR DESCRIPTION
<!--
Please explain the motivation behind the changes.

In other words, explain **WHY** instead of **WHAT**.
-->
