### PR TITLE
Make the website easier to use for AI agents

### DIFF
--- a/website/app/[[...mdxPath]]/page.jsx
+++ b/website/app/[[...mdxPath]]/page.jsx
@@ -23,7 +23,8 @@ export async function generateMetadata(props) {
     const mdxPath = params.mdxPath ?? []
     const { metadata } = await importPage(mdxPath)
     const isHome = mdxPath.length === 0
-    const isDocsPage = mdxPath[0] === 'docs' && mdxPath.length > 1
+    // Pages that have a Markdown version (see src/lib/markdown.js)
+    const hasMarkdown = (mdxPath[0] === 'docs' && mdxPath.length > 1) || (mdxPath[0] === 'news' && mdxPath.length > 1)
     // `seoTitle` frontmatter sets the exact <title> (no "– Bref" suffix) without
     // affecting the sidebar label; `ogImage` overrides the default social card.
     const seoTitle = metadata.seoTitle
@@ -38,9 +39,9 @@ export async function generateMetadata(props) {
             images: [{ url: ogImage ?? 'https://bref.sh/social-card.png' }],
             ...(metadata.openGraph || {}),
         },
-        // Per-docs-page alternate markdown link (was theme.config.head conditional)
-        ...(isDocsPage
-            ? { alternates: { types: { 'text/markdown': `/docs/${mdxPath.slice(1).join('/')}.md` } } }
+        // Alternate Markdown version of the page, for AI agents
+        ...(hasMarkdown
+            ? { alternates: { types: { 'text/markdown': `/${mdxPath.join('/')}.md` } } }
             : {}),
     }
 }

--- a/website/app/api/md/[[...slug]]/route.js
+++ b/website/app/api/md/[[...slug]]/route.js
@@ -1,46 +1,28 @@
-import fs from 'fs'
-import path from 'path'
+import { readMarkdown, routeToUrl } from '../../../../src/lib/markdown'
 
