### PR TITLE
Add a newsletter subscribe page for the Serverless PHP news migration

### DIFF
--- a/website/content/news.mdx
+++ b/website/content/news.mdx
@@ -9,12 +9,9 @@ import SubscribeForm from '../src/components/news/SubscribeForm';
 
 Get Bref news by email:
 
-<SubscribeForm tag="bref_website" className="mt-2 mb-8 sm:max-w-xl" />
+<SubscribeForm tag="bref_website" className="mt-2 sm:max-w-xl" />
 
-<div className="hidden md:block float-right ml-8 pt-16">
-    <a className="twitter-timeline" data-width="300" data-height="1200" data-dnt="true" href="https://twitter.com/brefphp?ref_src=twsrc%5Etfw">Tweets by brefphp</a>
-    <script async src="https://platform.twitter.com/widgets.js"></script>
-</div>
+You can also follow [@brefphp](https://x.com/brefphp) on X.
 
 ## [August 2026: osls v4 and zero-downtime assets](/news/04-august-2026)
 

--- a/website/content/news.mdx
+++ b/website/content/news.mdx
@@ -3,7 +3,13 @@ title: News
 description: "Bref-related news."
 ---
 
+import SubscribeForm from '../src/components/news/SubscribeForm';
+
 # Latest news
+
+Get Bref news by email:
+
+<SubscribeForm tag="bref_website" className="mt-2 mb-8 sm:max-w-xl" />
 
 <div className="hidden md:block float-right ml-8 pt-16">
     <a className="twitter-timeline" data-width="300" data-height="1200" data-dnt="true" href="https://twitter.com/brefphp?ref_src=twsrc%5Etfw">Tweets by brefphp</a>

--- a/website/content/news/_meta.js
+++ b/website/content/news/_meta.js
@@ -3,4 +3,8 @@ export default {
     '03-bref-3.0': 'Bref 3.0 is released',
     '02-bref-2.0': 'Bref 2.0 is released',
     '01-bref-1.0': 'Bref 1.0 is released',
+    // Newsletter subscribe landing pages (form + result pages), not articles
+    subscribe: {
+        display: 'hidden',
+    },
 }

--- a/website/content/news/subscribe/already.mdx
+++ b/website/content/news/subscribe/already.mdx
@@ -1,0 +1,11 @@
+---
+title: Already subscribed
+description: "This address is already on the list for the Bref newsletter."
+robots: noindex
+---
+
+# Already subscribed
+
+This address is already on the list for the Bref newsletter. You do not need to do anything.
+
+The [latest news](/news) is on the website.

--- a/website/content/news/subscribe/done.mdx
+++ b/website/content/news/subscribe/done.mdx
@@ -1,0 +1,11 @@
+---
+title: You are subscribed
+description: "You are subscribed to the Bref newsletter."
+robots: noindex
+---
+
+# You are subscribed
+
+You are subscribed to the Bref newsletter. Thank you.
+
+The [latest news](/news) is on the website.

--- a/website/content/news/subscribe/index.mdx
+++ b/website/content/news/subscribe/index.mdx
@@ -1,0 +1,16 @@
+---
+title: Subscribe to the Bref newsletter
+description: "The Bref newsletter replaces Serverless PHP news. Subscribe to the Bref newsletter to continue to get the emails."
+# Migration landing page for the old Serverless PHP news list, linked from an email only
+robots: noindex
+---
+
+import SubscribeForm from '../../../src/components/news/SubscribeForm';
+
+# Subscribe to the Bref newsletter
+
+The Bref newsletter replaces Serverless PHP news. The sender is the same person, Matthieu. The sender address is the same, `matthieu@bref.sh`. The Bref newsletter contains product and community updates.
+
+Read the latest issue: [osls v4, and zero-downtime assets](https://bref.mailcoach.app/webview/campaign/20729bf2-7950-4982-95a6-6fde1fb6b33d)
+
+<SubscribeForm tag="from-serverless-php-news" label="Email" />

--- a/website/content/news/subscribe/pending.mdx
+++ b/website/content/news/subscribe/pending.mdx
@@ -1,0 +1,11 @@
+---
+title: Check your inbox
+description: "We sent a confirmation email for the Bref newsletter to your address."
+robots: noindex
+---
+
+# Check your inbox
+
+We sent a confirmation email to your address. Look for it in your inbox and in your spam folder. Click the link in the email to complete the subscription.
+
+If the email does not arrive, return to [/news/subscribe](/news/subscribe) and submit the form again.

--- a/website/next-sitemap.config.js
+++ b/website/next-sitemap.config.js
@@ -2,4 +2,6 @@
 module.exports = {
     siteUrl: process.env.SITE_URL || 'https://bref.sh',
     generateRobotsTxt: true,
+    // Newsletter subscribe landing pages: linked from the migration email and Mailcoach redirects only
+    exclude: ['/news/subscribe', '/news/subscribe/*'],
 }

--- a/website/src/components/home/case-studies.jsx
+++ b/website/src/components/home/case-studies.jsx
@@ -1,3 +1,5 @@
+import SubscribeForm from '../news/SubscribeForm';
+
 const posts = [
     {
         id: 2,
@@ -38,20 +40,7 @@ export default function CaseStudies() {
                                 Support & consulting <span aria-hidden="true">&rarr;</span>
                             </a>
                         </div>
-                        <form action="https://bref.mailcoach.app/subscribe/be83c960-8fee-43fa-abfa-29669e9f433a"
-                              className="w-full flex flex-col items-start mt-8"
-                              method="post">
-                            <input type="hidden" name="tags" value="bref_website" />
-                            <div className="flex flex-col sm:flex-row w-full sm:w-auto gap-2">
-                                <input
-                                    className="min-w-0 flex-auto rounded-md border-0 bg-white/10 px-3.5 py-2 text-white shadow-sm ring-1 ring-inset ring-white/10 placeholder:text-white/75 focus:ring-2 focus:ring-inset focus:ring-white sm:text-sm sm:leading-6"
-                                    name="email" aria-label="Email" placeholder="you@example.com" required type="email" />
-                                <button type="submit"
-                                        className="flex-none rounded-md !bg-gray-500 hover:!bg-gray-400 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500">
-                                    Subscribe to the newsletter
-                                </button>
-                            </div>
-                        </form>
+                        <SubscribeForm tag="bref_website" onDark className="mt-8 sm:w-fit" />
                     </div>
                     <div className="mx-auto w-full border-t border-gray-900/10 pt-12 sm:pt-16 lg:mx-0 lg:max-w-none lg:border-t-0 lg:pt-0 text-gray-300">
                         <div className="-my-4 divide-y divide-gray-900/10">

--- a/website/src/components/news/SubscribeForm.jsx
+++ b/website/src/components/news/SubscribeForm.jsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+// Same Mailcoach list as the homepage form (src/components/home/case-studies.jsx).
+const MAILCOACH_SUBSCRIBE_URL = 'https://bref.mailcoach.app/subscribe/be83c960-8fee-43fa-abfa-29669e9f433a'
+
+// POST-only subscribe form for the Bref newsletter, used inline on /news and on
+// /news/subscribe (the page that moves the old "Serverless PHP news" list to the
+// Bref list with an explicit opt-in).
+//
+// - `tag`: Mailcoach subscriber tag, to measure where subscribers come from.
+// - `label`: visible label above the field. Without it the form is a single row
+//   (placeholder + button).
+// - The migration email links to /news/subscribe?email=... : the address is
+//   prefilled but nothing is submitted until the reader clicks the button, so
+//   email prefetchers (which only GET the link) cannot subscribe anyone.
+// - Mailcoach sends its double opt-in email and redirects to the bref.sh
+//   result pages below.
+export default function SubscribeForm({ tag, label, className = 'my-8' }) {
+    const emailRef = useRef(null)
+    const honeypotRef = useRef(null)
+
+    useEffect(() => {
+        const email = new URLSearchParams(window.location.search).get('email')
+        if (email && emailRef.current && !emailRef.current.value) {
+            // A `+` in the address decodes to a space if the link was not URL-encoded
+            emailRef.current.value = email.replace(/ /g, '+')
+        }
+    }, [])
+
+    const onSubmit = (event) => {
+        // Honeypot: humans never see this field, bots fill it in
+        if (honeypotRef.current?.value) {
+            event.preventDefault()
+            return
+        }
+        // Mailcoach stores unknown form fields as subscriber attributes: leave the honeypot out
+        if (honeypotRef.current) honeypotRef.current.disabled = true
+    }
+
+    return (
+        <form method="POST" action={MAILCOACH_SUBSCRIBE_URL} onSubmit={onSubmit} className={`not-prose ${className}`}>
+            <input type="hidden" name="tags" value={tag} />
+            <input type="hidden" name="redirect_after_subscription_pending" value="https://bref.sh/news/subscribe/pending" />
+            <input type="hidden" name="redirect_after_already_subscribed" value="https://bref.sh/news/subscribe/already" />
+            <input type="hidden" name="redirect_after_subscribed" value="https://bref.sh/news/subscribe/done" />
+
+            <div className="hidden" aria-hidden="true">
+                <label htmlFor="subscribe-website">Website</label>
+                <input ref={honeypotRef} id="subscribe-website" type="text" name="website" tabIndex={-1} autoComplete="off" />
+            </div>
+
+            {label && (
+                <label htmlFor="subscribe-email" className="block mb-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+                    {label}
+                </label>
+            )}
+            <div className="flex flex-col sm:flex-row gap-2">
+                <input
+                    ref={emailRef}
+                    id="subscribe-email"
+                    type="email"
+                    name="email"
+                    required
+                    autoComplete="email"
+                    aria-label={label ? undefined : 'Email'}
+                    placeholder="you@example.com"
+                    className="min-w-0 flex-auto rounded-md border-0 px-3.5 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6 dark:bg-white/5 dark:text-white dark:ring-white/10 dark:placeholder:text-white/50"
+                />
+                <button
+                    type="submit"
+                    className="flex-none rounded-md bg-blue-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                    Subscribe to the Bref newsletter
+                </button>
+            </div>
+        </form>
+    )
+}

--- a/website/src/components/news/SubscribeForm.jsx
+++ b/website/src/components/news/SubscribeForm.jsx
@@ -12,12 +12,24 @@ const MAILCOACH_SUBSCRIBE_URL = 'https://bref.mailcoach.app/subscribe/be83c960-8
 // - `tag`: Mailcoach subscriber tag, to measure where subscribers come from.
 // - `label`: visible label above the field. Without it the form is a single row
 //   (placeholder + button).
+// - `onDark`: styles for a dark background (the homepage section), instead of
+//   following the site theme.
 // - The migration email links to /news/subscribe?email=... : the address is
 //   prefilled but nothing is submitted until the reader clicks the button, so
 //   email prefetchers (which only GET the link) cannot subscribe anyone.
 // - Mailcoach sends its double opt-in email and redirects to the bref.sh
 //   result pages below.
-export default function SubscribeForm({ tag, label, className = 'my-8' }) {
+const INPUT_CLASS = {
+    light: 'text-gray-900 ring-gray-300 placeholder:text-gray-400 focus:ring-blue-500 dark:bg-white/5 dark:text-white dark:ring-white/10 dark:placeholder:text-white/50',
+    dark: 'bg-white/10 text-white ring-white/10 placeholder:text-white/75 focus:ring-white',
+}
+const BUTTON_CLASS = {
+    light: 'bg-blue-500 hover:bg-blue-400',
+    dark: '!bg-gray-500 hover:!bg-gray-400',
+}
+
+export default function SubscribeForm({ tag, label, onDark = false, className = 'my-8' }) {
+    const variant = onDark ? 'dark' : 'light'
     const emailRef = useRef(null)
     const honeypotRef = useRef(null)
 
@@ -66,11 +78,11 @@ export default function SubscribeForm({ tag, label, className = 'my-8' }) {
                     autoComplete="email"
                     aria-label={label ? undefined : 'Email'}
                     placeholder="you@example.com"
-                    className="min-w-0 flex-auto rounded-md border-0 px-3.5 py-2 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-500 sm:text-sm sm:leading-6 dark:bg-white/5 dark:text-white dark:ring-white/10 dark:placeholder:text-white/50"
+                    className={`min-w-0 flex-auto rounded-md border-0 px-3.5 py-2 shadow-sm ring-1 ring-inset focus:ring-2 focus:ring-inset sm:text-sm sm:leading-6 ${INPUT_CLASS[variant]}`}
                 />
                 <button
                     type="submit"
-                    className="flex-none rounded-md bg-blue-500 px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                    className={`flex-none rounded-md px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 ${BUTTON_CLASS[variant]}`}
                 >
                     Subscribe to the Bref newsletter
                 </button>

--- a/website/src/lib/site-index.js
+++ b/website/src/lib/site-index.js
@@ -43,8 +43,10 @@ export async function getDocsSections() {
  */
 export async function getNewsPages() {
     const pages = (await getPageMap('/news'))
-        // Skip the /news index page, keep the articles
-        .filter(item => item.route && item.route !== '/news' && 'frontMatter' in item)
+        // Keep the articles: their file names start with a number (01-bref-1.0,
+        // 02-bref-2.0...). This skips the /news index and the newsletter subscribe
+        // landing pages (/news/subscribe/...).
+        .filter(item => item.route && /^\/news\/\d+-/.test(item.route) && 'frontMatter' in item)
         .map(item => ({
             title: item.frontMatter?.title ?? item.title,
             route: item.route,


### PR DESCRIPTION
I'm migrating the https://serverless-php.news/ newsletter to the Bref newsletter, so I need a way for subscribers to confirm they want to migrate over. This adds a form for that + various improvements to subscribe to the newsletter.


- Adds `/news/subscribe`, a landing page with a POST form to the Bref Mailcoach list. The migration email for the old Serverless PHP news list links to this page with `?email=`. The page prefills the address. The page does not submit the form until the reader clicks the button, so email prefetchers cannot subscribe anyone. A hidden honeypot field stops simple bots. The page is not indexed and is not in the sitemap.
- Adds three result pages: `/news/subscribe/pending`, `/news/subscribe/already` and `/news/subscribe/done`. Mailcoach redirects to these pages after the submit.
- Adds a subscribe form at the top of `/news`.
- Replaces the Twitter timeline on `/news` with a link to @brefphp on X. The embed no longer loads for anonymous visitors, and its script caused a hydration error.
- Uses the same form component on the homepage. The homepage form now redirects to the bref.sh result pages and has the honeypot field.
