### PR TITLE
Pass explicit character lists to `trim()` calls

### DIFF
--- a/src/Event/Http/HttpRequestEvent.php
+++ b/src/Event/Http/HttpRequestEvent.php
@@ -101,13 +101,13 @@ final class HttpRequestEvent implements LambdaEvent
      */
     public function getBasicAuthCredentials(): array
     {
-        $authorizationHeader = trim($this->headers['authorization'][0] ?? '');
+        $authorizationHeader = trim($this->headers['authorization'][0] ?? '', " \t");
 
         if (! str_starts_with($authorizationHeader, 'Basic ')) {
             return [null, null];
         }
 
-        $auth = base64_decode(trim(explode(' ', $authorizationHeader)[1]), true);
+        $auth = base64_decode(trim(explode(' ', $authorizationHeader)[1], " \t"), true);
 
         if ($auth === false || ! str_contains($auth, ':')) {
             return [null, null];
@@ -186,7 +186,7 @@ final class HttpRequestEvent implements LambdaEvent
             // Multiple "Cookie" headers are not authorized
             // https://stackoverflow.com/questions/16305814/are-multiple-cookie-headers-allowed-in-an-http-request
             $cookieHeader = $this->headers['cookie'][0];
-            $cookieParts = array_map('trim', explode(';', $cookieHeader));
+            $cookieParts = array_map(fn (string $part) => trim($part, " \t"), explode(';', $cookieHeader));
         }
 
         $cookies = [];

--- a/src/Runtime/LambdaRuntime.php
+++ b/src/Runtime/LambdaRuntime.php
@@ -149,7 +149,7 @@ final class LambdaRuntime
             }
             [$name, $value] = preg_split('/:\s*/', $header, 2);
             $name = strtolower($name);
-            $value = trim($value);
+            $value = trim($value, " \t\r\n");
             if ($name === 'lambda-runtime-aws-request-id') {
                 $contextBuilder->setAwsRequestId($value);
             }

--- a/tests/Event/Http/HttpRequestEventTest.php
+++ b/tests/Event/Http/HttpRequestEventTest.php
@@ -170,6 +170,18 @@ class HttpRequestEventTest extends CommonHttpTest
         $this->assertSame(['user', ''], $event->getBasicAuthCredentials());
     }
 
+    public function test basic auth with whitespace around the header value()
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'Authorization' => "\t Basic " . base64_encode('user:password') . " \t",
+            ],
+        ]);
+
+        $this->assertSame(['user', 'password'], $event->getBasicAuthCredentials());
+    }
+
     public function test basic auth without a colon is rejected()
     {
         $event = new HttpRequestEvent([
@@ -198,6 +210,18 @@ class HttpRequestEventTest extends CommonHttpTest
             'httpMethod' => 'GET',
             'headers' => [
                 'Cookie' => 'a=1;b=2; c=3',
+            ],
+        ]);
+
+        $this->assertSame(['a' => '1', 'b' => '2', 'c' => '3'], $event->getCookies());
+    }
+
+    public function test cookies with whitespace around the pairs()
+    {
+        $event = new HttpRequestEvent([
+            'httpMethod' => 'GET',
+            'headers' => [
+                'Cookie' => "a=1 ;\tb=2\t; c=3",
             ],
         ]);
 

--- a/tests/Sam/PhpRuntimeTest.php
+++ b/tests/Sam/PhpRuntimeTest.php
@@ -258,7 +258,7 @@ LOGS;
         $stderr = preg_replace('/\x1b\[[0-9;]*m/', '', $stderr);
 
         // Extract the result from stdout
-        $output = explode("\n", trim($process->getOutput()));
+        $output = explode("\n", trim($process->getOutput(), " \t\n\r\0\x0B"));
         $lastLine = end($output);
         if (! empty($lastLine)) {
             $result = json_decode($lastLine, true, 512, JSON_THROW_ON_ERROR);
@@ -269,7 +269,7 @@ LOGS;
             $result = null;
             // Was there an error?
             preg_match('/REPORT RequestId: [^\n]*(.*)/s', $stderr, $matches);
-            $error = trim($matches[1] ?? '');
+            $error = trim($matches[1] ?? '', " \t\n\r\0\x0B");
             if ($error !== '') {
                 $result = json_decode($error, true, 512, JSON_THROW_ON_ERROR);
                 if (json_last_error()) {
@@ -314,7 +314,7 @@ LOGS;
         // Extract the only interesting log line
         $logLines = explode("\n", $logs);
         $logLines = array_filter($logLines, function (string $line): bool {
-            $line = trim($line);
+            $line = trim($line, " \t\n\r\0\x0B");
             return $line !== ''
                 && (strpos($line, 'START') !== 0)
                 && (strpos($line, 'END') !== 0)


### PR DESCRIPTION
Relying on `trim()`'s default character list is undesirable: it is broader than the whitespace HTTP allows, and the default has changed in PHP 8.6, causing inconsistent behaviour. This passes an explicit list at every call site, narrowing header parsing to RFC 7230 OWS and pinning current behaviour elsewhere.