### PR TITLE
feat: add lambda layer support for ap-southeast-5 (#2091)

### DIFF
--- a/utils/layers.json/regions.json
+++ b/utils/layers.json/regions.json
@@ -18,6 +18,7 @@
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-southeast-3",
+    "ap-southeast-5",
     "eu-south-1",
     "eu-south-2",
     "af-south-1"


### PR DESCRIPTION
## Motivation

AWS has officially launched the `ap-southeast-5` region in Malaysia. Currently, developers looking to deploy serverless PHP applications to this new region cannot leverage Bref runtimes because the region identifier is missing from the core configuration layout. 

Adding `ap-southeast-5` to the list of recognized regions ensures that the deployment utilities and Serverless framework integrations can successfully resolve and reference Bref's published Lambda layers in the Malaysia data centers, expanding the framework's global infrastructure reach.

## Related Issues

Resolves #2091