### PR TITLE
chore: remove redundant ext-json requirement (#2050)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "require": {
         "php": ">=8.2",
         "ext-curl": "*",
-        "ext-json": "*",
         "crwlr/query-string": "^1.0.3",
         "hollodotme/fast-cgi-client": "^3.0.1",
         "nyholm/psr7": "^1.4.1",


### PR DESCRIPTION
Closes #2050

**Motivation**
Since PHP >= 8.0, the JSON extension is bundled directly into the PHP core by default and can no longer be disabled. Because of this, explicitly requiring `"ext-json": "*"` in `composer.json` is completely redundant and can be safely removed to clean up the package dependencies.