### PR TITLE
Allow symfony ^5.4 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "psr/http-message": "^1.0|^2.0",
         "psr/http-server-handler": "^1.0",
         "riverline/multipart-parser": "^2.1.2",
-        "symfony/process": "^6.4|^7.0|^8.0"
+        "symfony/process": "^5.4|^6.4|^7.0|^8.0"
     },
     "require-dev": {
         "async-aws/core": "^1.0",
@@ -40,8 +40,8 @@
         "guzzlehttp/guzzle": "^7.5",
         "phpstan/phpstan": "^2",
         "phpunit/phpunit": "^10.1",
-        "symfony/console": "^6.4|^7.0|^8.0",
-        "symfony/yaml": "^6.4|^7.0|^8.0"
+        "symfony/console": "^5.4|^6.4|^7.0|^8.0",
+        "symfony/yaml": "^5.4|^6.4|^7.0|^8.0"
     },
     "scripts": {
         "test": [


### PR DESCRIPTION
symfony/process, symfony/console, and symfony/yaml previously required ^6.4|^7.0|^8.0. Many projects migrating to Bref 3 are still on Symfony 5.4 LTS (supported until Nov 2026), and bref/extra-php-extensions already supports 5.4, so this brings bref/bref in line with the rest of the Bref ecosystem.

symfony/process 5.4 supports PHP 8.2+, matching this package's existing php: >=8.2 requirement, so no conflict there.

Fixes #2080