-// App Router Route Handler replacing pages/api/md/[...slug].js.
-// Reads raw MDX from content/docs and strips imports + YAML frontmatter
-// (NextSeo is gone in v4, so the old <NextSeo> stripper is replaced by a frontmatter strip).
+// Markdown version of docs and news pages, for AI agents. Reached via:
+// - /docs/<page>.md and /news/<page>.md (rewrites in next.config.mjs)
+// - `Accept: text/markdown` on the HTML URL (middleware.js)
 export async function GET(req, { params }) {
     const { slug } = await params
-    const slugPath = Array.isArray(slug) ? slug.join('/') : (slug ?? '')
+    const route = Array.isArray(slug) ? slug.join('/') : (slug ?? '')
 
-    const docsDir = path.join(process.cwd(), 'content/docs')
-    const candidates = slugPath
-        ? [
-              path.join(docsDir, `${slugPath}.mdx`),
-              path.join(docsDir, `${slugPath}.md`),
-              path.join(docsDir, slugPath, 'index.mdx'),
-          ]
-        : [path.join(docsDir, 'index.mdx')]
-
-    // Reject any path that escapes content/docs (e.g. via `..` segments).
-    const resolvedDocsDir = path.resolve(docsDir) + path.sep
-    let filePath = candidates.find(
-        candidate => path.resolve(candidate).startsWith(resolvedDocsDir) && fs.existsSync(candidate)
-    )
-    if (!filePath) {
-        return new Response(JSON.stringify({ error: 'Page not found' }), {
+    const content = readMarkdown(route)
+    if (content === null) {
+        return new Response('Page not found', {
             status: 404,
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
         })
     }
 
-    let content = fs.readFileSync(filePath, 'utf8')
-    // Strip YAML frontmatter
-    content = content.replace(/^---\n[\s\S]*?\n---\n/, '')
-    // Strip import statements
-    content = content.replace(/^import\s+.*?(?:from\s+['"].*?['"])?;?\s*$/gm, '')
-    // Strip JSX comments (invisible when rendered, but not valid Markdown)
-    content = content.replace(/\{\/\*[\s\S]*?\*\/\}\n?/g, '')
-    // Clean up excessive blank lines at the start
-    content = content.replace(/^\s*\n+/, '')
-
     return new Response(content, {
         status: 200,
-        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+        headers: {
+            'Content-Type': 'text/markdown; charset=utf-8',
+            // The HTML page is the canonical version of this content
+            Link: `<${routeToUrl(route)}>; rel="canonical"`,
+            // The same URL serves HTML or Markdown depending on the Accept header
+            Vary: 'Accept',
+        },
     })
 }

--- a/website/app/llms-full.txt/route.js
+++ b/website/app/llms-full.txt/route.js
@@ -1,0 +1,27 @@
+import { getDocsSections } from '../../src/lib/site-index'
+import { readMarkdown, SITE_URL } from '../../src/lib/markdown'
+
+// The whole documentation as a single Markdown file, for AI agents.
+export const dynamic = 'force-static'
+
+export async function GET() {
+    const sections = await getDocsSections()
+
+    const parts = [
+        '# Bref documentation',
+        '',
+        `> Bref is an open-source framework to run PHP applications on AWS Lambda (serverless). This file contains the whole documentation of ${SITE_URL}. Each page starts with its canonical URL.`,
+        '',
+    ]
+    for (const section of sections) {
+        for (const page of section.pages) {
+            const content = readMarkdown(page.route)
+            if (content === null) continue
+            parts.push('---', '', `Source: ${SITE_URL}${page.route}`, '', content.trim(), '')
+        }
+    }
+
+    return new Response(parts.join('\n'), {
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+}

--- a/website/app/llms.txt/route.js
+++ b/website/app/llms.txt/route.js
@@ -1,0 +1,55 @@
+import { getDocsSections, getNewsPages } from '../../src/lib/site-index'
+import { SITE_URL } from '../../src/lib/markdown'
+
+// https://llmstxt.org/ - an index of the website for AI agents.
+export const dynamic = 'force-static'
+
+const intro = `# Bref
+
+> Bref is an open-source framework to run PHP applications on AWS Lambda (serverless): PHP runtimes for Lambda, deployment tooling, and integrations for Laravel and Symfony. Bref Cloud is the hosted service that deploys, monitors and operates Bref applications in your own AWS account.
+
+Every documentation page is available as Markdown: append \`.md\` to its URL (for example ${SITE_URL}/docs/laravel/getting-started.md), or request the HTML URL with an \`Accept: text/markdown\` header. The whole documentation is also available as a single file: ${SITE_URL}/llms-full.txt
+
+Bref is free and open-source (MIT license). Bref Cloud has a free plan for personal projects and paid plans with a free trial: ${SITE_URL}/cloud#pricing
+`
+
+const line = page => `- [${page.title}](${SITE_URL}${page.route}${page.md ? '.md' : ''})${page.description ? `: ${page.description}` : ''}`
+
+export async function GET() {
+    const sections = await getDocsSections()
+    const news = await getNewsPages()
+
+    const docs = sections.map(section => [
+        `## ${section.title ? `Documentation: ${section.title}` : 'Documentation'}`,
+        '',
+        ...section.pages.map(page => line({ ...page, md: true })),
+        '',
+    ].join('\n'))
+
+    const site = [
+        '## Bref Cloud',
+        '',
+        line({ title: 'Bref Cloud', route: '/cloud', description: 'Serverless PHP hosting on AWS Lambda: deploy, monitor and operate PHP applications in your own AWS account. Features, how it works, plans and pricing.' }),
+        line({ title: 'Bref Cloud documentation', route: '/docs/cloud', md: true, description: 'What Bref Cloud does and how to get started.' }),
+        '',
+        '## Support and community',
+        '',
+        line({ title: 'Support plans', route: '/support', description: 'Consulting and support plans for serverless migrations to AWS with Bref and PHP.' }),
+        line({ title: 'Community', route: '/docs/community', md: true, description: 'Slack, GitHub and other places to get help.' }),
+        '- [GitHub repository](https://github.com/brefphp/bref): source code, issues and releases of the open-source project.',
+        '',
+        '## News',
+        '',
+        ...news.map(page => line({ ...page, md: true })),
+        '',
+        '## Optional',
+        '',
+        `- [Full documentation in one file](${SITE_URL}/llms-full.txt)`,
+        `- [Sitemap](${SITE_URL}/sitemap.xml)`,
+        '',
+    ].join('\n')
+
+    return new Response([intro, ...docs, site].join('\n'), {
+        headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    })
+}

--- a/website/middleware.js
+++ b/website/middleware.js
@@ -1,17 +1,36 @@
 import { NextResponse } from 'next/server';
 
-export function middleware(request) {
-    const accept = request.headers.get('accept') || '';
+const SITE_URL = 'https://bref.sh';
 
-    // Content negotiation: serve Markdown for AI crawlers requesting it
-    if (accept.includes('text/markdown') && request.nextUrl.pathname.startsWith('/docs/')) {
-        const mdPath = request.nextUrl.pathname.replace('/docs/', '/api/md/');
-        return NextResponse.rewrite(new URL(mdPath, request.url));
+// Routes that have a Markdown version (see app/api/md and src/lib/markdown.js)
+const MARKDOWN_ROUTES = /^\/(docs|news)(\/|$)/;
+
+export function middleware(request) {
+    const { pathname } = request.nextUrl;
+    // `.md` URLs are already served as Markdown (rewrites in next.config.mjs)
+    if (pathname.endsWith('.md')) return NextResponse.next();
+    const hasMarkdown = MARKDOWN_ROUTES.test(pathname);
+
+    // Content negotiation: serve Markdown to AI agents that ask for it
+    const accept = request.headers.get('accept') || '';
+    if (hasMarkdown && accept.includes('text/markdown')) {
+        return NextResponse.rewrite(new URL('/api/md' + pathname, request.url));
     }
 
-    return NextResponse.next();
+    // Advertise the machine-readable resources in HTTP headers, so that agents
+    // that do not parse the HTML can still discover them.
+    const links = [`<${SITE_URL}/llms.txt>; rel="llms-txt"`];
+    if (hasMarkdown) {
+        links.push(`<${SITE_URL}${pathname.replace(/\/$/, '')}.md>; rel="alternate"; type="text/markdown"`);
+    }
+    const response = NextResponse.next();
+    response.headers.set('Link', links.join(', '));
+    return response;
 }
 
 export const config = {
-    matcher: '/docs/:path*',
+    // All pages, excluding Next.js internals, API routes and static files.
+    // (page routes can contain dots, e.g. /news/01-bref-1.0, so we cannot
+    // simply exclude every path that contains a dot)
+    matcher: ['/((?!_next/|api/|_pagefind/|js/|.*\\.(?:txt|xml|json|png|jpe?g|gif|svg|ico|webp|woff2?|css|js|map)$).*)'],
 };

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -63,16 +63,21 @@ export default withNextra(withPlausibleProxy()({
             ...redirectList,
         ]
     },
-    // Serve Markdown versions of docs for AI crawlers
+    // Serve Markdown versions of docs and news pages for AI agents
+    // (see also middleware.js for the `Accept: text/markdown` content negotiation)
     async rewrites() {
         return [
             {
                 source: '/docs/:path*.md',
-                destination: '/api/md/:path*',
+                destination: '/api/md/docs/:path*',
             },
             {
                 source: '/docs.md',
-                destination: '/api/md',
+                destination: '/api/md/docs',
+            },
+            {
+                source: '/news/:path*.md',
+                destination: '/api/md/news/:path*',
             },
         ]
     },

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,8 @@
     "dev": "next dev -p 8000",
     "build": "next build",
     "postbuild": "next-sitemap && pagefind --site .next/server/app --glob \"{docs.html,docs/**/*.html}\" --output-path public/_pagefind",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --test \"src/**/*.test.js\""
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch": "^3.1109.0",

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -3,6 +3,9 @@ module.exports.redirects = {
     '/#ecosystem': '/support',
     '/#plans': '/support',
     '/#enterprise': '/support',
+    // URLs that people (and AI agents) guess
+    '/pricing': '/cloud#pricing',
+    '/cloud/pricing': '/cloud#pricing',
     '/docs/news': '/news',
     '/docs/news/01-bref-1.0': '/news/01-bref-1.0',
     '/docs/news/02-bref-2.0': '/news/02-bref-2.0',

--- a/website/src/lib/markdown.js
+++ b/website/src/lib/markdown.js
@@ -1,0 +1,110 @@
+import fs from 'fs'
+import path from 'path'
+
+export const SITE_URL = 'https://bref.sh'
+
+const contentDir = path.join(process.cwd(), 'content')
+
+// Top-level content folders whose pages are served as Markdown (for AI agents).
+// The marketing pages (home, /cloud, /support...) are React components, not
+// prose, so they are not exposed here.
+const MARKDOWN_ROOTS = ['docs', 'news']
+
+/**
+ * Resolve a site route (e.g. "docs/laravel/getting-started", "docs", "news/04-august-2026")
+ * to its MDX source file, or null if none exists.
+ */
+export function findSourceFile(route) {
+    // Normalize first so that `..` segments cannot escape the allowed roots
+    const clean = path.posix.normalize('/' + route).replace(/^\/+|\/+$/g, '')
+    const root = clean.split('/')[0]
+    if (!MARKDOWN_ROOTS.includes(root)) return null
+
+    const candidates = [
+        path.join(contentDir, `${clean}.mdx`),
+        path.join(contentDir, `${clean}.md`),
+        path.join(contentDir, clean, 'index.mdx'),
+    ]
+    // Reject any path that escapes content/ (e.g. via `..` segments).
+    const resolvedContentDir = path.resolve(contentDir) + path.sep
+    return (
+        candidates.find(
+            candidate => path.resolve(candidate).startsWith(resolvedContentDir) && fs.existsSync(candidate)
+        ) ?? null
+    )
+}
+
+/**
+ * Turn the URL of a page (relative to the site root, without leading slash)
+ * into the canonical HTML URL of that page.
+ */
+export function routeToUrl(route) {
+    const clean = route.replace(/^\/+|\/+$/g, '')
+    return clean ? `${SITE_URL}/${clean}` : SITE_URL
+}
+
+/**
+ * Rewrite a link target found in a MDX file into an absolute URL.
+ * `fileRoute` is the route of the file that contains the link (e.g. "docs/laravel/index").
+ */
+function absoluteUrl(target, fileRoute) {
+    if (/^(https?:|mailto:|#|data:)/.test(target)) return target
+
+    const [pathPart, hash] = target.split('#')
+    // Relative links are resolved from the directory of the file
+    let resolved = pathPart.startsWith('/')
+        ? pathPart
+        : path.posix.join(path.posix.dirname('/' + fileRoute), pathPart)
+    // `./getting-started.mdx` -> `/docs/laravel/getting-started`
+    resolved = resolved.replace(/\.mdx?$/, '').replace(/\/index$/, '')
+    return `${SITE_URL}${resolved}${hash ? '#' + hash : ''}`
+}
+
+/**
+ * Convert the raw MDX source of a page into Markdown suitable for AI agents:
+ * strips the frontmatter, imports and JSX comments, and makes all links absolute.
+ * The occasional JSX component (tabs, cards...) is left as is.
+ *
+ * `fileRoute` is the route of the source file relative to content/, without
+ * extension (e.g. "docs/laravel/index").
+ */
+export function toMarkdown(source, fileRoute) {
+    let content = source
+    // Strip YAML frontmatter
+    content = content.replace(/^---\n[\s\S]*?\n---\n/, '')
+    // Strip JSX comments (invisible when rendered, but not valid Markdown)
+    content = content.replace(/\{\/\*[\s\S]*?\*\/\}\n?/g, '')
+
+    // The rest only applies outside of code blocks and inline code, so that code
+    // samples (e.g. JS `import` statements or HTML links) are preserved.
+    content = content
+        .split(/(```[\s\S]*?```|`[^`\n]*`)/)
+        .map((part, index) => (index % 2 === 1 ? part : transformProse(part, fileRoute)))
+        .join('')
+
+    // Clean up excessive blank lines at the start
+    content = content.replace(/^\s*\n+/, '')
+    return content
+}
+
+function transformProse(content, fileRoute) {
+    // Strip import statements
+    content = content.replace(/^import\s+.*?(?:from\s+['"].*?['"])?;?\s*$/gm, '')
+    // Absolute URLs in Markdown links: [text](./page.mdx#anchor) -> [text](https://bref.sh/docs/page#anchor)
+    content = content.replace(/\]\(([^)\s]+)((?:\s[^)]*)?)\)/g, (match, target, title) => {
+        return `](${absoluteUrl(target, fileRoute)}${title})`
+    })
+    // Absolute URLs in JSX/HTML links: href="./page.mdx" -> href="https://bref.sh/docs/page"
+    content = content.replace(/href="([^"]+)"/g, (match, target) => `href="${absoluteUrl(target, fileRoute)}"`)
+    return content
+}
+
+/**
+ * Read a page and return its Markdown, or null if the page has no source file.
+ */
+export function readMarkdown(route) {
+    const filePath = findSourceFile(route)
+    if (!filePath) return null
+    const fileRoute = path.relative(contentDir, filePath).replace(/\.mdx?$/, '')
+    return toMarkdown(fs.readFileSync(filePath, 'utf8'), fileRoute)
+}

--- a/website/src/lib/markdown.test.js
+++ b/website/src/lib/markdown.test.js
@@ -1,0 +1,68 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { toMarkdown, findSourceFile } from './markdown.js'
+
+// Run with `npm test`
+
+test('strips frontmatter, imports and JSX comments', () => {
+    const source = `---
+title: Hello
+---
+
+import { Callout } from 'nextra/components'
+import img from './img.png';
+
+{/* not visible */}
+# Hello
+`
+    assert.equal(toMarkdown(source, 'docs/hello'), '# Hello\n')
+})
+
+test('makes links absolute, resolved from the file location', () => {
+    const cases = [
+        ['[a](./getting-started.mdx)', '[a](https://bref.sh/docs/laravel/getting-started)'],
+        ['[a](../symfony/getting-started.mdx#queues)', '[a](https://bref.sh/docs/symfony/getting-started#queues)'],
+        ['[a](../laravel.mdx "Title")', '[a](https://bref.sh/docs/laravel "Title")'],
+        ['[a](/docs/deploy.md#production)', '[a](https://bref.sh/docs/deploy#production)'],
+        ['[a](/cloud)', '[a](https://bref.sh/cloud)'],
+        ['[a](#anchor)', '[a](#anchor)'],
+        ['[a](https://example.com/page.md)', '[a](https://example.com/page.md)'],
+        ['[a](mailto:hi@bref.sh)', '[a](mailto:hi@bref.sh)'],
+        ['<Cards.Card href="./queues.mdx" />', '<Cards.Card href="https://bref.sh/docs/laravel/queues" />'],
+    ]
+    for (const [input, expected] of cases) {
+        assert.equal(toMarkdown(input, 'docs/laravel/index'), expected)
+    }
+})
+
+test('leaves code blocks and inline code untouched', () => {
+    const source = `Intro [link](./a.mdx)
+
+\`\`\`js
+import { Stack } from 'aws-cdk-lib';
+const html = '<a href="/foo">[x](./b.mdx)</a>';
+\`\`\`
+
+Inline \`href="/bar"\` and \`[x](./c.mdx)\` stay, but [link](./d.mdx) changes.
+`
+    const expected = `Intro [link](https://bref.sh/docs/a)
+
+\`\`\`js
+import { Stack } from 'aws-cdk-lib';
+const html = '<a href="/foo">[x](./b.mdx)</a>';
+\`\`\`
+
+Inline \`href="/bar"\` and \`[x](./c.mdx)\` stay, but [link](https://bref.sh/docs/d) changes.
+`
+    assert.equal(toMarkdown(source, 'docs/index'), expected)
+})
+
+test('only resolves pages under the allowed content roots', () => {
+    assert.match(findSourceFile('docs/serverless-costs'), /content\/docs\/serverless-costs\.mdx$/)
+    assert.match(findSourceFile('docs/setup'), /content\/docs\/setup\/index\.mdx$/)
+    assert.match(findSourceFile('/docs/'), /content\/docs\/index\.mdx$/)
+    assert.equal(findSourceFile('docs/does-not-exist'), null)
+    assert.equal(findSourceFile('support'), null)
+    assert.equal(findSourceFile('docs/../index'), null)
+    assert.equal(findSourceFile('docs/../../package'), null)
+})

--- a/website/src/lib/site-index.js
+++ b/website/src/lib/site-index.js
@@ -1,0 +1,55 @@
+import { getPageMap } from 'nextra/page-map'
+import { normalizePages } from 'nextra/normalize-pages'
+
+/**
+ * List the documentation pages in sidebar order, grouped by the sidebar
+ * sections (the separators in content/docs/_meta.js).
+ *
+ * Returns [{ title: 'Getting started', pages: [{ title, route, description }] }]
+ */
+export async function getDocsSections() {
+    const { docsDirectories } = normalizePages({
+        list: await getPageMap(),
+        route: '/docs',
+    })
+
+    const sections = [{ title: null, pages: [] }]
+    const visit = (items, parentTitle) => {
+        for (const item of items) {
+            if (item.display === 'hidden') continue
+            if (item.type === 'separator') {
+                sections.push({ title: item.title, pages: [] })
+                continue
+            }
+            if (item.route && 'frontMatter' in item) {
+                sections.at(-1).pages.push({
+                    title: parentTitle && item.name !== 'index' ? `${parentTitle} - ${item.title}` : item.title,
+                    route: item.route,
+                    description: item.frontMatter?.description ?? '',
+                })
+            }
+            if (item.children) {
+                visit(item.children, item.title)
+            }
+        }
+    }
+    visit(docsDirectories, null)
+
+    return sections.filter(section => section.pages.length > 0)
+}
+
+/**
+ * List the news articles, newest first.
+ */
+export async function getNewsPages() {
+    const pages = (await getPageMap('/news'))
+        // Skip the /news index page, keep the articles
+        .filter(item => item.route && item.route !== '/news' && 'frontMatter' in item)
+        .map(item => ({
+            title: item.frontMatter?.title ?? item.title,
+            route: item.route,
+            description: item.frontMatter?.description ?? '',
+        }))
+    // Article file names start with a number (01-bref-1.0, 02-bref-2.0...): newest first
+    return pages.sort((a, b) => b.route.localeCompare(a.route))
+}


### PR DESCRIPTION
Following a low "agent readiness" score on https://ora.ai/score/bref.sh: agents fetching the site without JavaScript get 250 KB of HTML per page with the content buried after ~100 KB of sidebar markup, and there was no `llms.txt` to point them at the Markdown versions of the docs that already existed.

**Website changes**

- `/llms.txt`: index of the site for AI agents (docs pages in sidebar order with descriptions, Bref Cloud, support, news), generated from the Nextra page map at build time
- `/llms-full.txt`: the whole documentation as a single Markdown file
- Markdown versions (`.md` URLs and `Accept: text/markdown`) now also cover news articles
- Markdown output improvements: all links are absolute `bref.sh` URLs, code samples are preserved (the old endpoint stripped `import` lines inside code blocks), `Link: rel=canonical` and `Vary: Accept` headers
- Every HTML page advertises `llms.txt` in a `Link` header, docs and news pages also advertise their Markdown alternate
- `/pricing` and `/cloud/pricing` redirect to `/cloud#pricing`
- Small `node:test` suite for the Markdown transform (`npm test` in `website/`)

