### PR TITLE
docs: preserve Bref php.ini scan directory

### DIFF
--- a/docs/environment/php.mdx
+++ b/docs/environment/php.mdx
@@ -25,10 +25,18 @@ PHP will automatically include any `*.ini` file found in `php/conf.d/` in your p
 
 ### Customizing php.ini using a custom path
 
-If you want PHP to scan a different directory than `php/conf.d/` in your project, you can override the path by setting it in the [`PHP_INI_SCAN_DIR`](https://www.php.net/manual/en/configuration.file.php#configuration.file.scan) environment variable.
+If you want PHP to scan a different directory than `php/conf.d/` in your project, you can add it with the [`PHP_INI_SCAN_DIR`](https://www.php.net/manual/en/configuration.file.php#configuration.file.scan) environment variable:
+
+```yaml filename="serverless.yml"
+provider:
+    environment:
+        PHP_INI_SCAN_DIR: '/opt/bref/etc/php/conf.d:/var/task/my/different/dir'
+```
 
 <Callout>
-    `PHP_INI_SCAN_DIR` must contain an absolute path. Since your code is placed in `/var/task` on AWS Lambda, the environment variable should contain something like `/var/task/my/different/dir`.
+    Keep `/opt/bref/etc/php/conf.d` in the value so that Bref continues to load its configuration.
+    Setting only your custom directory would prevent `/opt/bref/etc/php/conf.d/bref.ini` from
+    loading.
 </Callout>
 
 Learn how to declare environment variables by reading the [Environment Variables](variables.mdx) guide.


### PR DESCRIPTION
## Summary

- document how to add a custom PHP configuration directory without replacing Bref's default scan directory
- add a `serverless.yml` example that keeps `/opt/bref/etc/php/conf.d`
- warn that setting only the custom directory prevents `bref.ini` from loading

## Why

`PHP_INI_SCAN_DIR` replaces PHP's configured scan directory. The current example suggests using only a custom path, which can stop Bref's `/opt/bref/etc/php/conf.d/bref.ini` from loading and cause bundled extension configuration to be lost.

The explicit default path follows the working configuration reported in #487.

## Validation

- `npm run lint` (0 errors; one existing `no-explicit-any` warning)
- `npm run build` in `website` (93 pages generated, including `/docs/environment/php`)
- verified the rendered HTML contains the configuration example and warning
- `git diff --check`

Fixes #487

## AI assistance

AI assistance was used to research and prepare this documentation change. I reviewed the final diff and validation results.
